### PR TITLE
fix: update vitepress base path

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,8 +1,8 @@
 export default {
   title: 'AgentKit',
   description: 'Python SDK and CLI for building Agent applications on Volcengine',
-  base: '/',
-  
+  base: '/agentkit-sdk-python/',
+
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }]
   ],


### PR DESCRIPTION
Update base path to deploying directory(usually the repo name).

If base is set to '/'，VitePress will generate a link pointing to the root directory of the domain name(https://volcengine.github.io/), which will result in a 404 error when deploying under a subdirectory(https://volcengine.github.io/agentkit-sdk-python).