### PR TITLE
feat(cloud): add OAuth2/JWT authentication support for CloudStrategy

### DIFF
--- a/agentkit/toolkit/config/__init__.py
+++ b/agentkit/toolkit/config/__init__.py
@@ -44,6 +44,8 @@ from .global_config import (
 from .utils import is_valid_config, is_invalid_config, merge_runtime_envs
 from .constants import (
     AUTO_CREATE_VE,
+    AUTH_TYPE_KEY_AUTH,
+    AUTH_TYPE_CUSTOM_JWT,
     GLOBAL_CONFIG_FILE_PERMISSIONS,
     GLOBAL_CONFIG_FILE,
     GLOBAL_CONFIG_DIR,
@@ -70,6 +72,8 @@ __all__ = [
     "CRGlobalConfig",
     "TOSGlobalConfig",
     "AUTO_CREATE_VE",
+    "AUTH_TYPE_KEY_AUTH",
+    "AUTH_TYPE_CUSTOM_JWT",
     "DEFAULT_WORKSPACE_NAME",
     "DEFAULT_CR_NAMESPACE",
     "DEFAULT_CR_INSTANCE_TEMPLATE_NAME",

--- a/agentkit/toolkit/config/constants.py
+++ b/agentkit/toolkit/config/constants.py
@@ -36,3 +36,6 @@ DEFAULT_IMAGE_TAG_TEMPLATE = "{{timestamp}}"
 GLOBAL_CONFIG_DIR = Path.home() / ".agentkit"
 GLOBAL_CONFIG_FILE = GLOBAL_CONFIG_DIR / "config.yaml"
 GLOBAL_CONFIG_FILE_PERMISSIONS = 0o600  # Owner read/write only
+
+AUTH_TYPE_KEY_AUTH = "key_auth"
+AUTH_TYPE_CUSTOM_JWT = "custom_jwt"

--- a/agentkit/toolkit/config/strategy_configs.py
+++ b/agentkit/toolkit/config/strategy_configs.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from typing import Dict, List
 from .dataclass_utils import AutoSerializableMixin
 from .constants import (
+    AUTH_TYPE_CUSTOM_JWT,
+    AUTH_TYPE_KEY_AUTH,
     AUTO_CREATE_VE,
     DEFAULT_CR_NAMESPACE,
     DEFAULT_IMAGE_TAG,
@@ -207,6 +209,20 @@ class HybridStrategyConfig(AutoSerializableMixin):
             "aliases": ["ve_runtime_role_name"],
         },
     )
+    runtime_auth_type: str = field(
+        default=AUTH_TYPE_KEY_AUTH,
+        metadata={
+            "description": "Runtime authentication type",
+            "icon": "🔑",
+            "choices": [
+                {"value": AUTH_TYPE_KEY_AUTH, "description": "API Key authentication"},
+                {
+                    "value": AUTH_TYPE_CUSTOM_JWT,
+                    "description": "OAuth2/JWT authentication",
+                },
+            ],
+        },
+    )
     runtime_apikey_name: str = field(
         default=AUTO_CREATE_VE,
         metadata={
@@ -221,6 +237,20 @@ class HybridStrategyConfig(AutoSerializableMixin):
             "system": True,
             "description": "Runtime API key",
             "aliases": ["ve_runtime_apikey"],
+        },
+    )
+    runtime_jwt_discovery_url: str = field(
+        default="",
+        metadata={
+            "description": "OIDC Discovery URL for JWT validation (required when auth_type is custom_jwt)",
+            "examples": "https://userpool-xxx.userpool.auth.id.cn-beijing.volces.com/.well-known/openid-configuration",
+        },
+    )
+    runtime_jwt_allowed_clients: List[str] = field(
+        default_factory=list,
+        metadata={
+            "description": "Allowed OAuth2 client IDs (required when auth_type is custom_jwt)",
+            "examples": "['fa99ec54-8a1c-49b2-9a9e-3f3ba31d9a33']",
         },
     )
     runtime_endpoint: str = field(
@@ -403,6 +433,20 @@ class CloudStrategyConfig(AutoSerializableMixin):
             "aliases": ["ve_runtime_role_name"],
         },
     )
+    runtime_auth_type: str = field(
+        default=AUTH_TYPE_KEY_AUTH,
+        metadata={
+            "description": "Runtime authentication type",
+            "icon": "🔑",
+            "choices": [
+                {"value": AUTH_TYPE_KEY_AUTH, "description": "API Key authentication"},
+                {
+                    "value": AUTH_TYPE_CUSTOM_JWT,
+                    "description": "OAuth2/JWT authentication",
+                },
+            ],
+        },
+    )
     runtime_apikey_name: str = field(
         default=AUTO_CREATE_VE,
         metadata={
@@ -417,6 +461,20 @@ class CloudStrategyConfig(AutoSerializableMixin):
             "system": True,
             "description": "Runtime API key for authentication",
             "aliases": ["ve_runtime_apikey"],
+        },
+    )
+    runtime_jwt_discovery_url: str = field(
+        default="",
+        metadata={
+            "description": "OIDC Discovery URL for JWT validation (required when auth_type is custom_jwt)",
+            "examples": "https://userpool-xxx.userpool.auth.id.cn-beijing.volces.com/.well-known/openid-configuration",
+        },
+    )
+    runtime_jwt_allowed_clients: List[str] = field(
+        default_factory=list,
+        metadata={
+            "description": "Allowed OAuth2 client IDs (required when auth_type is custom_jwt)",
+            "examples": "['fa99ec54-8a1c-49b2-9a9e-3f3ba31d9a33']",
         },
     )
     runtime_endpoint: str = field(

--- a/agentkit/toolkit/strategies/cloud_strategy.py
+++ b/agentkit/toolkit/strategies/cloud_strategy.py
@@ -325,5 +325,8 @@ class CloudStrategy(Strategy):
             runtime_apikey_name=strategy_config.runtime_apikey_name,
             runtime_endpoint=strategy_config.runtime_endpoint,
             runtime_envs=merged_envs,
+            runtime_auth_type=strategy_config.runtime_auth_type,
+            runtime_jwt_discovery_url=strategy_config.runtime_jwt_discovery_url,
+            runtime_jwt_allowed_clients=strategy_config.runtime_jwt_allowed_clients,
             image_url=strategy_config.cr_image_full_url,
         )

--- a/agentkit/toolkit/strategies/hybrid_strategy.py
+++ b/agentkit/toolkit/strategies/hybrid_strategy.py
@@ -492,6 +492,9 @@ class HybridStrategy(Strategy):
             runtime_apikey_name=strategy_config.runtime_apikey_name,
             runtime_endpoint=strategy_config.runtime_endpoint,
             runtime_envs=merged_envs,
+            runtime_auth_type=strategy_config.runtime_auth_type,
+            runtime_jwt_discovery_url=strategy_config.runtime_jwt_discovery_url,
+            runtime_jwt_allowed_clients=strategy_config.runtime_jwt_allowed_clients,
             image_url=strategy_config.cr_image_full_url,
         )
 


### PR DESCRIPTION
Add support for OAuth2/JWT (Custom JWT Authorizer) authentication mode in CloudStrategy and HybridStrategy, allowing Runtime to validate requests using OIDC-based JWT tokens instead of API Key.

Changes:

Add AUTH_TYPE_KEY_AUTH and AUTH_TYPE_CUSTOM_JWT constants
Add runtime_auth_type, runtime_jwt_discovery_url, and runtime_jwt_allowed_clients configuration fields to:
CloudStrategyConfig
HybridStrategyConfig
VeAgentkitRunnerConfig
Implement _build_authorizer_config_for_create() and _build_authorizer_config_for_update() helper methods to construct appropriate AuthorizerConfiguration based on auth type
Update _create_new_runtime() and _update_existing_runtime() to use new authorizer config builders
Update status() and invoke() methods to handle JWT auth scenarios:
Skip API key retrieval for JWT auth
Skip ping check in status() for JWT auth (no token available)
Require Authorization header in invoke() for JWT auth