### PR TITLE
feat: Update the version to 0.2.0 and adjust the default configuration

### DIFF
--- a/agentkit/toolkit/config/config.py
+++ b/agentkit/toolkit/config/config.py
@@ -42,7 +42,7 @@ class CommonConfig(AutoSerializableMixin):
         },
     )
     entry_point: str = field(
-        default="",
+        default="agent.py",
         metadata={
             "description": "Agent application entry file (path allowed), e.g. simple_agent.py or main.go or build.sh",
             "icon": "📝",
@@ -110,7 +110,7 @@ class CommonConfig(AutoSerializableMixin):
         },
     )
     launch_type: str = field(
-        default="local",
+        default="cloud",
         metadata={
             "description": "Deployment and runtime mode, defaults to local (local build and deploy), optional hybrid (local build, cloud deploy)",
             "icon": "🚀",

--- a/agentkit/toolkit/runners/ve_agentkit.py
+++ b/agentkit/toolkit/runners/ve_agentkit.py
@@ -107,6 +107,11 @@ class VeAgentkitRunnerConfig(AutoSerializableMixin):
     # Container image configuration
     image_url: str = field(default="", metadata={"description": "Container image URL"})
 
+    # Minimum instance count
+    min_instance: int = field(
+        default=1, metadata={"description": "Minimum number of Runtime instances"}
+    )
+
 
 # VeAgentkitDeployResult has been replaced by unified DeployResult
 # Configuration class is retained for backward compatibility
@@ -618,6 +623,7 @@ class VeAgentkitRuntimeRunner(Runner):
                 authorizer_configuration=authorizer_config,
                 client_token=generate_client_token(),
                 apmplus_enable=True,
+                min_instance=config.min_instance,
             )
 
             # Create Runtime
@@ -635,7 +641,7 @@ class VeAgentkitRuntimeRunner(Runner):
                 runtime_id=config.runtime_id,
                 target_status=RUNTIME_STATUS_READY,
                 task_description="Waiting for Runtime to be ready...",
-                timeout=None,  # No timeout for creation
+                timeout=600,
                 error_message="Initialization failed",
             )
 
@@ -1036,7 +1042,7 @@ class VeAgentkitRuntimeRunner(Runner):
                 runtime_id=config.runtime_id,
                 target_statuses=[RUNTIME_STATUS_UNRELEASED, RUNTIME_STATUS_READY],
                 task_description="Waiting for Runtime update to complete...",
-                timeout=180,
+                timeout=600,
                 error_message="Update failed",
             )
 

--- a/agentkit/version.py
+++ b/agentkit/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.1.15"
+VERSION = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentkit-sdk-python"
-version = "0.1.15"
+version = "0.2.0"
 description = "Python SDK for transforming any AI agent into a production-ready application. Framework-agnostic primitives for runtime, memory, authentication, and tools with volcengine-managed infrastructure."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,10 +26,10 @@ dependencies = [
     "a2a-sdk>=0.3.7",
     "fastapi>=0.117.1",
     "fastmcp>=2.12.3",
-    "opentelemetry-api>=1.32.1",
-    "opentelemetry-exporter-otlp-proto-common>=1.32.1",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",
-    "opentelemetry-sdk>=1.32.1",
+    "opentelemetry-api>=1.32.1, <=1.37.0",
+    "opentelemetry-exporter-otlp-proto-common>=1.32.1, <=1.37.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.32.1, <=1.37.0",
+    "opentelemetry-sdk>=1.32.1, <=1.37.0",
     "pydantic>=2.11.9",
     "requests>=2.32.5",
     "uvicorn>=0.37.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 a2a-sdk>=0.3.7
 fastapi>=0.117.1
 fastmcp>=2.12.3
-opentelemetry-api>=1.32.1
-opentelemetry-exporter-otlp-proto-common>=1.32.1
-opentelemetry-exporter-otlp-proto-grpc>=1.32.1
-opentelemetry-sdk>=1.32.1
+opentelemetry-api>=1.32.1, <=1.37.0
+opentelemetry-exporter-otlp-proto-common>=1.32.1, <=1.37.0
+opentelemetry-exporter-otlp-proto-grpc>=1.32.1, <=1.37.0
+opentelemetry-sdk>=1.32.1, <=1.37.0
 pydantic>=2.11.9
 requests>=2.32.5
 uvicorn>=0.37.0


### PR DESCRIPTION
- Upgrade the version number from 0.1.15 to 0.2.0
- Modify the default entry_point in CommonConfig to agent.py
- Change the default launch_type from local to cloud
- Add the min_instance field to VeAgentkitRunnerConfig
- Adjust the timeout for runtime creation and updates to 600 seconds