### PR TITLE
fix(volcengine/iam): Handle TrustPolicyDocument field as string type

### DIFF
--- a/agentkit/apps/agent_server_app/agent_server_app.py
+++ b/agentkit/apps/agent_server_app/agent_server_app.py
@@ -102,10 +102,7 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
             user_id = (
                 headers.get("user_id") or headers.get("x-user-id") or "agentkit_user"
             )
-            session_id = (
-                headers.get("session_id")
-                or ""
-            )
+            session_id = headers.get("session_id") or ""
 
             # Determine app_name from loader
             app_names = self.server.agent_loader.list_agents()

--- a/agentkit/toolkit/volcengine/iam.py
+++ b/agentkit/toolkit/volcengine/iam.py
@@ -221,7 +221,13 @@ class VeIAM(BaseIAMClient):
                 data="{}",
             )
             response_data = json.loads(res)
-            return GetRoleResponse(**response_data.get("Result", {}))
+            result_data = response_data.get("Result", {})
+            role_data = result_data.get("Role")
+            if isinstance(role_data, dict):
+                tpd = role_data.get("TrustPolicyDocument")
+                if isinstance(tpd, dict):
+                    role_data["TrustPolicyDocument"] = json.dumps(tpd)
+            return GetRoleResponse(**result_data)
         except Exception as e:
             # If role not found, return None
             if "RoleNotExist" in str(e) or "NotFound" in str(e) or "404" in str(e):


### PR DESCRIPTION
Ensure the TrustPolicyDocument field retrieved from the API is of string type to avoid type errors during subsequent processing
