### PR TITLE
chore: sync internal 0.5.7 to GitHub

### DIFF
--- a/agentkit/apps/agent_server_app/agent_server_app.py
+++ b/agentkit/apps/agent_server_app/agent_server_app.py
@@ -16,7 +16,6 @@ import json
 import logging
 from contextlib import asynccontextmanager
 from typing import Any
-from typing_extensions import override
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
@@ -42,9 +41,10 @@ from google.adk.sessions.base_session_service import BaseSessionService
 from google.adk.utils.context_utils import Aclosing
 from google.genai import types
 from opentelemetry import trace
+from typing_extensions import override
 from veadk import Agent
-from veadk.runner import Runner
 from veadk.memory.short_term_memory import ShortTermMemory
+from veadk.runner import Runner
 
 from agentkit.apps.agent_server_app.middleware import (
     AgentkitTelemetryHTTPMiddleware,
@@ -137,7 +137,12 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
             agents_dir=".",
         )
 
-        runner = Runner(agent=root_agent)
+        runner = Runner(
+            agent=root_agent,
+            short_term_memory=short_term_memory
+            if isinstance(short_term_memory, ShortTermMemory)
+            else None,
+        )
         _a2a_server_app = to_a2a(agent=root_agent, runner=runner)
 
         @asynccontextmanager

--- a/agentkit/apps/agent_server_app/agent_server_app.py
+++ b/agentkit/apps/agent_server_app/agent_server_app.py
@@ -100,6 +100,7 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
         short_term_memory: BaseSessionService | ShortTermMemory | None = None,
         *,
         app: App | None = None,
+        allow_origins: list[str] | None = None,
     ) -> None:
         super().__init__()
 
@@ -147,7 +148,9 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
                 await handler()
             yield
 
-        self.app = self.server.get_fast_api_app(lifespan=lifespan)
+        self.app = self.server.get_fast_api_app(
+            lifespan=lifespan, allow_origins=allow_origins
+        )
 
         @self.app.post("/run_sse")
         async def run_agent_sse(req: RunAgentRequest) -> StreamingResponse:

--- a/agentkit/version.py
+++ b/agentkit/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.5.6"
+VERSION = "0.5.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentkit-sdk-python"
-version = "0.5.6"
+version = "0.5.7"
 description = "Python SDK for transforming any AI agent into a production-ready application. Framework-agnostic primitives for runtime, memory, authentication, and tools with volcengine-managed infrastructure."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Cherry-pick internal commits up to 0.5.7:
  - 1208508 fix: support allow_origins in agent server app
  - 6ee5bec fix: server app runner pass in short term memory
  - 865f50c feat: release 0.5.7
- Bump package version from 0.5.6 to 0.5.7

## Tests
- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/bytedance/workspace/agentkit-sdk-python
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0
collected 133 items

tests/platform/test_configuration_byteplus.py ........                   [  6%]
tests/platform/test_configuration_creds.py ................              [ 18%]
tests/platform/test_configuration_dotenv_byteplus.py .                   [ 18%]
tests/platform/test_configuration_endpoints.py ..........                [ 26%]
tests/platform/test_global_config_compat.py ....                         [ 29%]
tests/platform/test_platform_context_provider.py .                       [ 30%]
tests/platform/test_vefaas_credential_rotation.py .                      [ 30%]
tests/test_client_uses_platform_context.py .                             [ 31%]
tests/toolkit/builders/test_ve_pipeline_cr_domain.py .....               [ 35%]
tests/toolkit/cli/test_cli_config_cloud_provider_noninteractive.py ..    [ 36%]
tests/toolkit/cli/test_cli_config_interactive_flow.py .                  [ 37%]
tests/toolkit/cli/test_cli_config_interactive_provider_resolution.py ..  [ 39%]
tests/toolkit/cli/test_cli_runtime_network_config.py .....               [ 42%]
tests/toolkit/cli/test_cli_skills_platform_compat.py ...........         [ 51%]
tests/toolkit/cli/test_cli_skills_workflow.py ......                     [ 55%]
tests/toolkit/cli/test_interactive_hidden_fields_carry_over.py ....      [ 58%]
tests/toolkit/config/test_common_cloud_provider_global_default.py ....   [ 61%]
tests/toolkit/config/test_config_show_cloud_provider.py .                [ 62%]
tests/toolkit/config/test_dynamic_region_default.py ....                 [ 65%]
tests/toolkit/config/test_env_files.py ...                               [ 67%]
tests/toolkit/config/test_persist_policy_explicit_only.py ...            [ 69%]
tests/toolkit/docker/test_base_image_defaults.py ...                     [ 72%]
tests/toolkit/docker/test_dockerfile_manager_regeneration.py ....        [ 75%]
tests/toolkit/docker/test_dockerignore_utils.py .                        [ 75%]
tests/toolkit/executors/test_executor_platform_context_provider.py .     [ 76%]
tests/toolkit/executors/test_init_cloud_provider_defaults.py ..          [ 78%]
tests/toolkit/runners/test_ve_agentkit_network_config.py ...             [ 80%]
tests/toolkit/test_byteplus_single_region.py ...                         [ 82%]
tests/toolkit/test_cloud_provider_resolution.py ....                     [ 85%]
tests/toolkit/test_dynamic_choices.py ...                                [ 87%]
tests/toolkit/test_lifecycle_destroy_platform_context.py .               [ 88%]
tests/toolkit/test_lifecycle_launch_preflight_platform_context.py ...    [ 90%]
tests/toolkit/test_no_env_rewrite.py ..                                  [ 92%]
tests/toolkit/volcengine/test_provider_injection.py ...                  [ 94%]
tests/toolkit/volcengine/utils/test_project_archiver_dockerignore.py ... [ 96%]
....                                                                     [100%]

============================= 133 passed in 1.05s ==============================
- 