### PR TITLE
chore: sync internal 0.5.8 to GitHub

### DIFF
--- a/agentkit/toolkit/cli/cli_invoke.py
+++ b/agentkit/toolkit/cli/cli_invoke.py
@@ -30,6 +30,26 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 
+def _sanitize_headers_for_display(headers: dict) -> dict:
+    if not isinstance(headers, dict):
+        return {}
+    redacted_keys = {
+        "authorization",
+        "proxy-authorization",
+        "x-api-key",
+        "x-auth-token",
+        "api-key",
+    }
+    out: dict = {}
+    for k, v in headers.items():
+        key = str(k)
+        if key.lower() in redacted_keys:
+            out[key] = "******"
+        else:
+            out[key] = v
+    return out
+
+
 def _extract_text_chunks_from_langchain_event(event: dict) -> list[str]:
     """Extract incremental text chunks from LangChain message_to_dict-style events.
 
@@ -211,13 +231,29 @@ def build_a2a_payload(
 
 
 def invoke_command(
-    config_file: Path = typer.Option("agentkit.yaml", help="Configuration file"),
+    config_file: Optional[Path] = typer.Option(
+        None, "--config-file", help="Configuration file"
+    ),
     message: str = typer.Argument(None, help="Simple message to send to agent"),
     payload: str = typer.Option(
         None, "--payload", "-p", help="JSON payload to send (advanced option)"
     ),
     headers: str = typer.Option(
         None, "--headers", "-h", help="JSON headers for request (advanced option)"
+    ),
+    runtime_id: str = typer.Option(
+        None, "--runtime-id", "-r", help="Runtime ID for direct invocation"
+    ),
+    endpoint: str = typer.Option(
+        None, "--endpoint", "-e", help="Endpoint URL for direct invocation"
+    ),
+    region: str = typer.Option(
+        None, "--region", help="Region for Runtime lookup (used with --runtime-id)"
+    ),
+    a2a: bool = typer.Option(
+        False,
+        "--a2a",
+        help="Force A2A JSON-RPC envelope (direct invocation mode only)",
     ),
     show_reasoning: bool = typer.Option(
         False,
@@ -262,8 +298,28 @@ def invoke_command(
             "[red]Error: Must provide either a message or --payload option.[/red]"
         )
         raise typer.Exit(1)
-    config = get_config(config_path=config_file)
-    common_config = config.get_common_config()
+
+    direct_mode = bool(runtime_id or endpoint)
+    if direct_mode and config_file is not None:
+        console.print(
+            "[red]Error: --config-file cannot be used with --runtime-id/--endpoint.[/red]"
+        )
+        raise typer.Exit(1)
+    if runtime_id and endpoint:
+        console.print(
+            "[red]Error: Cannot specify both --runtime-id and --endpoint.[/red]"
+        )
+        raise typer.Exit(1)
+    if region and not runtime_id:
+        console.print(
+            "[red]Error: --region can only be used together with --runtime-id.[/red]"
+        )
+        raise typer.Exit(1)
+    if a2a and not direct_mode:
+        console.print(
+            "[red]Error: --a2a can only be used with --runtime-id or --endpoint.[/red]"
+        )
+        raise typer.Exit(1)
 
     # Process headers
     default_headers = {
@@ -286,25 +342,27 @@ def invoke_command(
             )
             raise typer.Exit(1)
         final_headers.update(custom_headers)
-        console.print(f"[blue]Using merged headers: {final_headers}[/blue]")
-    else:
-        console.print(f"[blue]Using default headers: {final_headers}[/blue]")
-
-    final_payload = build_standard_payload(message, payload)
-    agent_type = getattr(common_config, "agent_type", "") or getattr(
-        common_config, "template_type", ""
-    )
-    is_a2a = isinstance(agent_type, str) and "a2a" in agent_type.lower()
-
-    # If it's an A2A Agent, reconstruct payload using A2A constructor
-    if is_a2a:
         console.print(
-            "[cyan]Detected A2A agent type - constructing A2A JSON-RPC envelope[/cyan]"
+            f"[blue]Using merged headers: {_sanitize_headers_for_display(final_headers)}[/blue]"
         )
-        final_payload = build_a2a_payload(message, payload, final_headers)
+    else:
+        console.print(
+            f"[blue]Using default headers: {_sanitize_headers_for_display(final_headers)}[/blue]"
+        )
 
     if apikey:
+        if runtime_id:
+            console.print(
+                "[red]Error: --apikey cannot be used together with --runtime-id. "
+                "--runtime-id mode resolves the Runtime and infers its auth type automatically: "
+                "for API Key (key_auth), omit auth flags and the CLI will fetch and inject the API key; "
+                'for JWT/OAuth (custom_jwt), provide an Authorization header via --headers \'{"Authorization":"Bearer <token>"}\'. '
+                "If you want to pass an API key manually, use --endpoint together with --apikey.[/red]"
+            )
+            raise typer.Exit(1)
         final_headers["Authorization"] = f"Bearer {apikey}"
+
+    final_payload = build_standard_payload(message, payload)
 
     from agentkit.toolkit.context import ExecutionContext
 
@@ -312,12 +370,72 @@ def invoke_command(
     ExecutionContext.set_reporter(reporter)
 
     executor = InvokeExecutor(reporter=reporter)
-    result = executor.execute(
-        payload=final_payload,
-        config_file=str(config_file),
-        headers=final_headers,
-        stream=None,  # Automatically determined by Runner
-    )
+
+    if direct_mode:
+        if endpoint and not apikey and not final_headers.get("Authorization"):
+            console.print(
+                "[red]Error: --endpoint requires --apikey or an Authorization header provided via --headers.[/red]"
+            )
+            raise typer.Exit(1)
+
+        direct_common = {
+            "agent_name": "direct_invoke",
+            "entry_point": "agent.py",
+            "launch_type": "cloud",
+        }
+
+        is_a2a_payload = isinstance(final_payload, dict) and bool(
+            final_payload.get("jsonrpc")
+        )
+        if a2a:
+            final_payload = build_a2a_payload(message, payload, final_headers)
+            is_a2a_payload = True
+
+        if is_a2a_payload:
+            direct_common["agent_type"] = "a2a"
+
+        direct_cloud: dict[str, Any] = {}
+        if region:
+            direct_cloud["region"] = region
+        if runtime_id:
+            direct_cloud["runtime_id"] = runtime_id
+        if endpoint:
+            direct_cloud["runtime_endpoint"] = endpoint
+            if apikey:
+                direct_cloud["runtime_apikey"] = apikey
+            else:
+                direct_cloud["runtime_auth_type"] = "custom_jwt"
+
+        config_dict = {"common": direct_common, "launch_types": {"cloud": direct_cloud}}
+
+        result = executor.execute(
+            payload=final_payload,
+            config_dict=config_dict,
+            headers=final_headers,
+            stream=None,
+        )
+    else:
+        config_path = config_file or Path("agentkit.yaml")
+        config = get_config(config_path=config_path)
+        common_config = config.get_common_config()
+
+        agent_type = getattr(common_config, "agent_type", "") or getattr(
+            common_config, "template_type", ""
+        )
+        is_a2a = isinstance(agent_type, str) and "a2a" in agent_type.lower()
+
+        if is_a2a:
+            console.print(
+                "[cyan]Detected A2A agent type - constructing A2A JSON-RPC envelope[/cyan]"
+            )
+            final_payload = build_a2a_payload(message, payload, final_headers)
+
+        result = executor.execute(
+            payload=final_payload,
+            config_file=str(config_path),
+            headers=final_headers,
+            stream=None,  # Automatically determined by Runner
+        )
 
     if not result.success:
         console.print(f"[red]❌ Invocation failed: {result.error}[/red]")

--- a/agentkit/toolkit/resources/templates/code-pipeline-tos-cr-step.j2
+++ b/agentkit/toolkit/resources/templates/code-pipeline-tos-cr-step.j2
@@ -26,22 +26,24 @@ stages:
                 shell: BASH
             - step: step-c4
               displayName: 镜像构建推送至镜像仓库服务
-              component: build@2.0.0/buildkit-cr@3.0.0
+              component: build@2.0.0/buildkit-cr@5.0.0
               inputs:
+                buildParams: ""
                 compression: gzip
                 contextPath: $PROJECT_ROOT_DIR
                 crDomain: $CR_DOMAIN
-                crNamespace: $CR_NAMESPACE
-                crRegion: $CR_REGION
-                crRegistryInstance: $CR_INSTANCE
-                crRepo: $CR_OCI
-                crTag: $CR_TAG
+                namespace: $CR_NAMESPACE
+                region: $CR_REGION
+                registryInstance: $CR_INSTANCE
+                repo: $CR_OCI
+                tag: $CR_TAG
                 disableSSLVerify: true
                 dockerfiles:
                     default:
                         path: $DOCKERFILE_PATH
                 loginCredential: []
                 useCache: false
+                nydusify: true
           outputs:
             - imageOutput_step-c4
           workspace: {}

--- a/agentkit/toolkit/runners/base.py
+++ b/agentkit/toolkit/runners/base.py
@@ -17,6 +17,9 @@ from typing import Dict, Any, Optional, Union, Generator, Tuple
 import logging
 import requests
 import json
+import time
+import uuid
+import random
 from urllib.parse import urljoin
 from dataclasses import dataclass
 
@@ -53,6 +56,8 @@ class Runner(ABC):
         """
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.reporter = reporter or SilentReporter()
+        self._backend_detect_cache: Dict[str, Tuple[str, float]] = {}
+        self._backend_detect_cache_ttl_s: int = 120
 
     # ===== Configuration types =====
     @dataclass
@@ -387,6 +392,99 @@ class Runner(ABC):
             or err.startswith("Invocation failed: 405")
         )
 
+    def _normalize_base_endpoint(self, base_endpoint: str) -> str:
+        try:
+            return (base_endpoint or "").rstrip("/")
+        except Exception:
+            return base_endpoint
+
+    def _get_cached_backend(self, base_endpoint: str) -> Optional[str]:
+        key = self._normalize_base_endpoint(base_endpoint)
+        item = self._backend_detect_cache.get(key)
+        if not item:
+            return None
+        kind, ts = item
+        if time.monotonic() - ts > self._backend_detect_cache_ttl_s:
+            try:
+                self._backend_detect_cache.pop(key, None)
+            except Exception:
+                pass
+            return None
+        return kind
+
+    def _set_cached_backend(self, base_endpoint: str, kind: str) -> None:
+        key = self._normalize_base_endpoint(base_endpoint)
+        try:
+            self._backend_detect_cache[key] = (kind, time.monotonic())
+        except Exception:
+            pass
+
+    def _is_a2a_agent_card_response(self, data: Any) -> bool:
+        if not isinstance(data, dict):
+            return False
+        name = data.get("name")
+        if not isinstance(name, str) or not name:
+            return False
+        if isinstance(data.get("capabilities"), dict):
+            return True
+        if isinstance(data.get("skills"), list):
+            return True
+        if isinstance(data.get("endpoints"), (dict, list)):
+            return True
+        if isinstance(data.get("protocol_version"), str) or isinstance(
+            data.get("protocolVersion"), str
+        ):
+            return True
+        return False
+
+    def _detect_a2a_backend(
+        self, base_endpoint: str, headers: Dict[str, str], timeout_s: int = 2
+    ) -> bool:
+        try:
+            base = (base_endpoint.rstrip("/") + "/") if base_endpoint else ""
+            url = urljoin(base, ".well-known/agent-card.json")
+            resp = requests.get(url, headers=headers, timeout=timeout_s)
+            if resp.status_code != 200:
+                return False
+            try:
+                data = resp.json()
+            except Exception:
+                return False
+            return self._is_a2a_agent_card_response(data)
+        except Exception:
+            return False
+
+    def _build_a2a_jsonrpc_payload(
+        self, original_payload: Any, headers: Dict[str, str]
+    ) -> Dict[str, Any]:
+        if isinstance(original_payload, dict) and original_payload.get("jsonrpc"):
+            return original_payload
+
+        text = None
+        if isinstance(original_payload, dict):
+            val = original_payload.get("prompt")
+            if isinstance(val, str):
+                text = val
+        if text is None:
+            try:
+                text = json.dumps(original_payload, ensure_ascii=False)
+            except Exception:
+                text = ""
+
+        return {
+            "jsonrpc": "2.0",
+            "method": "message/stream",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "messageId": str(uuid.uuid4()),
+                    "parts": [{"kind": "text", "text": text or ""}],
+                },
+                "metadata": headers,
+            },
+            "id": random.randint(1, 999999),
+        }
+
     def _post_run_sse(
         self,
         base_endpoint: str,
@@ -435,10 +533,8 @@ class Runner(ABC):
                 timeout=policy.invoke_timeout,
             )
         else:
-            # Non-A2A: detect ADK first
-            if self._detect_adk_backend(
-                ctx.base_endpoint, ctx.headers, timeout_s=policy.detect_timeout
-            ):
+            cached = self._get_cached_backend(ctx.base_endpoint)
+            if cached == "adk":
                 app_name = self._get_adk_app_name(
                     ctx.base_endpoint,
                     ctx.headers,
@@ -465,6 +561,16 @@ class Runner(ABC):
                     adk_payload,
                     timeout_s=policy.sse_timeout,
                 )
+            elif cached == "a2a":
+                a2a_payload = self._build_a2a_jsonrpc_payload(payload, ctx.headers)
+                success, response_data = self._http_post_invoke(
+                    endpoint=self._normalize_base_endpoint(ctx.base_endpoint)
+                    or ctx.base_endpoint,
+                    payload=a2a_payload,
+                    headers=ctx.headers,
+                    stream=None,
+                    timeout=policy.invoke_timeout,
+                )
             else:
                 success, response_data = self._http_post_invoke(
                     endpoint=ctx.invoke_endpoint,
@@ -473,35 +579,58 @@ class Runner(ABC):
                     stream=None,
                     timeout=policy.invoke_timeout,
                 )
-                if not success and self._should_fallback_to_adk(str(response_data)):
-                    app_name = self._get_adk_app_name(
-                        ctx.base_endpoint,
-                        ctx.headers,
-                        preferred_name=ctx.preferred_app_name,
-                        timeout_s=policy.list_apps_timeout,
-                    )
-                    app_name = app_name or "agentkit-app"
-                    user_id = ctx.headers.get("user_id") or "agentkit_user"
-                    session_id = (
-                        ctx.headers.get("session_id") or "agentkit_sample_session"
-                    )
-                    self._ensure_adk_session(
-                        ctx.base_endpoint,
-                        ctx.headers,
-                        app_name,
-                        user_id,
-                        session_id,
-                        timeout_s=policy.session_timeout,
-                    )
-                    adk_payload = self._build_adk_run_sse_payload(
-                        app_name, ctx.headers, payload
-                    )
-                    success, response_data = self._post_run_sse(
-                        ctx.base_endpoint,
-                        ctx.headers,
-                        adk_payload,
-                        timeout_s=policy.sse_timeout,
-                    )
+                if success:
+                    self._set_cached_backend(ctx.base_endpoint, "invoke")
+                elif self._should_fallback_to_adk(str(response_data)):
+                    if self._detect_adk_backend(
+                        ctx.base_endpoint, ctx.headers, timeout_s=policy.detect_timeout
+                    ):
+                        self._set_cached_backend(ctx.base_endpoint, "adk")
+                        app_name = self._get_adk_app_name(
+                            ctx.base_endpoint,
+                            ctx.headers,
+                            preferred_name=ctx.preferred_app_name,
+                            timeout_s=policy.list_apps_timeout,
+                        )
+                        app_name = app_name or "agentkit-app"
+                        user_id = ctx.headers.get("user_id") or "agentkit_user"
+                        session_id = (
+                            ctx.headers.get("session_id") or "agentkit_sample_session"
+                        )
+                        self._ensure_adk_session(
+                            ctx.base_endpoint,
+                            ctx.headers,
+                            app_name,
+                            user_id,
+                            session_id,
+                            timeout_s=policy.session_timeout,
+                        )
+                        adk_payload = self._build_adk_run_sse_payload(
+                            app_name, ctx.headers, payload
+                        )
+                        success, response_data = self._post_run_sse(
+                            ctx.base_endpoint,
+                            ctx.headers,
+                            adk_payload,
+                            timeout_s=policy.sse_timeout,
+                        )
+                    elif self._detect_a2a_backend(
+                        ctx.base_endpoint, ctx.headers, timeout_s=policy.detect_timeout
+                    ):
+                        self._set_cached_backend(ctx.base_endpoint, "a2a")
+                        a2a_payload = self._build_a2a_jsonrpc_payload(
+                            payload, ctx.headers
+                        )
+                        success, response_data = self._http_post_invoke(
+                            endpoint=self._normalize_base_endpoint(ctx.base_endpoint)
+                            or ctx.base_endpoint,
+                            payload=a2a_payload,
+                            headers=ctx.headers,
+                            stream=None,
+                            timeout=policy.invoke_timeout,
+                        )
+                    else:
+                        self._set_cached_backend(ctx.base_endpoint, "unknown")
 
         is_streaming = hasattr(response_data, "__iter__") and not isinstance(
             response_data, (dict, str, list, bytes)

--- a/agentkit/toolkit/runners/ve_agentkit.py
+++ b/agentkit/toolkit/runners/ve_agentkit.py
@@ -416,7 +416,8 @@ class VeAgentkitRuntimeRunner(Runner):
         """
         try:
             runner_config = config
-            is_jwt_auth = runner_config.runtime_auth_type == AUTH_TYPE_CUSTOM_JWT
+            effective_auth_type = runner_config.runtime_auth_type
+            is_jwt_auth = effective_auth_type == AUTH_TYPE_CUSTOM_JWT
 
             # Get Runtime endpoint and API key
             endpoint = runner_config.runtime_endpoint
@@ -455,6 +456,14 @@ class VeAgentkitRuntimeRunner(Runner):
                             error_code=ErrorCode.RESOURCE_NOT_FOUND,
                         )
                     raise e
+
+                authorizer = getattr(runtime, "authorizer_configuration", None)
+                if authorizer and getattr(authorizer, "custom_jwt_authorizer", None):
+                    effective_auth_type = AUTH_TYPE_CUSTOM_JWT
+                elif authorizer and getattr(authorizer, "key_auth", None):
+                    effective_auth_type = AUTH_TYPE_KEY_AUTH
+                is_jwt_auth = effective_auth_type == AUTH_TYPE_CUSTOM_JWT
+
                 endpoint = self.get_public_endpoint_of_runtime(runtime)
 
                 # Only fetch API key for key_auth mode
@@ -468,7 +477,7 @@ class VeAgentkitRuntimeRunner(Runner):
                 # Validate based on auth type
                 if not endpoint:
                     error_msg = "Failed to obtain Runtime endpoint. The 'agentkit invoke' command only supports public network endpoints."
-                    logger.error(f"{error_msg}, runtime: {runtime}")
+                    logger.error(error_msg)
                     return InvokeResult(
                         success=False,
                         error=error_msg,
@@ -476,7 +485,7 @@ class VeAgentkitRuntimeRunner(Runner):
                     )
                 if not is_jwt_auth and not api_key:
                     error_msg = "Failed to obtain Runtime API key."
-                    logger.error(f"{error_msg}, runtime: {runtime}")
+                    logger.error(error_msg)
                     return InvokeResult(
                         success=False,
                         error=error_msg,

--- a/agentkit/version.py
+++ b/agentkit/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.5.7"
+VERSION = "0.5.8"

--- a/docs/content/2.agentkit-cli/2.commands.md
+++ b/docs/content/2.agentkit-cli/2.commands.md
@@ -1239,6 +1239,30 @@ agentkit invoke [消息内容] [选项]
 - 默认会自动添加 `user_id` 和 `session_id`
 - 示例：<code v-pre>--headers '{"user_id": "test123"}'</code>
 
+`--runtime-id, -r` Runtime ID（直接调用模式）
+- **无需配置文件/无需在项目目录下执行**：通过 Runtime ID 直接调用 Agent
+- 系统会自动查询 Runtime 信息并提取公网 `endpoint`；若为 API Key 鉴权会自动提取 `API Key`
+- 与 `--endpoint`、`--config-file` 互斥，不能同时使用
+- 可配合 `--region` 指定查询区域
+- 不支持与 `--apikey` 同时使用；JWT/OAuth 场景请通过 `--headers` 提供 `Authorization`
+- 示例：`agentkit invoke --runtime-id r-xxxx "你好"`
+
+`--endpoint, -e` 直接指定 Endpoint URL（直接调用模式）
+- **无需配置文件/无需在项目目录下执行**：直接指定 Agent 的访问地址
+- 必须与 `--apikey` 一起使用，或通过 `--headers` 提供 `Authorization`（JWT/OAuth 场景）
+- 与 `--runtime-id`、`--config-file` 互斥，不能同时使用
+- 示例：`agentkit invoke --endpoint https://xxx.volceapi.com --apikey "xxx" "你好"`
+
+`--region` 区域（可选）
+- 配合 `--runtime-id` 使用，指定查询 Runtime 的区域
+- 默认使用全局配置或环境变量中的区域设置
+- 示例：`agentkit invoke --runtime-id r-xxxx --region cn-beijing "你好"`
+
+`--a2a` 强制使用 A2A JSON-RPC 协议（仅 direct 调用模式）
+- 当目标 Agent 为 A2A 协议时，强制把输入包装为 JSON-RPC envelope，并自动选择 A2A 调用路径
+- 仅能与 `--runtime-id` 或 `--endpoint` 一起使用
+- 示例：`agentkit invoke --runtime-id r-xxxx --a2a "你好"`
+
 `--raw` 输出原始响应（调试用）
 - 流式调用时：逐条打印服务端推送的 SSE 事件 JSON，便于确认事件格式
 - 非流式调用时：输出紧凑的原始 JSON（不做 pretty indent）
@@ -1291,6 +1315,24 @@ agentkit invoke \
 
 ```bash
 agentkit invoke "你好" --apikey your_api_key_here
+```
+
+#### 示例 5：直接调用（通过 Runtime ID）
+
+```bash
+agentkit invoke --runtime-id r-xxxx "你好"
+```
+
+#### 示例 6：直接调用（通过 Endpoint + API Key）
+
+```bash
+agentkit invoke --endpoint https://xxx.volceapi.com --apikey "xxx" "你好"
+```
+
+#### 示例 7：直接调用（A2A 协议）
+
+```bash
+agentkit invoke --runtime-id r-xxxx --a2a "你好"
 ```
 
 ### 运行效果

--- a/docs/en/content/2.agentkit-cli/2.commands.md
+++ b/docs/en/content/2.agentkit-cli/2.commands.md
@@ -1290,6 +1290,30 @@ agentkit invoke [message content] [options]
 - Automatically adds `user_id` and `session_id` by default
 - Example: <code v-pre>--headers '{"user_id": "test123"}'</code>
 
+`--runtime-id, -r` Runtime ID (direct invocation mode)
+- **No config file / no project directory required**: invoke the Agent directly via a Runtime ID
+- The CLI automatically queries Runtime details and extracts the public `endpoint`; for API Key auth it also extracts the `API Key`
+- Mutually exclusive with `--endpoint` and `--config-file`
+- Can be used with `--region`
+- Cannot be used with `--apikey`; for JWT/OAuth, provide `Authorization` via `--headers`
+- Example: `agentkit invoke --runtime-id r-xxxx "hello"`
+
+`--endpoint, -e` Explicit Endpoint URL (direct invocation mode)
+- **No config file / no project directory required**: invoke the Agent directly via an explicit access URL
+- Requires either `--apikey` (API Key auth) or an `Authorization` header provided via `--headers` (JWT/OAuth)
+- Mutually exclusive with `--runtime-id` and `--config-file`
+- Example: `agentkit invoke --endpoint https://xxx.volceapi.com --apikey "xxx" "hello"`
+
+`--region` Region (optional)
+- Used with `--runtime-id` to specify the region for Runtime lookup
+- Defaults to global config or environment variables if not provided
+- Example: `agentkit invoke --runtime-id r-xxxx --region cn-beijing "hello"`
+
+`--a2a` Force A2A JSON-RPC protocol (direct invocation mode only)
+- Forces wrapping the input as an A2A JSON-RPC envelope and uses the A2A invoke path
+- Can only be used together with `--runtime-id` or `--endpoint`
+- Example: `agentkit invoke --runtime-id r-xxxx --a2a "hello"`
+
 `--raw` Output raw response (for debugging)
 - For streaming calls: prints SSE event JSON from server line by line to verify event format
 - For non-streaming calls: outputs compact raw JSON (no pretty indent)
@@ -1344,6 +1368,24 @@ agentkit invoke \
 agentkit invoke "hello" --apikey your_api_key_here
 ```
 
+#### Example 5: Direct invocation (via Runtime ID)
+
+```bash
+agentkit invoke --runtime-id r-xxxx "hello"
+```
+
+#### Example 6: Direct invocation (via Endpoint + API Key)
+
+```bash
+agentkit invoke --endpoint https://xxx.volceapi.com --apikey "xxx" "hello"
+```
+
+#### Example 7: Direct invocation (A2A protocol)
+
+```bash
+agentkit invoke --runtime-id r-xxxx --a2a "hello"
+```
+
 ### Execution Output
 
 ```
@@ -1361,6 +1403,9 @@ Hangzhou is sunny today, 22°C, great for going out.
 - ⚠️ Message content and `--payload` are mutually exclusive
 - ⚠️ Cloud deployment may require API Key
 - ⚠️ Ensure Agent is deployed before calling (check with `agentkit status`)
+- ⚠️ `--runtime-id` and `--endpoint` are mutually exclusive
+- ⚠️ `--config-file` cannot be used with `--runtime-id`/`--endpoint`
+- ⚠️ `--region` can only be used together with `--runtime-id`
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentkit-sdk-python"
-version = "0.5.7"
+version = "0.5.8"
 description = "Python SDK for transforming any AI agent into a production-ready application. Framework-agnostic primitives for runtime, memory, authentication, and tools with volcengine-managed infrastructure."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/toolkit/cli/test_cli_invoke_direct_mode.py
+++ b/tests/toolkit/cli/test_cli_invoke_direct_mode.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+class _FakeInvokeExecutor:
+    last_kwargs = None
+
+    def __init__(self, reporter=None):
+        self.reporter = reporter
+
+    def execute(self, **kwargs):
+        from agentkit.toolkit.models import InvokeResult
+
+        _FakeInvokeExecutor.last_kwargs = kwargs
+        return InvokeResult(success=True, response={"ok": True}, is_streaming=False)
+
+
+runner = CliRunner()
+
+
+def test_invoke_direct_mode_rejects_config_file(monkeypatch) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.executors as executors
+
+    monkeypatch.setattr(executors, "InvokeExecutor", _FakeInvokeExecutor)
+
+    result = runner.invoke(
+        app,
+        [
+            "invoke",
+            "--runtime-id",
+            "r-123",
+            "--config-file",
+            str(Path("agentkit.yaml")),
+            "hi",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_invoke_direct_mode_endpoint_requires_auth(monkeypatch) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.executors as executors
+
+    monkeypatch.setattr(executors, "InvokeExecutor", _FakeInvokeExecutor)
+
+    result = runner.invoke(app, ["invoke", "--endpoint", "https://example.com", "hi"])
+    assert result.exit_code != 0
+
+
+def test_invoke_direct_mode_endpoint_with_authorization_header(monkeypatch) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.executors as executors
+
+    monkeypatch.setattr(executors, "InvokeExecutor", _FakeInvokeExecutor)
+
+    result = runner.invoke(
+        app,
+        [
+            "invoke",
+            "--endpoint",
+            "https://example.com",
+            "--headers",
+            '{"Authorization":"Bearer token"}',
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0
+
+    kwargs = _FakeInvokeExecutor.last_kwargs
+    assert kwargs is not None
+    assert kwargs.get("config_file") is None
+    cfg = kwargs.get("config_dict")
+    assert isinstance(cfg, dict)
+    cloud = cfg["launch_types"]["cloud"]
+    assert cloud["runtime_endpoint"] == "https://example.com"
+    assert cloud["runtime_auth_type"] == "custom_jwt"
+
+
+def test_invoke_direct_mode_runtime_id_with_region(monkeypatch) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.executors as executors
+
+    monkeypatch.setattr(executors, "InvokeExecutor", _FakeInvokeExecutor)
+
+    result = runner.invoke(
+        app,
+        ["invoke", "--runtime-id", "r-123", "--region", "cn-beijing", "hi"],
+    )
+    assert result.exit_code == 0
+
+    cfg = _FakeInvokeExecutor.last_kwargs["config_dict"]
+    cloud = cfg["launch_types"]["cloud"]
+    assert cloud["runtime_id"] == "r-123"
+    assert cloud["region"] == "cn-beijing"
+
+
+def test_invoke_direct_mode_runtime_id_rejects_apikey(monkeypatch) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.executors as executors
+
+    monkeypatch.setattr(executors, "InvokeExecutor", _FakeInvokeExecutor)
+
+    result = runner.invoke(
+        app,
+        ["invoke", "--runtime-id", "r-123", "--apikey", "x", "hi"],
+    )
+    assert result.exit_code != 0
+    normalized_output = " ".join(result.output.split())
+    assert "--apikey cannot be used together with --runtime-id" in normalized_output
+    assert (
+        "--runtime-id mode resolves the Runtime and infers its auth type"
+        in normalized_output
+    )
+    assert (
+        "If you want to pass an API key manually, use --endpoint together with --apikey."
+        in normalized_output
+    )
+
+
+def test_invoke_direct_mode_a2a_flag_wraps_message(monkeypatch) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.executors as executors
+
+    monkeypatch.setattr(executors, "InvokeExecutor", _FakeInvokeExecutor)
+
+    result = runner.invoke(
+        app,
+        [
+            "invoke",
+            "--endpoint",
+            "https://example.com",
+            "--apikey",
+            "k",
+            "--a2a",
+            "hi",
+        ],
+    )
+    assert result.exit_code == 0
+
+    cfg = _FakeInvokeExecutor.last_kwargs["config_dict"]
+    assert cfg["common"]["agent_type"] == "a2a"
+    payload = _FakeInvokeExecutor.last_kwargs["payload"]
+    assert isinstance(payload, dict)
+    assert payload.get("jsonrpc") == "2.0"
+
+
+def test_invoke_direct_mode_payload_jsonrpc_sets_a2a_agent_type(monkeypatch) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.executors as executors
+
+    monkeypatch.setattr(executors, "InvokeExecutor", _FakeInvokeExecutor)
+
+    result = runner.invoke(
+        app,
+        [
+            "invoke",
+            "--runtime-id",
+            "r-123",
+            "--payload",
+            '{"jsonrpc":"2.0","method":"message/stream","params":{},"id":1}',
+        ],
+    )
+    assert result.exit_code == 0
+
+    cfg = _FakeInvokeExecutor.last_kwargs["config_dict"]
+    assert cfg["common"]["agent_type"] == "a2a"

--- a/tests/toolkit/runners/test_runner_backend_autodetect.py
+++ b/tests/toolkit/runners/test_runner_backend_autodetect.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class _DummyRunner:
+    def __new__(cls):
+        from agentkit.toolkit.runners.base import Runner
+
+        class _Impl(Runner):
+            def deploy(self, config):
+                raise NotImplementedError()
+
+            def destroy(self, config):
+                raise NotImplementedError()
+
+            def status(self, config):
+                raise NotImplementedError()
+
+            def invoke(self, config, payload, headers=None, stream=None):
+                raise NotImplementedError()
+
+        return _Impl()
+
+
+def test_autodetect_invoke_success_no_probe(monkeypatch) -> None:
+    from agentkit.toolkit.runners.base import Runner
+    import agentkit.toolkit.runners.base as base_mod
+
+    runner: Runner = _DummyRunner()
+
+    calls: list[tuple[str, Any]] = []
+
+    def _http_post_invoke(endpoint, payload, headers, stream, timeout):
+        calls.append((endpoint, payload))
+        return True, {"ok": True}
+
+    monkeypatch.setattr(runner, "_http_post_invoke", _http_post_invoke)
+    monkeypatch.setattr(
+        runner,
+        "_detect_adk_backend",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()),
+    )
+    monkeypatch.setattr(
+        base_mod.requests,
+        "get",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    ctx = Runner.InvokeContext(
+        base_endpoint="https://x/",
+        invoke_endpoint="https://x/invoke",
+        headers={},
+        is_a2a=False,
+    )
+    ok, resp, is_stream = runner._invoke_with_adk_compat(
+        ctx, payload={"prompt": "hi"}, policy=Runner.TimeoutPolicy()
+    )
+    assert ok is True
+    assert resp == {"ok": True}
+    assert is_stream is False
+    assert calls == [("https://x/invoke", {"prompt": "hi"})]
+
+
+def test_autodetect_fallbacks_to_adk_and_caches(monkeypatch) -> None:
+    from agentkit.toolkit.runners.base import Runner
+    import agentkit.toolkit.runners.base as base_mod
+
+    runner: Runner = _DummyRunner()
+    runner._backend_detect_cache_ttl_s = 9999
+
+    adk_detect_calls = {"n": 0}
+    sse_calls = {"n": 0}
+
+    def _http_post_invoke(endpoint, payload, headers, stream, timeout):
+        if endpoint.endswith("/invoke"):
+            return False, "Invocation failed: 404"
+        raise AssertionError()
+
+    def _detect_adk_backend(*args, **kwargs):
+        adk_detect_calls["n"] += 1
+        return True
+
+    def _post_run_sse(*args, **kwargs):
+        sse_calls["n"] += 1
+        return True, {"ok": True}
+
+    monkeypatch.setattr(runner, "_http_post_invoke", _http_post_invoke)
+    monkeypatch.setattr(runner, "_detect_adk_backend", _detect_adk_backend)
+    monkeypatch.setattr(runner, "_get_adk_app_name", lambda *a, **k: "app")
+    monkeypatch.setattr(runner, "_ensure_adk_session", lambda *a, **k: True)
+    monkeypatch.setattr(runner, "_post_run_sse", _post_run_sse)
+    monkeypatch.setattr(
+        base_mod.requests,
+        "get",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    ctx = Runner.InvokeContext(
+        base_endpoint="https://x/",
+        invoke_endpoint="https://x/invoke",
+        headers={"user_id": "u", "session_id": "s"},
+        is_a2a=False,
+    )
+
+    ok, _, _ = runner._invoke_with_adk_compat(
+        ctx, payload={"prompt": "hi"}, policy=Runner.TimeoutPolicy()
+    )
+    assert ok is True
+    assert adk_detect_calls["n"] == 1
+    assert sse_calls["n"] == 1
+
+    ok2, _, _ = runner._invoke_with_adk_compat(
+        ctx, payload={"prompt": "hi"}, policy=Runner.TimeoutPolicy()
+    )
+    assert ok2 is True
+    assert adk_detect_calls["n"] == 1
+    assert sse_calls["n"] == 2
+
+
+def test_autodetect_fallbacks_to_a2a_and_caches(monkeypatch) -> None:
+    from agentkit.toolkit.runners.base import Runner
+    import agentkit.toolkit.runners.base as base_mod
+
+    runner: Runner = _DummyRunner()
+    runner._backend_detect_cache_ttl_s = 9999
+
+    get_calls = {"n": 0}
+    invoke_calls: list[tuple[str, Any]] = []
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"name": "a2a-agent", "capabilities": {}}
+
+    def _requests_get(*args, **kwargs):
+        get_calls["n"] += 1
+        return _Resp()
+
+    def _detect_adk_backend(*args, **kwargs):
+        return False
+
+    def _http_post_invoke(endpoint, payload, headers, stream, timeout):
+        invoke_calls.append((endpoint, payload))
+        if endpoint.endswith("/invoke"):
+            return False, "Invocation failed: 404"
+        assert endpoint == "https://x"
+        assert isinstance(payload, dict)
+        assert payload.get("jsonrpc") == "2.0"
+        return True, {"ok": True}
+
+    monkeypatch.setattr(base_mod.requests, "get", _requests_get)
+    monkeypatch.setattr(runner, "_detect_adk_backend", _detect_adk_backend)
+    monkeypatch.setattr(runner, "_http_post_invoke", _http_post_invoke)
+
+    ctx = Runner.InvokeContext(
+        base_endpoint="https://x/",
+        invoke_endpoint="https://x/invoke",
+        headers={"user_id": "u", "session_id": "s"},
+        is_a2a=False,
+    )
+
+    ok, _, _ = runner._invoke_with_adk_compat(
+        ctx, payload={"prompt": "hi"}, policy=Runner.TimeoutPolicy()
+    )
+    assert ok is True
+    assert get_calls["n"] == 1
+
+    ok2, _, _ = runner._invoke_with_adk_compat(
+        ctx, payload={"prompt": "hi"}, policy=Runner.TimeoutPolicy()
+    )
+    assert ok2 is True
+    assert get_calls["n"] == 1
+    assert any(ep == "https://x" for ep, _ in invoke_calls)

--- a/tests/toolkit/runners/test_ve_agentkit_invoke_auth_infer.py
+++ b/tests/toolkit/runners/test_ve_agentkit_invoke_auth_infer.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeRuntimeClient:
+    def __init__(self, runtime):
+        self._runtime = runtime
+
+    def get_runtime(self, req):
+        return self._runtime
+
+
+class _FakeKeyAuth:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+
+
+class _FakeAuthorizer:
+    def __init__(self, key_auth=None, custom_jwt_authorizer=None):
+        self.key_auth = key_auth
+        self.custom_jwt_authorizer = custom_jwt_authorizer
+
+
+class _FakeRuntime:
+    def __init__(self, authorizer_configuration):
+        self.authorizer_configuration = authorizer_configuration
+
+
+def test_invoke_infers_custom_jwt_auth_and_requires_authorization(monkeypatch) -> None:
+    from agentkit.toolkit.runners.ve_agentkit import (
+        VeAgentkitRuntimeRunner,
+        VeAgentkitRunnerConfig,
+    )
+    from agentkit.toolkit.errors import ErrorCode
+
+    runtime = _FakeRuntime(_FakeAuthorizer(custom_jwt_authorizer=object()))
+    runner = VeAgentkitRuntimeRunner()
+
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient(runtime)
+    )
+    monkeypatch.setattr(
+        runner, "get_public_endpoint_of_runtime", lambda rt: "https://x/"
+    )
+    monkeypatch.setattr(
+        runner,
+        "_invoke_with_adk_compat",
+        lambda ctx, payload, policy: (True, {"ok": True}, False),
+    )
+
+    cfg = VeAgentkitRunnerConfig(runtime_id="r-123", region="cn-beijing")
+    result = runner.invoke(cfg, payload={"prompt": "hi"}, headers={})
+    assert result.success is False
+    assert result.error_code == ErrorCode.AUTH_FAILED
+
+
+def test_invoke_infers_key_auth_and_injects_api_key(monkeypatch) -> None:
+    from agentkit.toolkit.runners.ve_agentkit import (
+        VeAgentkitRuntimeRunner,
+        VeAgentkitRunnerConfig,
+    )
+
+    runtime = _FakeRuntime(_FakeAuthorizer(key_auth=_FakeKeyAuth(api_key="k-1")))
+    runner = VeAgentkitRuntimeRunner()
+
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient(runtime)
+    )
+    monkeypatch.setattr(
+        runner, "get_public_endpoint_of_runtime", lambda rt: "https://x/"
+    )
+
+    seen = {}
+
+    def _fake_invoke(ctx, payload, policy):
+        seen["auth"] = ctx.headers.get("Authorization")
+        return True, {"ok": True}, False
+
+    monkeypatch.setattr(runner, "_invoke_with_adk_compat", _fake_invoke)
+
+    cfg = VeAgentkitRunnerConfig(runtime_id="r-123", region="cn-beijing")
+    result = runner.invoke(cfg, payload={"prompt": "hi"}, headers={})
+    assert result.success is True
+    assert seen["auth"] == "Bearer k-1"


### PR DESCRIPTION
## Summary
- Cherry-pick internal commits up to 0.5.8:
  - 75e82da feat: support invoke direct
  - faaf298 feat: update buildkit-cr version and enable nydusify
- Add direct invoke support in CLI/runners
- Update buildkit-cr template from 3.0.0 to 5.0.0 and enable nydusify
- Bump package version from 0.5.7 to 0.5.8

## Tests
- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/bytedance/workspace/agentkit-sdk-python
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0
collected 17 items

tests/toolkit/cli/test_cli_invoke_direct_mode.py .......                 [ 41%]
tests/toolkit/runners/test_runner_backend_autodetect.py ...              [ 58%]
tests/toolkit/runners/test_ve_agentkit_invoke_auth_infer.py ..           [ 70%]
tests/toolkit/builders/test_ve_pipeline_cr_domain.py .....               [100%]

============================== 17 passed in 0.79s ==============================
- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/bytedance/workspace/agentkit-sdk-python
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0
collected 145 items

tests/platform/test_configuration_byteplus.py ........                   [  5%]
tests/platform/test_configuration_creds.py ................              [ 16%]
tests/platform/test_configuration_dotenv_byteplus.py .                   [ 17%]
tests/platform/test_configuration_endpoints.py ..........                [ 24%]
tests/platform/test_global_config_compat.py ....                         [ 26%]
tests/platform/test_platform_context_provider.py .                       [ 27%]
tests/platform/test_vefaas_credential_rotation.py .                      [ 28%]
tests/test_client_uses_platform_context.py .                             [ 28%]
tests/toolkit/builders/test_ve_pipeline_cr_domain.py .....               [ 32%]
tests/toolkit/cli/test_cli_config_cloud_provider_noninteractive.py ..    [ 33%]
tests/toolkit/cli/test_cli_config_interactive_flow.py .                  [ 34%]
tests/toolkit/cli/test_cli_config_interactive_provider_resolution.py ..  [ 35%]
tests/toolkit/cli/test_cli_invoke_direct_mode.py .......                 [ 40%]
tests/toolkit/cli/test_cli_runtime_network_config.py .....               [ 44%]
tests/toolkit/cli/test_cli_skills_platform_compat.py ...........         [ 51%]
tests/toolkit/cli/test_cli_skills_workflow.py ......                     [ 55%]
tests/toolkit/cli/test_interactive_hidden_fields_carry_over.py ....      [ 58%]
tests/toolkit/config/test_common_cloud_provider_global_default.py ....   [ 61%]
tests/toolkit/config/test_config_show_cloud_provider.py .                [ 62%]
tests/toolkit/config/test_dynamic_region_default.py ....                 [ 64%]
tests/toolkit/config/test_env_files.py ...                               [ 66%]
tests/toolkit/config/test_persist_policy_explicit_only.py ...            [ 68%]
tests/toolkit/docker/test_base_image_defaults.py ...                     [ 71%]
tests/toolkit/docker/test_dockerfile_manager_regeneration.py ....        [ 73%]
tests/toolkit/docker/test_dockerignore_utils.py .                        [ 74%]
tests/toolkit/executors/test_executor_platform_context_provider.py .     [ 75%]
tests/toolkit/executors/test_init_cloud_provider_defaults.py ..          [ 76%]
tests/toolkit/runners/test_runner_backend_autodetect.py ...              [ 78%]
tests/toolkit/runners/test_ve_agentkit_invoke_auth_infer.py ..           [ 80%]
tests/toolkit/runners/test_ve_agentkit_network_config.py ...             [ 82%]
tests/toolkit/test_byteplus_single_region.py ...                         [ 84%]
tests/toolkit/test_cloud_provider_resolution.py ....                     [ 86%]
tests/toolkit/test_dynamic_choices.py ...                                [ 88%]
tests/toolkit/test_lifecycle_destroy_platform_context.py .               [ 89%]
tests/toolkit/test_lifecycle_launch_preflight_platform_context.py ...    [ 91%]
tests/toolkit/test_no_env_rewrite.py ..                                  [ 93%]
tests/toolkit/volcengine/test_provider_injection.py ...                  [ 95%]
tests/toolkit/volcengine/utils/test_project_archiver_dockerignore.py ... [ 97%]
....                                                                     [100%]

============================= 145 passed in 1.15s ==============================
- 