### PR TITLE
chore: sync internal 0.5.9 to GitHub

### DIFF
--- a/agentkit/platform/constants.py
+++ b/agentkit/platform/constants.py
@@ -29,7 +29,6 @@ class ServiceMeta:
 DEFAULT_REGION_RULES = {
     "cn-shanghai": {
         "cp": "cn-beijing",
-        "tos": "cn-beijing",
     }
 }
 

--- a/agentkit/toolkit/builders/ve_pipeline.py
+++ b/agentkit/toolkit/builders/ve_pipeline.py
@@ -952,6 +952,7 @@ class VeCPCRBuilder(Builder):
             import time
 
             created_in_this_run = False
+            name_conflict_not_created = False
 
             # Step 1: ensure bucket exists / accessible
             if auto_created_bucket:
@@ -988,9 +989,7 @@ class VeCPCRBuilder(Builder):
                         created_in_this_run = True
                     except tos.exceptions.TosServerError as e:
                         if e.status_code == 409:
-                            # The bucket name is already taken (possibly by another account).
-                            # Ownership verification in step 2 will block the upload.
-                            pass
+                            name_conflict_not_created = True
                         else:
                             raise
 
@@ -1032,9 +1031,42 @@ class VeCPCRBuilder(Builder):
                 )
                 raise Exception(error_msg)
 
+            if name_conflict_not_created and owned:
+                actual_location = tos_service.get_bucket_location(bucket_name)
+                current_region = getattr(
+                    tos_service, "actual_region", config.tos_region
+                )
+                if actual_location:
+                    raise Exception(
+                        f"TOS bucket '{bucket_name}' exists in region '{actual_location}', "
+                        f"but the current configuration targets region '{current_region}'. "
+                        "TOS buckets are region-scoped and cannot be accessed across regions. "
+                        "Please either switch to the bucket's region or use a different bucket name "
+                        f"(e.g. '{bucket_name}-{current_region.split('-')[-1]}')."
+                    )
+                else:
+                    raise Exception(
+                        f"TOS bucket '{bucket_name}' is owned by your account but does not exist "
+                        f"in the current region '{current_region}'. It may reside in another region. "
+                        "TOS buckets are region-scoped and cannot be accessed across regions. "
+                        "Please either switch to the bucket's region or use a different bucket name."
+                    )
+
             self.reporter.success(
                 f"TOS bucket ownership verified for current account: {bucket_name}"
             )
+
+            if created_in_this_run:
+                data_plane_timeout_s = 30
+                data_plane_interval_s = 3
+                data_plane_deadline = time.time() + data_plane_timeout_s
+                while not tos_service.bucket_exists():
+                    if time.time() >= data_plane_deadline:
+                        raise Exception(
+                            f"TOS bucket '{bucket_name}' was created but is not yet "
+                            "available for uploads. Please retry in a few seconds."
+                        )
+                    time.sleep(data_plane_interval_s)
 
             # Update config with auto-generated bucket name if applicable
             if auto_created_bucket:

--- a/agentkit/toolkit/volcengine/services/tos_service.py
+++ b/agentkit/toolkit/volcengine/services/tos_service.py
@@ -266,6 +266,30 @@ class TOSService:
             return False
         return name in set(self.list_bucket_names())
 
+    def get_bucket_location(self, bucket_name: Optional[str] = None) -> Optional[str]:
+        """Return the region (location) of a bucket owned by this account.
+
+        Uses the already-available ListBuckets data so no extra API call is needed
+        beyond what ``bucket_is_owned`` / ``list_bucket_names`` already do.
+
+        Args:
+            bucket_name: Bucket name to look up. Defaults to configured bucket.
+
+        Returns:
+            The region string (e.g. ``"cn-beijing"``) or ``None`` if not found.
+        """
+        name = bucket_name or self.config.bucket
+        if not name:
+            return None
+        try:
+            out = self.client.list_buckets()
+            for b in getattr(out, "buckets", None) or []:
+                if getattr(b, "name", None) == name:
+                    return getattr(b, "location", None)
+        except Exception as e:
+            logger.warning(f"Failed to get bucket location: {str(e)}")
+        return None
+
     def bucket_exists(self) -> bool:
         """Check if the configured bucket exists.
 

--- a/agentkit/version.py
+++ b/agentkit/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.5.8"
+VERSION = "0.5.9"

--- a/docs/content/2.agentkit-cli/3.configurations.md
+++ b/docs/content/2.agentkit-cli/3.configurations.md
@@ -573,7 +573,6 @@ runtime_envs:
 | 字段 | 说明 |
 |------|------|
 | `tos_prefix` | 对象存储前缀（默认 `agentkit-builds`） |
-| `tos_region` | TOS 服务区域 |
 | `tos_object_key` | 代码包的存储路径 |
 | `tos_object_url` | 代码包的访问地址 |
 

--- a/docs/en/content/2.agentkit-cli/3.configurations.md
+++ b/docs/en/content/2.agentkit-cli/3.configurations.md
@@ -594,7 +594,6 @@ The following fields are generated and managed by the CLI; **you do not need to 
 | Field | Description |
 |------|-------------|
 | `tos_prefix` | Object storage prefix (default `agentkit-builds`) |
-| `tos_region` | TOS region |
 | `tos_object_key` | Storage path for the code package |
 | `tos_object_url` | URL for the code package |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentkit-sdk-python"
-version = "0.5.8"
+version = "0.5.9"
 description = "Python SDK for transforming any AI agent into a production-ready application. Framework-agnostic primitives for runtime, memory, authentication, and tools with volcengine-managed infrastructure."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/platform/test_configuration_endpoints.py
+++ b/tests/platform/test_configuration_endpoints.py
@@ -64,6 +64,24 @@ class TestConfigurationEndpoints:
         cp_ep = config.get_service_endpoint("cp")
         assert cp_ep.region == "cn-beijing"
 
+    def test_tos_region_follows_user_region(self, clean_env, mock_global_config):
+        """TOS must follow user-specified region without any implicit remapping.
+
+        Historically cn-shanghai was silently mapped to cn-beijing for TOS.
+        That mapping has been removed so users can target the TOS region they
+        actually configured (cn-shanghai, cn-beijing, etc.).
+        """
+        config = VolcConfiguration(region="cn-shanghai")
+
+        tos_ep = config.get_service_endpoint("tos")
+        assert tos_ep.region == "cn-shanghai"
+        assert tos_ep.host == "tos-cn-shanghai.volces.com"
+
+        config_bj = VolcConfiguration(region="cn-beijing")
+        tos_bj_ep = config_bj.get_service_endpoint("tos")
+        assert tos_bj_ep.region == "cn-beijing"
+        assert tos_bj_ep.host == "tos-cn-beijing.volces.com"
+
     def test_region_mapping_custom(self, clean_env, mock_global_config):
         """Test user defined region mapping rules."""
         mock_global_config.update(


### PR DESCRIPTION
## Summary
- Cherry-pick internal commits up to 0.5.9:
  - f28c7e5 feat: remove hardcoded cn-shanghai tos region mapping
  - 8f4b36f chore: bump version to 0.5.9
- Remove hardcoded TOS region remapping from cn-shanghai to cn-beijing
- Improve bucket region conflict checks and newly-created bucket readiness handling
- Bump package version from 0.5.8 to 0.5.9

## Tests
- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/bytedance/workspace/agentkit-sdk-python
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0
collected 19 items

tests/platform/test_configuration_endpoints.py ...........               [ 57%]
tests/toolkit/builders/test_ve_pipeline_cr_domain.py .....               [ 84%]
tests/toolkit/test_lifecycle_launch_preflight_platform_context.py ...    [100%]

============================== 19 passed in 0.65s ==============================
- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/bytedance/workspace/agentkit-sdk-python
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0
collected 146 items

tests/platform/test_configuration_byteplus.py ........                   [  5%]
tests/platform/test_configuration_creds.py ................              [ 16%]
tests/platform/test_configuration_dotenv_byteplus.py .                   [ 17%]
tests/platform/test_configuration_endpoints.py ...........               [ 24%]
tests/platform/test_global_config_compat.py ....                         [ 27%]
tests/platform/test_platform_context_provider.py .                       [ 28%]
tests/platform/test_vefaas_credential_rotation.py .                      [ 28%]
tests/test_client_uses_platform_context.py .                             [ 29%]
tests/toolkit/builders/test_ve_pipeline_cr_domain.py .....               [ 32%]
tests/toolkit/cli/test_cli_config_cloud_provider_noninteractive.py ..    [ 34%]
tests/toolkit/cli/test_cli_config_interactive_flow.py .                  [ 34%]
tests/toolkit/cli/test_cli_config_interactive_provider_resolution.py ..  [ 36%]
tests/toolkit/cli/test_cli_invoke_direct_mode.py .......                 [ 41%]
tests/toolkit/cli/test_cli_runtime_network_config.py .....               [ 44%]
tests/toolkit/cli/test_cli_skills_platform_compat.py ...........         [ 52%]
tests/toolkit/cli/test_cli_skills_workflow.py ......                     [ 56%]
tests/toolkit/cli/test_interactive_hidden_fields_carry_over.py ....      [ 58%]
tests/toolkit/config/test_common_cloud_provider_global_default.py ....   [ 61%]
tests/toolkit/config/test_config_show_cloud_provider.py .                [ 62%]
tests/toolkit/config/test_dynamic_region_default.py ....                 [ 65%]
tests/toolkit/config/test_env_files.py ...                               [ 67%]
tests/toolkit/config/test_persist_policy_explicit_only.py ...            [ 69%]
tests/toolkit/docker/test_base_image_defaults.py ...                     [ 71%]
tests/toolkit/docker/test_dockerfile_manager_regeneration.py ....        [ 73%]
tests/toolkit/docker/test_dockerignore_utils.py .                        [ 74%]
tests/toolkit/executors/test_executor_platform_context_provider.py .     [ 75%]
tests/toolkit/executors/test_init_cloud_provider_defaults.py ..          [ 76%]
tests/toolkit/runners/test_runner_backend_autodetect.py ...              [ 78%]
tests/toolkit/runners/test_ve_agentkit_invoke_auth_infer.py ..           [ 80%]
tests/toolkit/runners/test_ve_agentkit_network_config.py ...             [ 82%]
tests/toolkit/test_byteplus_single_region.py ...                         [ 84%]
tests/toolkit/test_cloud_provider_resolution.py ....                     [ 86%]
tests/toolkit/test_dynamic_choices.py ...                                [ 89%]
tests/toolkit/test_lifecycle_destroy_platform_context.py .               [ 89%]
tests/toolkit/test_lifecycle_launch_preflight_platform_context.py ...    [ 91%]
tests/toolkit/test_no_env_rewrite.py ..                                  [ 93%]
tests/toolkit/volcengine/test_provider_injection.py ...                  [ 95%]
tests/toolkit/volcengine/utils/test_project_archiver_dockerignore.py ... [ 97%]
....                                                                     [100%]

============================= 146 passed in 1.10s ==============================
- 