### PR TITLE
chore: sync internal 0.5.10 to GitHub

### DIFF
--- a/agentkit/apps/agent_server_app/agent_server_app.py
+++ b/agentkit/apps/agent_server_app/agent_server_app.py
@@ -49,6 +49,13 @@ from veadk.runner import Runner
 from agentkit.apps.agent_server_app.middleware import (
     AgentkitTelemetryHTTPMiddleware,
 )
+from agentkit.apps.agent_server_app.origin import (
+    add_cors_compat_middleware,
+    adk_supports_regex_origins,
+    resolve_agentkit_allow_origins,
+    split_allow_origins,
+    supports_get_fast_api_kwarg,
+)
 from agentkit.apps.agent_server_app.telemetry import telemetry
 from agentkit.apps.base_app import BaseAgentkitApp
 
@@ -101,6 +108,7 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
         *,
         app: App | None = None,
         allow_origins: list[str] | None = None,
+        allow_origin_regex: str | list[str] | None = None,
     ) -> None:
         super().__init__()
 
@@ -153,9 +161,36 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
                 await handler()
             yield
 
-        self.app = self.server.get_fast_api_app(
-            lifespan=lifespan, allow_origins=allow_origins
+        resolved_allow_origins = resolve_agentkit_allow_origins(
+            allow_origins=allow_origins,
+            allow_origin_regex=allow_origin_regex,
         )
+        get_fast_api_app = self.server.get_fast_api_app
+        get_fast_api_app_kwargs: dict[str, Any] = {"lifespan": lifespan}
+        supports_allow_origins = supports_get_fast_api_kwarg(
+            get_fast_api_app, "allow_origins"
+        )
+        supports_regex_origins = adk_supports_regex_origins()
+        needs_cors_compat_middleware = False
+
+        if supports_allow_origins:
+            if supports_regex_origins:
+                get_fast_api_app_kwargs["allow_origins"] = (
+                    resolved_allow_origins or None
+                )
+            else:
+                literal_origins, combined_regex = split_allow_origins(
+                    resolved_allow_origins
+                )
+                get_fast_api_app_kwargs["allow_origins"] = literal_origins or None
+                needs_cors_compat_middleware = combined_regex is not None
+        else:
+            needs_cors_compat_middleware = bool(resolved_allow_origins)
+
+        self.app = get_fast_api_app(**get_fast_api_app_kwargs)
+
+        if needs_cors_compat_middleware:
+            add_cors_compat_middleware(self.app, resolved_allow_origins)
 
         @self.app.post("/run_sse")
         async def run_agent_sse(req: RunAgentRequest) -> StreamingResponse:

--- a/agentkit/apps/agent_server_app/origin.py
+++ b/agentkit/apps/agent_server_app/origin.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import os
+import re
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+_REGEX_PREFIX = "regex:"
+
+DEFAULT_AGENTKIT_ALLOW_ORIGINS = ["*"]
+
+STRICT_AGENTKIT_HOSTED_ORIGINS = [
+    "https://console.volcengine.com",
+    "https://console.byteplus.com",
+    "regex:https://.*\\.volcengine\\.com",
+    "regex:https://.*\\.volceapi\\.com",
+    "regex:https://.*\\.byteplus\\.com",
+    "regex:https://.*\\.byteplusapi\\.com",
+]
+
+
+def resolve_agentkit_allow_origins(
+    *,
+    allow_origins: list[str] | None,
+    allow_origin_regex: str | list[str] | None = None,
+) -> list[str]:
+    """Resolve AgentKit CORS origins with SDK defaults and env overrides."""
+
+    env_origins = _get_env_list("AGENTKIT_ALLOW_ORIGINS", "ADK_ALLOW_ORIGINS")
+    env_regexes = _get_env_list(
+        "AGENTKIT_ALLOW_ORIGIN_REGEX",
+        "ADK_ALLOW_ORIGIN_REGEX",
+    )
+    if allow_origins is not None:
+        origins = list(allow_origins)
+    elif env_origins is not None or env_regexes is not None:
+        origins = env_origins or []
+    elif _truthy_env("AGENTKIT_DISABLE_DEFAULT_ALLOW_ORIGINS"):
+        origins = []
+    else:
+        origins = list(DEFAULT_AGENTKIT_ALLOW_ORIGINS)
+
+    if allow_origin_regex is None:
+        regexes = env_regexes or []
+    else:
+        regexes = _as_list(allow_origin_regex)
+
+    resolved = [_normalize_origin(origin) for origin in origins]
+    resolved.extend(_normalize_regex(pattern) for pattern in regexes)
+
+    deduped = _dedupe(resolved)
+    _validate_regex_origins(deduped)
+    return deduped
+
+
+def split_allow_origins(allow_origins: list[str]) -> tuple[list[str], str | None]:
+    """Split ADK-style origins into literal origins and a combined regex."""
+
+    literal_origins: list[str] = []
+    regex_patterns: list[str] = []
+    for origin in allow_origins:
+        if origin.startswith(_REGEX_PREFIX):
+            pattern = origin[len(_REGEX_PREFIX) :]
+            if pattern:
+                regex_patterns.append(pattern)
+        else:
+            literal_origins.append(origin)
+
+    return literal_origins, "|".join(regex_patterns) if regex_patterns else None
+
+
+def supports_get_fast_api_kwarg(func: Callable[..., Any], kwarg_name: str) -> bool:
+    """Return whether a callable accepts a given keyword argument."""
+
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True
+
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return kwarg_name in signature.parameters
+
+
+def adk_supports_regex_origins() -> bool:
+    """Return whether installed ADK understands `regex:` allow_origins entries."""
+
+    try:
+        from google.adk.cli import adk_web_server
+
+        return hasattr(adk_web_server, "_parse_cors_origins")
+    except Exception:
+        return False
+
+
+def add_cors_compat_middleware(app: FastAPI, allow_origins: list[str]) -> None:
+    """Add CORS middleware for ADK versions that cannot parse regex origins."""
+
+    literal_origins, allow_origin_regex = split_allow_origins(allow_origins)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=literal_origins,
+        allow_origin_regex=allow_origin_regex,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+def _normalize_origin(origin: str) -> str:
+    origin = origin.strip()
+    if not origin or origin == "*" or origin.startswith(_REGEX_PREFIX):
+        return origin
+    if "*" in origin:
+        return _normalize_regex(_glob_to_regex(origin))
+    return origin
+
+
+def _normalize_regex(pattern: str) -> str:
+    pattern = pattern.strip()
+    if not pattern:
+        return pattern
+    if pattern.startswith(_REGEX_PREFIX):
+        return pattern
+    return f"{_REGEX_PREFIX}{pattern}"
+
+
+def _glob_to_regex(origin: str) -> str:
+    return re.escape(origin).replace("\\*", ".*")
+
+
+def _validate_regex_origins(origins: list[str]) -> None:
+    for origin in origins:
+        if not origin.startswith(_REGEX_PREFIX):
+            continue
+        pattern = origin[len(_REGEX_PREFIX) :]
+        try:
+            re.compile(pattern)
+        except re.error as e:
+            raise ValueError(f"Invalid allow origin regex '{pattern}': {e}") from e
+
+
+def _get_env_list(*names: str) -> list[str] | None:
+    for name in names:
+        value = os.getenv(name)
+        if value is None:
+            continue
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return None
+
+
+def _truthy_env(name: str) -> bool:
+    value = os.getenv(name, "")
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _as_list(value: str | list[str] | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped

--- a/agentkit/version.py
+++ b/agentkit/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.5.9"
+VERSION = "0.5.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentkit-sdk-python"
-version = "0.5.9"
+version = "0.5.10"
 description = "Python SDK for transforming any AI agent into a production-ready application. Framework-agnostic primitives for runtime, memory, authentication, and tools with volcengine-managed infrastructure."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/apps/test_agent_server_origin.py
+++ b/tests/apps/test_agent_server_origin.py
@@ -140,8 +140,9 @@ def test_add_cors_compat_middleware_splits_literal_and_regex():
     )
 
     [middleware] = app.user_middleware
+    options = getattr(middleware, "options", None) or getattr(middleware, "kwargs", {})
     assert middleware.cls.__name__ == "CORSMiddleware"
-    assert middleware.kwargs["allow_origins"] == ["*"]
-    assert middleware.kwargs["allow_origin_regex"] == "https://.*\\.example\\.com"
-    assert middleware.kwargs["allow_methods"] == ["*"]
-    assert middleware.kwargs["allow_headers"] == ["*"]
+    assert options["allow_origins"] == ["*"]
+    assert options["allow_origin_regex"] == "https://.*\\.example\\.com"
+    assert options["allow_methods"] == ["*"]
+    assert options["allow_headers"] == ["*"]

--- a/tests/apps/test_agent_server_origin.py
+++ b/tests/apps/test_agent_server_origin.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastapi import FastAPI
+
+from agentkit.apps.agent_server_app.origin import (
+    DEFAULT_AGENTKIT_ALLOW_ORIGINS,
+    add_cors_compat_middleware,
+    resolve_agentkit_allow_origins,
+    split_allow_origins,
+    supports_get_fast_api_kwarg,
+)
+
+
+def test_resolve_allow_origins_defaults_to_wildcard(monkeypatch):
+    monkeypatch.delenv("AGENTKIT_ALLOW_ORIGINS", raising=False)
+    monkeypatch.delenv("ADK_ALLOW_ORIGINS", raising=False)
+    monkeypatch.delenv("AGENTKIT_DISABLE_DEFAULT_ALLOW_ORIGINS", raising=False)
+
+    assert (
+        resolve_agentkit_allow_origins(allow_origins=None)
+        == DEFAULT_AGENTKIT_ALLOW_ORIGINS
+        == ["*"]
+    )
+
+
+def test_resolve_allow_origins_can_disable_default(monkeypatch):
+    monkeypatch.delenv("AGENTKIT_ALLOW_ORIGINS", raising=False)
+    monkeypatch.delenv("ADK_ALLOW_ORIGINS", raising=False)
+    monkeypatch.setenv("AGENTKIT_DISABLE_DEFAULT_ALLOW_ORIGINS", "true")
+
+    assert resolve_agentkit_allow_origins(allow_origins=None) == []
+
+
+def test_resolve_allow_origins_explicit_empty_disables_default(monkeypatch):
+    monkeypatch.setenv("AGENTKIT_ALLOW_ORIGINS", "*")
+
+    assert resolve_agentkit_allow_origins(allow_origins=[]) == []
+
+
+def test_resolve_allow_origins_env_overrides_default(monkeypatch):
+    monkeypatch.setenv(
+        "AGENTKIT_ALLOW_ORIGINS",
+        "https://console.example.com, regex:https://.*\\.example\\.com",
+    )
+
+    assert resolve_agentkit_allow_origins(allow_origins=None) == [
+        "https://console.example.com",
+        "regex:https://.*\\.example\\.com",
+    ]
+
+
+def test_resolve_allow_origin_regex_env_overrides_default(monkeypatch):
+    monkeypatch.delenv("AGENTKIT_ALLOW_ORIGINS", raising=False)
+    monkeypatch.delenv("ADK_ALLOW_ORIGINS", raising=False)
+    monkeypatch.setenv("AGENTKIT_ALLOW_ORIGIN_REGEX", "https://.*\\.example\\.com")
+
+    assert resolve_agentkit_allow_origins(allow_origins=None) == [
+        "regex:https://.*\\.example\\.com",
+    ]
+
+
+def test_resolve_allow_origin_regex_adds_regex_prefix(monkeypatch):
+    monkeypatch.delenv("AGENTKIT_ALLOW_ORIGINS", raising=False)
+    monkeypatch.delenv("ADK_ALLOW_ORIGINS", raising=False)
+
+    assert resolve_agentkit_allow_origins(
+        allow_origins=["https://console.example.com"],
+        allow_origin_regex="https://.*\\.example\\.com",
+    ) == [
+        "https://console.example.com",
+        "regex:https://.*\\.example\\.com",
+    ]
+
+
+def test_resolve_allow_origins_converts_glob_to_regex():
+    assert resolve_agentkit_allow_origins(
+        allow_origins=["https://*.example.com"]
+    ) == ["regex:https://.*\\.example\\.com"]
+
+
+def test_resolve_allow_origins_rejects_invalid_regex():
+    with pytest.raises(ValueError, match="Invalid allow origin regex"):
+        resolve_agentkit_allow_origins(
+            allow_origins=[],
+            allow_origin_regex="https://[",
+        )
+
+
+def test_split_allow_origins():
+    literals, regex = split_allow_origins(
+        [
+            "*",
+            "https://console.example.com",
+            "regex:https://.*\\.example\\.com",
+            "regex:https://.*\\.example.org",
+        ]
+    )
+
+    assert literals == ["*", "https://console.example.com"]
+    assert regex == "https://.*\\.example\\.com|https://.*\\.example.org"
+
+
+def test_supports_get_fast_api_kwarg():
+    def without_allow_origins(lifespan=None):
+        del lifespan
+
+    def with_allow_origins(lifespan=None, allow_origins=None):
+        del lifespan, allow_origins
+
+    def with_kwargs(**kwargs):
+        del kwargs
+
+    assert not supports_get_fast_api_kwarg(without_allow_origins, "allow_origins")
+    assert supports_get_fast_api_kwarg(with_allow_origins, "allow_origins")
+    assert supports_get_fast_api_kwarg(with_kwargs, "allow_origins")
+
+
+def test_add_cors_compat_middleware_splits_literal_and_regex():
+    app = FastAPI()
+
+    add_cors_compat_middleware(
+        app,
+        [
+            "*",
+            "regex:https://.*\\.example\\.com",
+        ],
+    )
+
+    [middleware] = app.user_middleware
+    assert middleware.cls.__name__ == "CORSMiddleware"
+    assert middleware.kwargs["allow_origins"] == ["*"]
+    assert middleware.kwargs["allow_origin_regex"] == "https://.*\\.example\\.com"
+    assert middleware.kwargs["allow_methods"] == ["*"]
+    assert middleware.kwargs["allow_headers"] == ["*"]


### PR DESCRIPTION
## Summary
- Cherry-pick internal `0.5.10` commits `21ec738` and `ce07a86`
- Fix Agent Server CORS defaults and origin test middleware options
- Bump package version from `0.5.9` to `0.5.10`
- Add origin middleware tests

## Tests
- `uv run --with pytest --with pytest-mock pytest tests/apps/test_agent_server_origin.py` (`11 passed`)
