### PR TITLE
feat(harness): deploy --harness updates same-name runtime + keeps deploy creds off the runtime

### DIFF
--- a/agentkit/toolkit/cli/cli_deploy.py
+++ b/agentkit/toolkit/cli/cli_deploy.py
@@ -15,7 +15,7 @@
 """AgentKit CLI - Deploy command implementation."""
 
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Dict, Optional
 
 import typer
 from rich.console import Console
@@ -23,6 +23,17 @@ from rich.console import Console
 # Note: Avoid importing heavy packages at the top to keep CLI startup fast
 
 console = Console()
+
+
+def _prompt_harness_update(info: Dict) -> bool:
+    """Interactive [y/N] confirmation to update an existing same-name harness."""
+    version = info.get("version")
+    version_label = f"v{version}" if version is not None else "unknown"
+    return typer.confirm(
+        f"Harness '{info['name']}' already exists (current version "
+        f"{version_label}). Update it to a new version?",
+        default=False,
+    )
 
 
 def deploy_command(
@@ -52,6 +63,12 @@ def deploy_command(
         "--allowed-id",
         help="Comma-separated allowed client IDs for OAuth2/JWT auth (harness deploy).",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Harness deploy: update an existing same-name harness without prompting.",
+    ),
 ):
     """Deploy the Agent to target environment."""
     from agentkit.toolkit.executors import DeployExecutor
@@ -66,6 +83,7 @@ def deploy_command(
             secret_key=volcengine_secret_key,
             discovery_url=discovery_url,
             allowed_id=allowed_id,
+            assume_yes=yes,
         )
         return
 
@@ -107,9 +125,12 @@ def _deploy_harness(
     secret_key,
     discovery_url,
     allowed_id,
+    assume_yes: bool = False,
 ):
     """Deploy a harness spec <name>.harness.json from the current directory."""
-    from agentkit.toolkit.sdk import deploy_harness
+    import sys
+
+    from agentkit.toolkit.sdk import deploy_harness, HarnessDeployAborted
     from agentkit.toolkit.cli.console_reporter import ConsoleReporter
     from agentkit.toolkit.context import ExecutionContext
 
@@ -117,6 +138,16 @@ def _deploy_harness(
 
     reporter = ConsoleReporter()
     ExecutionContext.set_reporter(reporter)
+
+    # Decide how a same-name harness collision is resolved:
+    #   --yes        -> update without prompting
+    #   tty          -> prompt [y/N]
+    #   non-tty      -> on_conflict=None, so deploy_harness fast-fails
+    on_conflict: Optional[Callable[[Dict], bool]] = None
+    if assume_yes:
+        on_conflict = lambda info: True  # noqa: E731
+    elif sys.stdin.isatty():
+        on_conflict = _prompt_harness_update
 
     # Surface fast-fail input/validation errors (missing spec, missing creds,
     # name collision) as a clean CLI error + exit code, not a raw traceback.
@@ -129,7 +160,11 @@ def _deploy_harness(
             discovery_url=discovery_url,
             allowed_id=allowed_id,
             reporter=reporter,
+            on_conflict=on_conflict,
         )
+    except HarnessDeployAborted:
+        console.print("[yellow]Harness deploy cancelled.[/yellow]")
+        return
     except (ValueError, FileNotFoundError, NotADirectoryError) as exc:
         console.print(f"[red]❌ Harness deploy failed: {exc}[/red]")
         raise typer.Exit(1)

--- a/agentkit/toolkit/config/utils.py
+++ b/agentkit/toolkit/config/utils.py
@@ -82,12 +82,25 @@ def load_veadk_yaml_file(project_dir: Path) -> Dict[str, str]:
         return {}
 
 
+# Opt-in denylist of env keys to drop from the veADK-compat (.env / config.yaml)
+# layer before it is merged into a runtime's uploaded environment. Empty by
+# default (no-op). A deploy flow may populate it (scoped, restored afterwards) to
+# keep deploy-only secrets in a local `.env` from leaking into the cloud runtime;
+# e.g. harness deploy excludes the Volcengine deploy credentials here. Compared
+# case-insensitively. Higher-priority sources (agentkit.yaml runtime_envs) are
+# unaffected, so a value explicitly set there still reaches the runtime.
+COMPAT_ENV_EXCLUDE: set = set()
+
+
 def load_compat_config_files(project_dir: Optional[Path] = None) -> Dict[str, str]:
     """Load compatibility configuration files (.env and veADK config.yaml).
 
     This function loads external configuration files for veADK compatibility:
     1. Load standard .env file if exists (higher priority)
     2. Load veADK config.yaml file if exists and flatten nested structure (lower priority)
+
+    Keys listed in :data:`COMPAT_ENV_EXCLUDE` are dropped from the result (used to
+    keep deploy-only credentials out of the uploaded runtime environment).
 
     Args:
         project_dir: Project directory to search for files. If None, uses current working directory.
@@ -101,6 +114,10 @@ def load_compat_config_files(project_dir: Optional[Path] = None) -> Dict[str, st
     veadk_envs = {}
     veadk_envs.update(load_veadk_yaml_file(project_dir))
     veadk_envs.update(load_dotenv_file(project_dir))
+
+    if COMPAT_ENV_EXCLUDE:
+        excluded = {k.upper() for k in COMPAT_ENV_EXCLUDE}
+        veadk_envs = {k: v for k, v in veadk_envs.items() if k.upper() not in excluded}
 
     return veadk_envs
 

--- a/agentkit/toolkit/harness/__init__.py
+++ b/agentkit/toolkit/harness/__init__.py
@@ -15,7 +15,7 @@
 """Harness deploy support: flatten a layered harness spec and deploy it as a runtime."""
 
 from .config_builder import build_agentkit_config
-from .deploy import deploy_harness, load_harness_registry
+from .deploy import HarnessDeployAborted, deploy_harness, load_harness_registry
 from .env_mapping import to_runtime_env
 
 __all__ = [
@@ -23,4 +23,5 @@ __all__ = [
     "build_agentkit_config",
     "deploy_harness",
     "load_harness_registry",
+    "HarnessDeployAborted",
 ]

--- a/agentkit/toolkit/harness/config_builder.py
+++ b/agentkit/toolkit/harness/config_builder.py
@@ -22,12 +22,18 @@ def build_agentkit_config(
     region: str,
     envs: Dict[str, str],
     auth: Optional[Dict[str, Any]] = None,
+    runtime_id: str = "Auto",
 ) -> Dict[str, Any]:
     """Build the cloud AgentKit launch config dict (auto-provision).
 
     Mirrors the structure ``agentkit init`` produces for ``launch_type: cloud``.
     The ``{{account_id}}`` / ``{{timestamp}}`` templates are resolved by AgentKit
     at deploy time and are passed through literally.
+
+    ``runtime_id`` defaults to ``"Auto"`` (create a new runtime). Passing an
+    existing runtime id makes the deploy update that runtime in place (the runner
+    routes a real id to ``UpdateRuntime``, which the platform releases as a new
+    version).
 
     When ``auth`` (a normalized ``{discovery_url, allowed_ids}`` block) is given,
     the runtime is gated by OAuth2/JWT (``custom_jwt``); otherwise it keeps the
@@ -45,7 +51,7 @@ def build_agentkit_config(
         "build_timeout": 3600,
         "cp_workspace_name": "agentkit-cli-workspace",
         "cp_pipeline_name": "Auto",
-        "runtime_id": "Auto",
+        "runtime_id": runtime_id,
         "runtime_name": runtime_name,
         "runtime_role_name": "Auto",
     }

--- a/agentkit/toolkit/harness/deploy.py
+++ b/agentkit/toolkit/harness/deploy.py
@@ -24,7 +24,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from ..models import LifecycleResult
 from ..reporter import Reporter
@@ -42,6 +42,25 @@ _DEFAULT_HARNESS_NAME = "default"
 # harness` uses this exact key/value to recognize harness runtimes.
 HARNESS_TAG_KEY = "agentkit:agenttype"
 HARNESS_TAG_VALUE = "harness"
+
+# Volcengine deploy credentials: needed locally to authenticate the build/deploy,
+# but must never be uploaded into the cloud runtime's environment (the runtime
+# gets its Volcengine access from its IAM role). A harness's own `.env` carries
+# these for deploy; they are excluded from the runtime env upload (see
+# COMPAT_ENV_EXCLUDE). Credentials a harness genuinely needs at runtime come from
+# its spec instead, so they are not affected.
+_DEPLOY_CREDENTIAL_ENV_KEYS = {
+    "VOLCENGINE_ACCESS_KEY",
+    "VOLCENGINE_SECRET_KEY",
+    "VOLCENGINE_SESSION_TOKEN",
+    "VOLC_ACCESSKEY",
+    "VOLC_SECRETKEY",
+    "VOLC_SESSIONTOKEN",
+}
+
+
+class HarnessDeployAborted(Exception):
+    """Raised when the user declines to update an existing same-name harness."""
 
 
 def _resolve_auth(
@@ -122,16 +141,16 @@ def _record_harness(
     return path
 
 
-def _existing_runtime_ids(client, name: str) -> list:
-    """Return the ids of every runtime whose name equals ``name`` (all pages).
+def _find_runtimes_by_name(client, name: str) -> list:
+    """Return ``[{runtime_id, is_harness}]`` for every runtime named ``name``.
 
-    Used to fast-fail before a harness deploy: the harness config always sets
-    ``runtime_id: Auto`` (always create-new), so without this check re-deploying
-    would pile up duplicate same-name runtimes.
+    Scans all pages. ``is_harness`` is derived from the deploy-time harness tag on
+    the list item (no extra get_runtime call). Used to decide between create,
+    update, and fast-fail before a harness deploy.
     """
     from agentkit.sdk.runtime import types as rt_types
 
-    ids = []
+    matches = []
     next_token = None
     while True:
         resp = client.list_runtimes(
@@ -139,11 +158,25 @@ def _existing_runtime_ids(client, name: str) -> list:
         )
         for runtime in resp.agent_kit_runtimes or []:
             if runtime.name == name:
-                ids.append(runtime.runtime_id or "")
+                is_harness = any(
+                    tag.key == HARNESS_TAG_KEY and tag.value == HARNESS_TAG_VALUE
+                    for tag in (runtime.tags or [])
+                )
+                matches.append(
+                    {"runtime_id": runtime.runtime_id or "", "is_harness": is_harness}
+                )
         next_token = resp.next_token
         if not next_token:
             break
-    return ids
+    return matches
+
+
+def _get_runtime_version(client, runtime_id: str) -> Optional[int]:
+    """Return a runtime's current version number (None if unavailable)."""
+    from agentkit.sdk.runtime import types as rt_types
+
+    runtime = client.get_runtime(rt_types.GetRuntimeRequest(runtime_id=runtime_id))
+    return runtime.current_version_number
 
 
 def _load_harness_spec(path: Path) -> Dict[str, Any]:
@@ -166,6 +199,7 @@ def deploy_harness(
     discovery_url: Optional[str] = None,
     allowed_id: Optional[str] = None,
     reporter: Optional[Reporter] = None,
+    on_conflict: Optional[Callable[[Dict[str, Any]], bool]] = None,
 ) -> LifecycleResult:
     """Deploy a harness spec as an AgentKit runtime (cloud build, no local Docker).
 
@@ -174,6 +208,20 @@ def deploy_harness(
     directory must also contain the harness server ``Dockerfile``. On success the
     runtime is recorded in ``<path>/harness.json`` (keyed by ``name``).
 
+    Name-collision handling (a same-name runtime already exists):
+
+    * not a harness runtime, or more than one match -> fast-fail (``ValueError``);
+    * a single harness runtime -> if ``on_conflict`` is given, it is called with
+      ``{name, runtime_id, version}`` and must return ``True`` to update that
+      runtime in place (the platform releases a new version) or ``False`` to abort
+      (``HarnessDeployAborted``); if ``on_conflict`` is ``None`` (e.g. a
+      programmatic caller or a non-interactive CLI), it fast-fails.
+
+    Credentials note: a local ``.env`` is loaded for deploy auth, but the
+    Volcengine deploy credentials in it are NOT uploaded into the runtime
+    environment (the runtime authenticates via its IAM role); other ``.env`` keys
+    are still merged in.
+
     Args:
         name: Harness name; locates ``<name>.harness.json`` and names the runtime.
         path: Directory containing the spec and Dockerfile (default: cwd).
@@ -181,18 +229,22 @@ def deploy_harness(
         access_key / secret_key: Volcengine credentials (default: ``VOLCENGINE_*`` env).
         discovery_url / allowed_id: OAuth2/JWT overrides for the spec ``auth`` block.
         reporter: Progress reporter forwarded to the launch (default: silent).
+        on_conflict: Callback consulted when a single same-name harness exists;
+            returns True to update it, False to abort.
 
     Returns:
         LifecycleResult: the build+deploy result from ``sdk.launch``.
 
     Raises:
         NotADirectoryError / FileNotFoundError / ValueError: on invalid inputs
-        (fast-fail). Deployment failures are returned in ``LifecycleResult.error``.
+        (fast-fail). HarnessDeployAborted when the user declines an update.
+        Deployment failures are returned in ``LifecycleResult.error``.
     """
     # Heavy imports are lazy: this module is imported by `agentkit.toolkit.sdk`
     # at package init, and these pull in the runtime client / executors.
     from agentkit.toolkit.sdk.lifecycle import launch
     from agentkit.toolkit.models import PreflightMode
+    from agentkit.toolkit.config import utils as cfg_utils
     from agentkit.toolkit.config.utils import load_dotenv_file
     from agentkit.sdk.runtime import types as rt_types
     from agentkit.sdk.runtime.client import AgentkitRuntimeClient
@@ -227,20 +279,56 @@ def deploy_harness(
 
     resolved_region = region or os.getenv("VOLCENGINE_REGION") or "cn-beijing"
 
-    # Fast-fail on a name collision: the harness config sets `runtime_id: Auto`
-    # (always create-new), so deploying over an existing same-name runtime would
-    # silently create a duplicate. Refuse and let the user delete/rename first.
-    existing_ids = _existing_runtime_ids(
-        AgentkitRuntimeClient(region=resolved_region), runtime_name
-    )
-    if existing_ids:
+    # Resolve a name collision into a deploy mode. The harness config defaults to
+    # `runtime_id: Auto` (create new); an existing same-name harness can instead
+    # be updated in place (new version) after confirmation.
+    client = AgentkitRuntimeClient(region=resolved_region)
+    matches = _find_runtimes_by_name(client, runtime_name)
+    update_runtime_id = None
+    if len(matches) > 1:
+        ids = ", ".join(m["runtime_id"] for m in matches if m["runtime_id"])
         raise ValueError(
-            f"A runtime named '{runtime_name}' already exists "
-            f"(runtime_id: {', '.join(i for i in existing_ids if i)}). "
-            "Delete it or use a different harness name before deploying."
+            f"Multiple runtimes named '{runtime_name}' already exist "
+            f"(runtime_id: {ids}). Clean them up or use a different name."
         )
+    if matches:
+        match = matches[0]
+        if not match["is_harness"]:
+            raise ValueError(
+                f"'{runtime_name}' already exists but is not a harness application "
+                f"(missing {HARNESS_TAG_KEY}={HARNESS_TAG_VALUE} tag). "
+                "Refusing to update it."
+            )
+        existing_id = match["runtime_id"]
+        version = _get_runtime_version(client, existing_id)
+        version_label = f"v{version}" if version is not None else "unknown"
+        if reporter:
+            reporter.info(
+                f"Harness '{runtime_name}' already exists "
+                f"(runtime_id: {existing_id}, current version {version_label})."
+            )
+        if on_conflict is None:
+            raise ValueError(
+                f"A runtime named '{runtime_name}' already exists "
+                f"(runtime_id: {existing_id}, current version {version_label}). "
+                "Re-run interactively to update it, pass --yes, or use a "
+                "different name."
+            )
+        if not on_conflict(
+            {"name": runtime_name, "runtime_id": existing_id, "version": version}
+        ):
+            raise HarnessDeployAborted(
+                f"Update of harness '{runtime_name}' was declined."
+            )
+        update_runtime_id = existing_id
 
-    cfg = build_agentkit_config(runtime_name, resolved_region, runtime_envs, auth)
+    cfg = build_agentkit_config(
+        runtime_name,
+        resolved_region,
+        runtime_envs,
+        auth,
+        runtime_id=update_runtime_id or "Auto",
+    )
 
     # AgentKit's launch path exposes no hook for runtime tags, so tag the runtime
     # at creation by wrapping the SDK's create_runtime: every harness runtime is
@@ -256,10 +344,16 @@ def deploy_harness(
         ]
         return orig_create_runtime(self, request)
 
-    logger.info("Deploying harness runtime '%s' from %s", runtime_name, proj_dir)
+    action = "Updating" if update_runtime_id else "Deploying"
+    logger.info("%s harness runtime '%s' from %s", action, runtime_name, proj_dir)
     cwd = os.getcwd()
     os.chdir(proj_dir)
     AgentkitRuntimeClient.create_runtime = _create_runtime_with_harness_tag
+    # Keep deploy-only Volcengine credentials in the local .env out of the
+    # uploaded runtime environment (the compat layer auto-loads .env). Scoped to
+    # this launch and restored afterwards.
+    prev_exclude = cfg_utils.COMPAT_ENV_EXCLUDE
+    cfg_utils.COMPAT_ENV_EXCLUDE = set(prev_exclude) | _DEPLOY_CREDENTIAL_ENV_KEYS
     try:
         result = launch(
             config_dict=cfg,
@@ -268,6 +362,7 @@ def deploy_harness(
         )
     finally:
         AgentkitRuntimeClient.create_runtime = orig_create_runtime
+        cfg_utils.COMPAT_ENV_EXCLUDE = prev_exclude
         os.chdir(cwd)
 
     if not result.success:
@@ -280,7 +375,15 @@ def deploy_harness(
     meta = deploy_result.metadata if (deploy_result and deploy_result.metadata) else {}
     endpoint = deploy_result.endpoint_url if deploy_result else None
     apikey = meta.get("runtime_apikey")
-    runtime_id = meta.get("runtime_id")
+    runtime_id = meta.get("runtime_id") or update_runtime_id
+
+    # Echo the new version after an in-place update (the platform bumps it).
+    if update_runtime_id and reporter:
+        new_version = _get_runtime_version(client, update_runtime_id)
+        if new_version is not None:
+            reporter.success(
+                f"Harness '{runtime_name}' updated to version v{new_version}."
+            )
 
     if endpoint:
         _record_harness(

--- a/agentkit/toolkit/sdk/__init__.py
+++ b/agentkit/toolkit/sdk/__init__.py
@@ -50,7 +50,7 @@ from .invoker import invoke
 from .lifecycle import launch, destroy
 from .status import status
 from .initializer import init_project, get_available_templates
-from ..harness import deploy_harness
+from ..harness import deploy_harness, HarnessDeployAborted
 
 # Import client, config and helpers
 from .client import AgentKitClient
@@ -78,6 +78,7 @@ __all__ = [
     "init_project",
     "get_available_templates",
     "deploy_harness",
+    "HarnessDeployAborted",
     # Client and Config
     "AgentKitClient",
     "AgentConfig",


### PR DESCRIPTION
## What

Builds on the existing `agentkit deploy --harness` flow with two behaviors:

### 1. Same-name runtime → update in place (new version)
Previously `deploy --harness <name>` fast-failed if a runtime with that name existed (the harness config uses `runtime_id: Auto` = always create). Now it resolves the collision:

- **single existing harness runtime** → prompt `[y/N]` (or `--yes`/`-y` for non-interactive) to update it in place; the runner routes a real `runtime_id` to `UpdateRuntime`/`ReleaseRuntime`, so the platform releases a **new version**. The current version is echoed before, and the new version after.
- **non-harness same-name runtime** → fast-fail (refuse to touch a non-harness app).
- **multiple same-name** → fast-fail.
- **non-interactive (no tty) without `--yes`** → fast-fail.

`build_agentkit_config` gains a `runtime_id` arg (`Auto` = create, real id = update).

### 2. Deploy credentials never uploaded to the runtime
A local `.env` is still loaded for deploy auth, but the Volcengine deploy credentials in it (`VOLCENGINE_ACCESS_KEY`/`SECRET_KEY`, `VOLC_*`) are no longer merged into the **runtime** environment — the runtime authenticates via its IAM role. Implemented via an opt-in `COMPAT_ENV_EXCLUDE` applied only to the veADK-compat env layer; other `.env` keys and spec-provided credentials (higher priority) are unaffected.

## Verified
- Live: deployed `sixth` then re-ran `deploy --harness sixth --yes` → same `runtime_id`, version v1→v2; runtime envs confirmed to contain no AK/SK.
- Stubbed all branches: create / update / non-harness reject / multiple reject / decline-abort / non-interactive fast-fail.
- ruff clean.

## Docs
`HARNESS_QUICKSTART.md` updated (`--yes`, same-name update, credential note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)