### PR TITLE
docs(cli): add Harness section under AgentKit CLI

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -41,6 +41,7 @@ export default {
           items: [
             { text: 'CLI 概览', link: '/content/2.agentkit-cli/1.overview' },
             { text: '命令详解', link: '/content/2.agentkit-cli/2.commands' },
+            { text: 'Harness', link: '/content/2.agentkit-cli/5.harness' },
             { text: '配置文件说明', link: '/content/2.agentkit-cli/3.configurations' },
             { text: 'Logging', link: '/content/2.agentkit-cli/4.logging' },
           ],

--- a/docs/content/2.agentkit-cli/5.harness.md
+++ b/docs/content/2.agentkit-cli/5.harness.md
@@ -1,0 +1,267 @@
+---
+title: Harness
+---
+
+# Harness <Badge type="warning" text="Beta" />
+
+Harness 是 AgentKit 提供的「动态装配、调用时按需覆写」的 Agent 工作流。一个 Harness 在创建时声明一套默认装配（模型、系统提示词、工具、技能、运行时、知识库与记忆等），部署为云端运行时后即可按名调用；在单次调用时还能临时覆写部分参数，**不改变已部署的默认配置**，便于在一次部署内对比 N 种模型 / 提示词 / 工具 / 技能组合。
+
+完整生命周期由以下命令串起：
+
+```plaintext
+agentkit init <name> --template harness     # 1. 生成 harness 项目骨架
+agentkit add harness --name <name> ...      # 2. 生成 / 更新 <name>.harness.json 配置
+agentkit deploy --harness <name> ...        # 3. 云端构建 + 部署为运行时，回写 harness.json 注册表
+agentkit invoke harness <name> "<prompt>"   # 4. 按名调用（支持一次性覆写、流式）
+agentkit list harness                       # 5. 列出已部署的 harness 运行时
+```
+
+部署出的运行时同时对外暴露三类接口：
+
+- `POST /harness/invoke` —— Harness 专属入口，支持一次性覆写；
+- ADK Web/API 路由（`/run_sse`、`/list-apps`、会话管理等）；
+- A2A 协议路由（`/.well-known/agent-card.json` 及 JSON-RPC）。
+
+---
+
+## 1. init —— 生成 Harness 项目骨架
+
+`agentkit init <name> --template harness` 在 `--directory`（默认当前目录）下创建一个 Harness 项目目录，内含部署所需的 `.env.example` 与 `Dockerfile`（镜像从 VeADK 主分支构建 `veadk.cloud.harness_app`，自带上述三类路由及 `codex` 运行时依赖）。
+
+| 参数 | 说明 | 默认值 |
+| :--- | :--- | :--- |
+| `<name>` | 项目 / Harness 名称，决定目录名。仅允许字母、数字、`_`、`-`。 | 必填 |
+| `--template`, `-t` | 模板类型，Harness 场景固定为 `harness`。 | — |
+| `--directory` | 创建项目的目标目录。 | 当前目录 |
+
+```bash
+agentkit init my-harness --template harness
+cd my-harness
+cp .env.example .env          # 填入火山引擎 AK/SK
+```
+
+生成的目录结构：
+
+```plaintext
+my-harness/
+├── .env.example   # 复制为 .env，填入 VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY
+└── Dockerfile     # 云端构建 veadk.cloud.harness_app 服务
+```
+
+---
+
+## 2. add harness —— 生成 / 更新 Harness 配置
+
+`agentkit add harness --name <name> [options]` 在 `--directory` 下写入 `<name>.harness.json`，声明 Harness 的默认装配。对同一 `--name` **重复执行会增量合并**到现有文件，便于逐步完善配置。每个选项只在显式传入时写入；`--tools` / `--skills` / `--allowed-id` 接受逗号分隔列表。
+
+### 2.1 核心与组件参数
+
+| 参数 | 说明 | 取值 |
+| :--- | :--- | :--- |
+| `--name` | **（必填）** Harness 名称，决定输出文件 `<name>.harness.json`。 | 字母 / 数字 / `_` / `-` |
+| `--model-name` | 推理模型名。 | 如 `doubao-seed-1-6-250615` |
+| `--system-prompt` | 系统提示词 / instruction。 | 任意字符串 |
+| `--tools` | 内置工具名，逗号分隔。 | 如 `web_search,web_fetch` |
+| `--skills` | 技能 Hub 名，逗号分隔。 | 如 `data-visualization-cloud` |
+| `--runtime` | Agent 运行时后端。 | `adk`（默认）/ `codex` |
+| `--knowledgebase-type` | 知识库后端。 | `viking` / `opensearch` / `redis` / `tos_vector` / `context_search` |
+| `--long-term-memory-type` | 长期记忆后端。 | `viking` / `opensearch` / `redis` / `mem0` |
+| `--short-term-memory-type` | 短期记忆后端。 | `local`（默认）/ `sqlite` / `mysql` / `postgresql` |
+| `--discovery-url` | OIDC discovery URL，启用 OAuth2/JWT 鉴权。 | 见「6. 鉴权」 |
+| `--allowed-id` | 允许的客户端 ID，逗号分隔。 | 见「6. 鉴权」 |
+| `--directory` | 写入 `<name>.harness.json` 的目录。 | 当前目录 |
+
+> 内置工具名以 VeADK `veadk/tools/__init__.py` 的 `_BUILTIN_TOOLS` 为准（如 `web_search`、`web_fetch`、`run_code`、`link_reader` 等）；技能名为技能 Hub 的下载路径，可带命名空间（如 `clawhub/<org>/<skill>`）。
+
+### 2.2 组件连接参数
+
+各组件除 `type` 外，还可传入其连接参数；这些参数会被写入对应组件块，部署时映射为运行时环境变量（详见「5. memory / knowledgebase」）。
+
+| 组件 | 连接参数（旗标前缀） |
+| :--- | :--- |
+| 知识库 | `--knowledgebase-project` / `-region` / `-host` / `-port` / `-username` / `-password` / `-use-ssl` / `-cert-path` / `-secret-token` / `-db` |
+| 长期记忆 | `--long-term-memory-project` / `-region` / `-host` / `-port` / `-username` / `-password` / `-db` / `-api-key` / `-api-key-id` / `-project-id` / `-base-url` |
+| 短期记忆 | `--short-term-memory-host` / `-port` / `-user` / `-password` / `-database` / `-charset` |
+
+### 2.3 例子
+
+```bash
+# 最小：模型 + 工具 + 系统提示词
+agentkit add harness --name my-harness \
+  --model-name doubao-seed-1-6-250615 \
+  --tools web_search,web_fetch \
+  --system-prompt "You are a helpful assistant."
+
+# 增量补充技能与运行时（合并进同名文件）
+agentkit add harness --name my-harness --skills data-visualization-cloud --runtime adk
+
+# 配置知识库（Viking）+ 长期记忆（mem0）+ 短期记忆（PostgreSQL）
+agentkit add harness --name my-harness \
+  --knowledgebase-type viking --knowledgebase-project my-proj --knowledgebase-region cn-beijing \
+  --long-term-memory-type mem0 --long-term-memory-api-key "$MEM0_API_KEY" \
+  --long-term-memory-project-id "$MEM0_PROJECT_ID" \
+  --short-term-memory-type postgresql --short-term-memory-host pg.example.com \
+  --short-term-memory-user agent --short-term-memory-password "$PG_PASSWORD" \
+  --short-term-memory-database harness
+```
+
+执行后 `my-harness.harness.json` 形如：
+
+```json
+{
+  "harness_name": "my-harness",
+  "runtime": "adk",
+  "short_term_memory": { "type": "local" },
+  "model": { "name": "doubao-seed-1-6-250615" },
+  "system_prompt": "You are a helpful assistant.",
+  "tools": ["web_search", "web_fetch"]
+}
+```
+
+---
+
+## 3. deploy —— 部署为云端运行时
+
+`agentkit deploy --harness <name> [options]` 读取当前目录的 `<name>.harness.json`，将其展平为运行时环境变量，执行**云端构建 + 部署**（无需本地 Docker），并为运行时打上 `agentkit:agenttype=harness` 标签。成功后把运行时坐标回写到同目录的 `harness.json` **注册表**，供按名调用。
+
+| 参数 | 说明 | 默认值 |
+| :--- | :--- | :--- |
+| `--harness` | **（必填）** 要部署的 Harness 名称，对应 `<name>.harness.json`。 | — |
+| `--region` | AgentKit 区域。 | `cn-beijing` 或 `VOLCENGINE_REGION` |
+| `--volcengine-access-key` | 火山引擎 Access Key。 | 环境变量 `VOLCENGINE_ACCESS_KEY` |
+| `--volcengine-secret-key` | 火山引擎 Secret Key。 | 环境变量 `VOLCENGINE_SECRET_KEY` |
+| `--discovery-url` | OIDC discovery URL；设置后运行时改用 `custom_jwt` 网关鉴权。 | 见「6. 鉴权」 |
+| `--allowed-id` | 允许的客户端 ID，逗号分隔（custom_jwt）。 | 见「6. 鉴权」 |
+| `--yes`, `-y` | 同名运行时已存在时直接更新为新版本，不交互询问。 | `false` |
+
+凭证安全：`.env` 中的火山 AK/SK 仅用于本地发起部署，不会写入镜像或运行时明文。
+
+`harness.json` 注册表条目（按鉴权类型）：
+
+```json
+{
+  "my-harness": { "url": "https://xxx.apigateway-cn-beijing.volceapi.com", "key": "...", "runtime_id": "r-xxx" }
+}
+```
+
+custom_jwt 部署的条目不含 `key`，而记录 `auth_type` / `discovery_url` / `allowed_ids`（JWT 由调用方每次请求携带）。
+
+```bash
+# 在 harness 目录下执行
+agentkit deploy --harness my-harness
+
+# 指定区域；同名已存在时直接更新
+agentkit deploy --harness my-harness --region cn-beijing --yes
+```
+
+---
+
+## 4. invoke harness —— 按名调用
+
+`agentkit invoke harness <name> "<prompt>" [options]` 在 `--directory`（默认当前目录）下的 `harness.json` 注册表中按名查找运行时并发起调用。通过 `--protocol` 选择传输方式：
+
+- `invoke`（默认）：`POST /harness/invoke`，**非流式**，返回完整结果（含错误透传）。
+- `run_sse`：调用 ADK 的 `/run_sse`，**流式**返回。其 `app_name` 固定为 `harness`，`user_id` 由 CLI 随机生成（临时占位），`session_id` 取 `--session-id`。
+
+两种方式都支持一次性覆写（`--system-prompt` / `--model-name` / `--tools` / `--skills` / `--runtime`）；覆写为**叠加在本次调用上的临时值**，不写回 spec、不改动运行时（工具 / 技能为增量加入）。
+
+| 参数 | 说明 | 默认值 / 取值 |
+| :--- | :--- | :--- |
+| `<name>` | **（必填）** 已部署的 Harness 名称（注册表键）。 | — |
+| `<message>` | **（必填）** 发送给 Harness 的提示词。 | — |
+| `--protocol` | 传输方式。 | `invoke`（默认）/ `run_sse` |
+| `--directory` | `harness.json` 注册表所在目录。 | 当前目录 |
+| `--user-id` | 运行的 user_id（仅 `invoke`；`run_sse` 由 CLI 随机生成）。 | `agentkit_user` |
+| `--session-id` | 运行的 session_id。 | `agentkit_sample_session` |
+| `--max-llm-calls` | 本次调用的最大 LLM 调用次数（**仅 `invoke`**）。 | 不限 |
+| `--system-prompt` | 覆写系统提示词。 | — |
+| `--model-name` | 覆写模型名。 | — |
+| `--tools` | 覆写工具（逗号分隔，增量加入）。 | — |
+| `--skills` | 覆写技能（逗号分隔，增量加入）。 | — |
+| `--runtime` | 覆写运行时后端。 | `adk` / `codex` |
+| `--apikey`, `-ak` | Bearer Token 覆写（如 custom_jwt 的用户 JWT）。 | 注册表 `key` |
+| `--raw` | 打印原始响应（`InvokeHarnessResponse` / SSE）。 | `false` |
+
+> `--max-llm-calls` 不属于 ADK `run_sse` 请求，故仅在 `invoke` 模式生效；在 `run_sse` 模式传入会被忽略并提示。
+
+```bash
+# 基础调用（invoke，默认）
+agentkit invoke harness my-harness "今天杭州天气如何？"
+
+# 一次性覆写系统提示词（invoke）
+agentkit invoke harness my-harness "2+2=?" --system-prompt "请简洁作答。"
+
+# 限制本次最大 LLM 调用次数（仅 invoke）
+agentkit invoke harness my-harness "规划一次多步研究任务。" --max-llm-calls 10
+
+# 流式调用（run_sse），并覆写模型与工具
+agentkit invoke harness my-harness "帮我查一下杭州天气" \
+  --protocol run_sse --model-name doubao-seed-1-6-250615 --tools web_search,web_fetch \
+  --session-id sess-001
+
+# OAuth（custom_jwt）的 Harness：携带用户池签发的 JWT
+agentkit invoke harness my-harness "你好" -ak "<user-oauth-jwt>"
+```
+
+错误透传：当 Harness 返回失败（工具不支持 / 技能加载失败 / 运行期错误等）时，CLI 以红色高亮原样回显错误信息并以非 0 退出。
+
+---
+
+## 5. memory / knowledgebase 配置
+
+知识库与记忆在 `add harness` 时声明、`deploy` 时绑定到**基础 Agent**。部署时各组件的 `type` 映射为选择器环境变量，连接参数映射为 VeADK 的 `DATABASE_*` 环境变量，火山凭证复用 `.env` 的 `VOLCENGINE_*`。
+
+| 组件 | 选择器 env | 支持后端 | 连接参数 env 前缀 |
+| :--- | :--- | :--- | :--- |
+| 知识库 | `KNOWLEDGEBASE_TYPE` | `viking` / `opensearch` / `redis` / `tos_vector` / `context_search` | `DATABASE_VIKING_*` / `DATABASE_OPENSEARCH_*` / `DATABASE_REDIS_*` |
+| 长期记忆 | `LONG_TERM_MEMORY_TYPE` | `viking` / `opensearch` / `redis` / `mem0` | 同上 + `DATABASE_MEM0_*` |
+| 短期记忆 | `SHORT_TERM_MEMORY_TYPE` | `local` / `sqlite` / `mysql` / `postgresql` | `DATABASE_MYSQL_*` / `DATABASE_POSTGRESQL_*`（`local`/`sqlite` 无需参数） |
+
+```bash
+# 只挂知识库（Viking）
+agentkit add harness --name my-harness \
+  --knowledgebase-type viking --knowledgebase-project my-proj --knowledgebase-region cn-beijing
+```
+
+> memory / knowledgebase 是**部署时**绑定的：`invoke` / `run_sse` 的一次性覆写**不包含** memory / knowledgebase——调用时用的始终是部署时配置的那套；要更改需修改 spec 后重新部署。
+
+---
+
+## 6. 鉴权
+
+部署后默认采用 **API Key（`key_auth`）** 鉴权：注册表记录 `key`，调用时 CLI 自动以 `Authorization: Bearer <key>` 发送。
+
+若希望用火山引擎**用户池**签发的 JWT 进行网关鉴权（**`custom_jwt`**），在 `add harness` 或 `deploy` 时提供 `--discovery-url` 与 `--allowed-id`：
+
+| 参数 | 说明 |
+| :--- | :--- |
+| `--discovery-url` | 用户池 OIDC discovery 地址，如 `https://userpool-<id>.userpool.auth.id.cn-beijing.volces.com/.well-known/openid-configuration` |
+| `--allowed-id` | 允许访问该运行时的客户端 ID（JWT audience），逗号分隔 |
+
+二者必须同时提供，否则部署时快速失败。采用 custom_jwt 后，注册表条目不含 `key`，调用时需通过 `-ak <jwt>`（或 `--headers '{"Authorization":"Bearer <jwt>"}'`）携带用户池签发的 JWT（CLI 不负责签发）。
+
+```bash
+# 部署为 OAuth2/JWT 鉴权
+agentkit deploy --harness my-harness \
+  --discovery-url "https://userpool-<id>.userpool.auth.id.cn-beijing.volces.com/.well-known/openid-configuration" \
+  --allowed-id "<client-id-1>,<client-id-2>"
+```
+
+---
+
+## 7. list harness —— 列出已部署的 Harness
+
+`agentkit list harness` 列出当前凭证下所有带 `agentkit:agenttype=harness` 标签的运行时。
+
+| 参数 | 说明 | 默认值 |
+| :--- | :--- | :--- |
+| `--region` | 区域覆盖。 | 环境变量 / 全局配置 |
+| `--output` | 输出格式 `table` / `json` / `yaml`。 | `table` |
+| `--quiet`, `-q` | 仅打印 RuntimeId。 | `false` |
+| `--no-color`, `-nc` | 关闭彩色输出。 | `false` |
+| `--limit`, `-l` | 每批拉取的运行时数量。 | `50` |
+
+```bash
+agentkit list harness
+agentkit list harness --output json --region cn-beijing
+```


### PR DESCRIPTION
## Summary

Adds a dedicated **Harness** page to the AgentKit CLI docs: `docs/content/2.agentkit-cli/5.harness.md`, plus a sidebar entry (under *命令详解*). The title carries a **Beta** badge.

Documents the full harness lifecycle, with each section structured as **description → parameter table → examples**:

1. Overview (lifecycle + the three exposed route families)
2. `init --template harness` (scaffold)
3. `add harness` — core/component params + connection-param tables, examples, resulting JSON
4. `deploy --harness` — all flags, the `harness.json` registry, credential handling
5. `invoke harness` — `--protocol invoke|run_sse`, full override/param table, examples, error pass-through
6. memory / knowledgebase — backends + env mapping + the "deploy-time, not per-call overridable" caveat
7. Auth — `key_auth` vs `custom_jwt` (OAuth) with params + example
8. `list harness`

All supported parameters and backends are listed in tables.

## Preview

Verified locally with `vitepress dev` — page renders (HTTP 200, no compile errors), sidebar shows **AgentKit CLI → Harness**, Beta badge on the title.

Docs-only change (one new page + one sidebar line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)