### PR TITLE
chore: sync internal 0.6.3 to GitHub

### DIFF
--- a/agentkit/platform/configuration.py
+++ b/agentkit/platform/configuration.py
@@ -536,15 +536,22 @@ class VolcConfiguration:
         """
         Resolves region for a specific service.
         Priority:
-        1. Service-specific environment variable: VOLCENGINE_{SERVICE}_REGION
-        2. Service-specific config file: services.{service}.region
-        3. Logical region mapping: region_policy.rules.{logical_region}.{service}
-        4. Global environment variable: VOLCENGINE_REGION
-        5. Global config file: volcengine.region
-        6. Default: DEFAULT_REGION
+        1. Explicitly passed in constructor
+        2. Service-specific environment variable: VOLCENGINE_{SERVICE}_REGION
+        3. Service-specific config file: services.{service}.region
+        4. Logical region mapping: region_policy.rules.{logical_region}.{service}
+        5. Global environment variable: VOLCENGINE_REGION
+        6. Global config file: volcengine.region
+        7. Default: DEFAULT_REGION
         """
         key_lower = service_key.lower()
         key_upper = service_key.upper()
+
+        if self._region:
+            mapped_region = self._get_mapped_region(self._region, service_key)
+            if mapped_region:
+                return mapped_region
+            return self._region
 
         if self._provider == CloudProvider.BYTEPLUS:
             svc_region = os.getenv(f"BYTEPLUS_{key_upper}_REGION")

--- a/agentkit/toolkit/cli/sandbox/README.md
+++ b/agentkit/toolkit/cli/sandbox/README.md
@@ -59,8 +59,13 @@ Options:
   tool is created without TOS mount configuration.
 - `--cpu`: optional. Sandbox vCPU count; allowed values are `2`, `4`, `8`, and
   `16`. Defaults to `4`. Memory is derived as 2 GiB per vCPU.
+- `--model-provider`: optional. Model provider to use for base URLs, the
+  default model, and the Codex model catalog. Supported values are
+  `model_square`, `coding_plan`, and `agent_plan`; defaults to `model_square`.
 - `--model-name`: optional. Injected into the tool as `OPENCODE_MODEL`,
-  `CODEX_MODEL`, and `ANTHROPIC_MODEL`.
+  `CODEX_MODEL`, and `ANTHROPIC_MODEL`. If omitted, the provider's default
+  model is used. Custom model names are allowed and are added to the Codex
+  model catalog with default capabilities.
 - `--model-api-key`: optional. Injected into the tool as `OPENCODE_API_KEY`,
   `CODEX_API_KEY`, and `ANTHROPIC_AUTH_TOKEN`. If omitted, the CLI uses
   `MODEL_API_KEY` when that environment variable is set.
@@ -68,9 +73,27 @@ Options:
 The sandbox create request maps `--cpu` to `CpuMilli=<cpu * 1000>` and
 `MemoryMb=<cpu * 2048>`, so the default shape is 4 vCPU / 8 GiB.
 
-The tool always injects Volcengine Ark compatible endpoints into
-`OPENCODE_BASE_URL`, `CODEX_BASE_URL`, `MODEL_BASE_URL`, and
-`ANTHROPIC_BASE_URL`. Custom `--model-base-url` is intentionally not exposed.
+The tool injects the selected provider's Volcengine Ark compatible endpoints
+into `OPENCODE_BASE_URL`, `CODEX_BASE_URL`, `MODEL_BASE_URL`, and
+`ANTHROPIC_BASE_URL`, and stores the selected provider in
+`AGENTKIT_SANDBOX_MODEL_PROVIDER`. The same provider ID and base URL are written
+into `CODEX_CONFIG_TOML`, and provider-supported models are written into
+`CODEX_MODEL_CATALOG_JSON`. The create request also injects
+`BROWSER_EXTRA_ARGS` for browser startup inside the sandbox:
+
+```sh
+--enable-unsafe-swiftshader --use-gl=angle --use-angle=swiftshader-webgl --ignore-gpu-blocklist
+```
+
+Custom `--model-base-url` is intentionally not exposed.
+
+Provider defaults:
+
+| Provider | Default model | Model base URL |
+| --- | --- | --- |
+| `model_square` | `deepseek-v4-flash-260425` | `https://ark.cn-beijing.volces.com/api/v3` |
+| `coding_plan` | `deepseek-v4-flash` | `https://ark.cn-beijing.volces.com/api/coding/v3` |
+| `agent_plan` | `deepseek-v4-flash` | `https://ark.cn-beijing.volces.com/api/plan/v3` |
 
 Credential resolution is delegated to the underlying SDK/service clients:
 `AgentkitToolsClient` handles `CreateTool` credentials, and `TOSService` handles
@@ -380,7 +403,13 @@ Options:
   a relative path appended under `--workspace`; when omitted, sources are
   uploaded into `--workspace`.
 - `--model-name`: optional. When creating a sandbox session, injects the value
-  as `OPENCODE_MODEL`, `CODEX_MODEL`, and `ANTHROPIC_MODEL`.
+  as `OPENCODE_MODEL`, `CODEX_MODEL`, and `ANTHROPIC_MODEL`. Custom model names
+  are allowed.
+- `--model-provider`: optional. When creating a sandbox session, uses the
+  provider's default model if `--model-name` is omitted, injects provider base
+  URL envs, and updates `CODEX_CONFIG_TOML` / `CODEX_MODEL_CATALOG_JSON` for
+  `CodeEnv` sessions. Supported values are `model_square`, `coding_plan`, and
+  `agent_plan`.
 - `--model-api-key`: optional. When creating a sandbox session, injects the
   value as `OPENCODE_API_KEY`, `CODEX_API_KEY`, and `ANTHROPIC_AUTH_TOKEN`. If
   omitted, the CLI uses `MODEL_API_KEY` when that environment variable is set.
@@ -400,6 +429,12 @@ stores it in the `terminal_shell_id` list in `.agentkit/sandbox/sessions.json`
 while the connection is active. Multiple live WebSocket connections under the
 same sandbox `session_id` are tracked in the same list. The CLI removes only the
 current shell ID from the list when that connection is detached or closed.
+
+When `--model-name` is provided without `--model-provider`, `exec` still updates
+`CODEX_CONFIG_TOML` / `CODEX_MODEL_CATALOG_JSON` for `CodeEnv` sessions. It
+first tries to reuse `AGENTKIT_SANDBOX_MODEL_PROVIDER` from the cached or remote
+tool configuration, then falls back to `model_square` when no marker is
+available.
 
 Press `Ctrl-]`, or type `exit` / `exit()`, to detach from the local terminal.
 `Ctrl-C` is forwarded to the remote process, which is useful for interrupting

--- a/agentkit/toolkit/cli/sandbox/README.md
+++ b/agentkit/toolkit/cli/sandbox/README.md
@@ -289,8 +289,7 @@ Execute a command in a sandbox shell.
 ```bash
 agentkit sandbox shell \
   --session-id 123456789 \
-  --command 'echo $TEST_VAR' \
-  --shell-id shell-example
+  --command 'echo $TEST_VAR'
 
 agentkit sandbox shell \
   --session-id 123456789 \
@@ -311,7 +310,6 @@ Options:
   `AGENTKIT_SANDBOX_TOOL_ID` are both absent.
 - `--command`: required. Command to execute in the sandbox.
 - `--exec-dir`: optional execution directory.
-- `--shell-id`: optional shell terminal ID for re-entering an existing shell.
 - `--workspace`: optional sandbox workspace root; defaults to `/home/gem`.
 - `--src-dir`: optional local file or directory to upload before executing the
   shell command. Additional file or directory paths can follow this option,
@@ -324,7 +322,7 @@ The command posts to `<endpoint>/v1/shell/exec` with:
 
 ```json
 {
-  "id": "shell-example",
+  "id": "",
   "exec_dir": "",
   "command": "echo $TEST_VAR"
 }
@@ -393,8 +391,6 @@ Options:
 - `--command`: optional. Initial command to run after the exec session is ready.
   Omit this option to connect without running an initial command. Use
   `--command codex` to start the remote Codex TUI.
-- `--shell-id`: optional. Existing shell terminal ID to connect to. When this is
-  set and `--command` is omitted, no initial command is sent.
 - `--workspace`: optional sandbox workspace root; defaults to `/home/gem`.
 - `--src-dir`: optional local file or directory to upload before opening the
   exec session. Additional file or directory paths can follow this option,

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -32,13 +32,16 @@ from agentkit.toolkit.cli.sandbox.model_config import (
     CODE_ENV_HOME,
     CODEX_CONFIG_TOML_ENV,
     CODEX_MODEL_CATALOG_JSON_ENV,
-    DEFAULT_ANTHROPIC_BASE_URL,
-    DEFAULT_MODEL_BASE_URL,
-    DEFAULT_MODEL_NAME,
+    DEFAULT_MODEL_PROVIDER,
+    ModelProviderType,
     MODEL_API_KEY_ENV,
     MODEL_API_KEY_ENV_KEYS,
     MODEL_BASE_URL_ENV_KEYS,
     MODEL_NAME_ENV_KEYS,
+    MODEL_PROVIDER_ENV,
+    get_model_provider_config,
+    normalize_model_provider,
+    resolve_model_name,
     build_codex_config_toml as _shared_build_codex_config_toml,
     build_codex_model_catalog_json as _shared_build_codex_model_catalog_json,
 )
@@ -63,6 +66,11 @@ DISABLED_SERVICE_ENV_KEYS = (
     "DISABLE_JUPYTER",
     "DISABLE_CODE_SERVER",
     "DISABLE_NODEJS_REPL",
+)
+BROWSER_EXTRA_ARGS_ENV = "BROWSER_EXTRA_ARGS"
+DEFAULT_BROWSER_EXTRA_ARGS = (
+    "--enable-unsafe-swiftshader --use-gl=angle "
+    "--use-angle=swiftshader-webgl --ignore-gpu-blocklist"
 )
 TOOL_READY_STATUS = "Ready"
 TOOL_FAILED_STATUSES = {"Error", "Failed", "CreateFailed", "Deleting", "Deleted"}
@@ -118,17 +126,24 @@ def _append_tool_envs(
     )
 
 
-def _build_codex_config_toml(model_name: str) -> str:
-    return _shared_build_codex_config_toml(model_name)
+def _build_codex_config_toml(
+    model_name: str,
+    model_provider: str | ModelProviderType | None = None,
+) -> str:
+    return _shared_build_codex_config_toml(model_name, model_provider)
 
 
-def _build_codex_model_catalog_json(model_name: str) -> str:
-    return _shared_build_codex_model_catalog_json(model_name)
+def _build_codex_model_catalog_json(
+    model_name: str,
+    model_provider: str | ModelProviderType | None = None,
+) -> str:
+    return _shared_build_codex_model_catalog_json(model_name, model_provider)
 
 
 def _append_code_env_tool_envs(
     envs: list[tools_types.EnvsItemForCreateTool],
     model_name: str,
+    model_provider: str | ModelProviderType | None,
 ) -> None:
     envs.extend(
         [
@@ -146,11 +161,11 @@ def _append_code_env_tool_envs(
             ),
             tools_types.EnvsItemForCreateTool(
                 Key=CODEX_CONFIG_TOML_ENV,
-                Value=_build_codex_config_toml(model_name),
+                Value=_build_codex_config_toml(model_name, model_provider),
             ),
             tools_types.EnvsItemForCreateTool(
                 Key=CODEX_MODEL_CATALOG_JSON_ENV,
-                Value=_build_codex_model_catalog_json(model_name),
+                Value=_build_codex_model_catalog_json(model_name, model_provider),
             ),
         ]
     )
@@ -161,25 +176,30 @@ def _build_tool_model_envs(
     tool_type: str,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
+    model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
 ) -> list[tools_types.EnvsItemForCreateTool] | None:
     envs: list[tools_types.EnvsItemForCreateTool] = []
-    resolved_model_name = (model_name or "").strip() or DEFAULT_MODEL_NAME
+    provider_config = get_model_provider_config(model_provider)
+    resolved_model_provider = normalize_model_provider(model_provider)
+    resolved_model_name = resolve_model_name(model_name, model_provider)
     resolved_model_api_key = model_api_key or os.getenv(MODEL_API_KEY_ENV)
+    _append_tool_envs(envs, (MODEL_PROVIDER_ENV,), resolved_model_provider)
     _append_tool_envs(envs, MODEL_NAME_ENV_KEYS, resolved_model_name)
     _append_tool_envs(envs, MODEL_API_KEY_ENV_KEYS, resolved_model_api_key)
     _append_tool_envs(
         envs,
         MODEL_BASE_URL_ENV_KEYS,
-        DEFAULT_MODEL_BASE_URL,
+        provider_config.model_base_url,
     )
     _append_tool_envs(
         envs,
         ANTHROPIC_BASE_URL_ENV_KEYS,
-        DEFAULT_ANTHROPIC_BASE_URL,
+        provider_config.anthropic_base_url,
     )
     _append_tool_envs(envs, DISABLED_SERVICE_ENV_KEYS, "true")
+    _append_tool_envs(envs, (BROWSER_EXTRA_ARGS_ENV,), DEFAULT_BROWSER_EXTRA_ARGS)
     if tool_type.strip() == DEFAULT_CREATE_TOOL_TYPE:
-        _append_code_env_tool_envs(envs, resolved_model_name)
+        _append_code_env_tool_envs(envs, resolved_model_name, model_provider)
     return envs or None
 
 
@@ -192,6 +212,7 @@ def _build_create_tool_request(
     cpu: int = DEFAULT_CPU,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
+    model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
 ) -> tools_types.CreateToolRequest:
     resolved_tool_type = tool_type.strip() or DEFAULT_CREATE_TOOL_TYPE
     resolved_name = (name or "").strip() or _generate_tool_name(resolved_tool_type)
@@ -218,6 +239,7 @@ def _build_create_tool_request(
             tool_type=resolved_tool_type,
             model_name=model_name,
             model_api_key=model_api_key,
+            model_provider=model_provider,
         ),
     )
 
@@ -329,7 +351,9 @@ def create_tool(
     cpu: int = DEFAULT_CPU,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
+    model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
 ) -> dict[str, object]:
+    resolved_model_provider = normalize_model_provider(model_provider)
     region = _resolve_region(SANDBOX_REGION_ENV, "agentkit")
     tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV, "tos")
     request = _build_create_tool_request(
@@ -340,6 +364,7 @@ def create_tool(
         cpu=cpu,
         model_name=model_name,
         model_api_key=model_api_key,
+        model_provider=resolved_model_provider,
     )
     client = AgentkitToolsClient(
         region=region,
@@ -354,6 +379,7 @@ def create_tool(
         "tool_type": final_tool.tool_type or request.tool_type,
         "name": final_tool.name or request.name,
         "status": final_tool.status or TOOL_READY_STATUS,
+        "model_provider": resolved_model_provider,
     }
 
 
@@ -398,6 +424,11 @@ def create_command(
             "and ANTHROPIC_AUTH_TOKEN when creating a tool."
         ),
     ),
+    model_provider: ModelProviderType = typer.Option(
+        ModelProviderType.MODEL_SQUARE,
+        "--model-provider",
+        help="Model provider to use for base URLs, defaults, and model catalog.",
+    ),
 ) -> None:
     """Create an AgentKit Tool with optional TOS mount."""
     try:
@@ -408,6 +439,7 @@ def create_command(
             cpu=cpu,
             model_name=model_name,
             model_api_key=model_api_key,
+            model_provider=model_provider.value,
         )
         save_tool_result(str(result["tool_type"]), result)
     except (typer.Abort, typer.Exit):

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 import typer
 
+from agentkit.platform import VolcConfiguration
 from agentkit.sdk.tools.client import AgentkitToolsClient
 from agentkit.sdk.tools import types as tools_types
 from agentkit.toolkit.cli.sandbox.model_config import (
@@ -50,7 +51,6 @@ from agentkit.toolkit.volcengine.services.tos_service import (
 )
 from agentkit.utils.misc import generate_apikey_name, generate_random_id
 
-DEFAULT_CREATE_TOOL_REGION = "cn-beijing"
 SANDBOX_REGION_ENV = "AGENTKIT_SANDBOX_REGION"
 SANDBOX_TOS_REGION_ENV = "AGENTKIT_SANDBOX_TOS_REGION"
 DEFAULT_CREATE_TOOL_TYPE = "CodeEnv"
@@ -70,11 +70,11 @@ TOOL_WAIT_INTERVAL_SECONDS = 5
 TOOL_WAIT_TIMEOUT_SECONDS = 600
 
 
-def _resolve_region(env_var_name: str) -> str:
+def _resolve_region(env_var_name: str, service_key: str) -> str:
     env_region = (os.getenv(env_var_name) or "").strip()
     if env_region:
         return env_region
-    return DEFAULT_CREATE_TOOL_REGION
+    return VolcConfiguration().get_service_endpoint(service_key).region
 
 
 def _generate_tool_name(tool_type: str) -> str:
@@ -330,8 +330,8 @@ def create_tool(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
 ) -> dict[str, object]:
-    region = _resolve_region(SANDBOX_REGION_ENV)
-    tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV)
+    region = _resolve_region(SANDBOX_REGION_ENV, "agentkit")
+    tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV, "tos")
     request = _build_create_tool_request(
         tool_type=tool_type,
         name=tool_name,

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -46,6 +46,7 @@ from agentkit.toolkit.cli.sandbox.session_create import (
     build_model_envs,
     ensure_sandbox_session,
 )
+from agentkit.toolkit.cli.sandbox.git_config import apply_git_config_to_session
 from agentkit.toolkit.cli.sandbox.tool_resolve import SandboxToolType
 from agentkit.toolkit.cli.sandbox.utils import (
     add_session_terminal_shell_id,
@@ -385,6 +386,14 @@ def exec_command(
             "to --workspace."
         ),
     ),
+    git_config: Optional[str] = typer.Option(
+        None,
+        "--git-config",
+        help=(
+            "Git identity source. Use 'local' to read local git config, or "
+            "provide an INI/TOML/JSON file path with user.name and user.email."
+        ),
+    ),
     model_name: Optional[str] = typer.Option(
         None,
         "--model-name",
@@ -437,9 +446,6 @@ def exec_command(
     except Exception as exc:
         error(str(exc))
 
-    ws_url = build_terminal_ws_url(session.get("endpoint"), shell_id=shell_id)
-    initial_command = command
-
     cleanup_shell_ids: list[str] = []
     cleanup_shell_ids_lock = threading.Lock()
 
@@ -448,9 +454,24 @@ def exec_command(
             if remote_shell_id not in cleanup_shell_ids:
                 cleanup_shell_ids.append(remote_shell_id)
 
-    if shell_id:
-        add_session_terminal_shell_id(session_id, shell_id)
-        remember_cleanup_shell_id(shell_id)
+    active_shell_id = shell_id
+    try:
+        apply_git_config_to_session(
+            session,
+            git_config,
+            shell_id=active_shell_id or "",
+        )
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        error(str(exc))
+
+    if active_shell_id:
+        add_session_terminal_shell_id(session_id, active_shell_id)
+        remember_cleanup_shell_id(active_shell_id)
+
+    ws_url = build_terminal_ws_url(session.get("endpoint"), shell_id=active_shell_id)
+    initial_command = command
 
     def on_shell_id(remote_shell_id: str) -> None:
         add_session_terminal_shell_id(session_id, remote_shell_id)

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -31,6 +31,7 @@ from typing import Iterator, Optional
 
 import typer
 
+from agentkit.sdk.tools.client import AgentkitToolsClient
 from agentkit.toolkit.cli.sandbox.cli_file import (
     _build_remote_extract_command,
     _create_upload_archive,
@@ -47,11 +48,17 @@ from agentkit.toolkit.cli.sandbox.session_create import (
     ensure_sandbox_session,
 )
 from agentkit.toolkit.cli.sandbox.git_config import apply_git_config_to_session
-from agentkit.toolkit.cli.sandbox.tool_resolve import SandboxToolType
+from agentkit.toolkit.cli.sandbox.model_config import ModelProviderType
+from agentkit.toolkit.cli.sandbox.tool_resolve import (
+    SandboxToolType,
+    find_tool_model_provider,
+    get_remote_tool_model_provider,
+)
 from agentkit.toolkit.cli.sandbox.utils import (
     add_session_terminal_shell_id,
     build_terminal_ws_url,
     error,
+    find_session_result,
     remove_session_terminal_shell_id,
 )
 
@@ -328,6 +335,48 @@ def _upload_source_before_exec(
     return resolved_dst_dir
 
 
+def _resolve_exec_model_provider(
+    *,
+    session_id: Optional[str],
+    tool_id: Optional[str],
+    tool_type: SandboxToolType,
+    model_name: Optional[str],
+    model_provider: Optional[ModelProviderType],
+) -> str | ModelProviderType | None:
+    if model_provider or not (model_name or "").strip():
+        return model_provider
+
+    resolved_tool_id = (tool_id or "").strip()
+    if not resolved_tool_id and session_id:
+        existing = find_session_result(session_id)
+        if existing:
+            existing_tool_id = existing.get("tool_id")
+            if isinstance(existing_tool_id, str):
+                resolved_tool_id = existing_tool_id.strip()
+
+    if not resolved_tool_id:
+        return None
+
+    cached_model_provider = find_tool_model_provider(
+        tool_id=resolved_tool_id,
+        tool_type=tool_type,
+    )
+    if cached_model_provider:
+        return cached_model_provider
+
+    if not (tool_id or "").strip():
+        return None
+
+    try:
+        return get_remote_tool_model_provider(
+            AgentkitToolsClient(),
+            resolved_tool_id,
+            tool_type=tool_type,
+        )
+    except Exception:
+        return None
+
+
 def exec_command(
     ctx: typer.Context,
     session_id: Optional[str] = typer.Option(
@@ -410,9 +459,24 @@ def exec_command(
             "and ANTHROPIC_AUTH_TOKEN when creating a sandbox session."
         ),
     ),
+    model_provider: Optional[ModelProviderType] = typer.Option(
+        None,
+        "--model-provider",
+        help=(
+            "Model provider to use for base URLs, defaults, and model catalog "
+            "when creating a sandbox session."
+        ),
+    ),
 ) -> None:
     """Open a streaming sandbox exec session. Press Ctrl-] or type exit/exit()."""
     try:
+        resolved_model_provider = _resolve_exec_model_provider(
+            session_id=session_id,
+            tool_id=tool_id,
+            tool_type=tool_type,
+            model_name=model_name,
+            model_provider=model_provider,
+        )
         session = ensure_sandbox_session(
             session_id=session_id,
             tool_id=tool_id,
@@ -420,6 +484,7 @@ def exec_command(
             envs=build_model_envs(
                 model_name=model_name,
                 model_api_key=model_api_key,
+                model_provider=resolved_model_provider,
                 include_codex_config=tool_type == SandboxToolType.CODE_ENV,
             ),
         )

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -459,7 +459,6 @@ def exec_command(
         apply_git_config_to_session(
             session,
             git_config,
-            shell_id=active_shell_id or "",
         )
     except typer.Exit:
         raise

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -407,11 +407,6 @@ def exec_command(
             "Omit this option to connect without an initial command."
         ),
     ),
-    shell_id: Optional[str] = typer.Option(
-        None,
-        "--shell-id",
-        help="Existing shell terminal ID to connect to.",
-    ),
     workspace: str = typer.Option(
         DEFAULT_EXEC_WORKSPACE,
         "--workspace",
@@ -519,7 +514,6 @@ def exec_command(
             if remote_shell_id not in cleanup_shell_ids:
                 cleanup_shell_ids.append(remote_shell_id)
 
-    active_shell_id = shell_id
     try:
         apply_git_config_to_session(
             session,
@@ -530,11 +524,7 @@ def exec_command(
     except Exception as exc:
         error(str(exc))
 
-    if active_shell_id:
-        add_session_terminal_shell_id(session_id, active_shell_id)
-        remember_cleanup_shell_id(active_shell_id)
-
-    ws_url = build_terminal_ws_url(session.get("endpoint"), shell_id=active_shell_id)
+    ws_url = build_terminal_ws_url(session.get("endpoint"))
     initial_command = command
 
     def on_shell_id(remote_shell_id: str) -> None:

--- a/agentkit/toolkit/cli/sandbox/cli_file.py
+++ b/agentkit/toolkit/cli/sandbox/cli_file.py
@@ -193,11 +193,13 @@ def _exec_shell_command(
     session: dict[str, object],
     command: str,
     *,
+    shell_id: str = "",
+    exec_dir: str = "",
     quiet_errors: bool = False,
 ) -> dict[str, object]:
     response = requests.post(
         build_exec_url(session.get("endpoint")),
-        json={"id": "", "exec_dir": "", "command": command},
+        json={"id": shell_id, "exec_dir": exec_dir, "command": command},
         timeout=SANDBOX_EXEC_TIMEOUT_SECONDS,
     )
     payload = _json_response(response, "shell exec")

--- a/agentkit/toolkit/cli/sandbox/cli_shell.py
+++ b/agentkit/toolkit/cli/sandbox/cli_shell.py
@@ -31,6 +31,7 @@ from agentkit.toolkit.cli.sandbox.session_create import (
     SANDBOX_TOOL_ID_ENV,
     ensure_sandbox_session,
 )
+from agentkit.toolkit.cli.sandbox.git_config import apply_git_config_to_session
 from agentkit.toolkit.cli.sandbox.tool_resolve import SandboxToolType
 from agentkit.toolkit.cli.sandbox.utils import (
     SANDBOX_EXEC_TIMEOUT_SECONDS,
@@ -101,6 +102,14 @@ def shell_command(
             "to --workspace."
         ),
     ),
+    git_config: Optional[str] = typer.Option(
+        None,
+        "--git-config",
+        help=(
+            "Git identity source. Use 'local' to read local git config, or "
+            "provide an INI/TOML/JSON file path with user.name and user.email."
+        ),
+    ),
 ) -> None:
     """Execute a command in a sandbox shell."""
     try:
@@ -128,9 +137,23 @@ def shell_command(
     except Exception as exc:
         error(str(exc))
 
+    effective_shell_id = shell_id or ""
+    try:
+        resolved_shell_id = apply_git_config_to_session(
+            session,
+            git_config,
+            shell_id=effective_shell_id,
+        )
+        if resolved_shell_id:
+            effective_shell_id = resolved_shell_id
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        error(str(exc))
+
     url = build_exec_url(session.get("endpoint"))
     body = {
-        "id": shell_id or "",
+        "id": effective_shell_id,
         "exec_dir": exec_dir or "",
         "command": command,
     }

--- a/agentkit/toolkit/cli/sandbox/cli_shell.py
+++ b/agentkit/toolkit/cli/sandbox/cli_shell.py
@@ -74,11 +74,6 @@ def shell_command(
         "--exec-dir",
         help="Execution directory.",
     ),
-    shell_id: Optional[str] = typer.Option(
-        None,
-        "--shell-id",
-        help="Shell terminal ID for re-entering an existing shell.",
-    ),
     workspace: str = typer.Option(
         DEFAULT_EXEC_WORKSPACE,
         "--workspace",
@@ -137,7 +132,6 @@ def shell_command(
     except Exception as exc:
         error(str(exc))
 
-    effective_shell_id = shell_id or ""
     try:
         apply_git_config_to_session(
             session,
@@ -150,7 +144,7 @@ def shell_command(
 
     url = build_exec_url(session.get("endpoint"))
     body = {
-        "id": effective_shell_id,
+        "id": "",
         "exec_dir": exec_dir or "",
         "command": command,
     }

--- a/agentkit/toolkit/cli/sandbox/cli_shell.py
+++ b/agentkit/toolkit/cli/sandbox/cli_shell.py
@@ -139,13 +139,10 @@ def shell_command(
 
     effective_shell_id = shell_id or ""
     try:
-        resolved_shell_id = apply_git_config_to_session(
+        apply_git_config_to_session(
             session,
             git_config,
-            shell_id=effective_shell_id,
         )
-        if resolved_shell_id:
-            effective_shell_id = resolved_shell_id
     except typer.Exit:
         raise
     except Exception as exc:

--- a/agentkit/toolkit/cli/sandbox/cli_web.py
+++ b/agentkit/toolkit/cli/sandbox/cli_web.py
@@ -21,37 +21,28 @@ from typing import Optional
 
 import typer
 
-from agentkit.sdk.tools.client import AgentkitToolsClient
-from agentkit.toolkit.cli.sandbox.session_create import SANDBOX_TOOL_ID_ENV
-from agentkit.toolkit.cli.sandbox.session_sync import sync_remote_sessions
+from agentkit.toolkit.cli.sandbox.session_create import (
+    SANDBOX_TOOL_ID_ENV,
+    ensure_sandbox_session_with_status,
+)
 from agentkit.toolkit.cli.sandbox.tool_resolve import SandboxToolType
 from agentkit.toolkit.cli.sandbox.utils import (
     build_web_url,
     echo_json,
     error,
-    find_session_result,
 )
 
 
-def _resolve_existing_session(
+def _resolve_web_session(
     *,
     session_id: str,
     tool_id: Optional[str],
-) -> dict[str, object]:
-    client = AgentkitToolsClient()
-    resolved_tool_id = sync_remote_sessions(
+) -> tuple[dict[str, object], bool]:
+    return ensure_sandbox_session_with_status(
         session_id=session_id,
         tool_id=tool_id,
-        tool_type=SandboxToolType.CODE_ENV,
-        client=client,
-        env_var_name=SANDBOX_TOOL_ID_ENV,
+        tool_type=SandboxToolType.CODE_ENV.value,
     )
-    result = find_session_result(session_id)
-    if result is None:
-        error(f"Sandbox session not found: {session_id}")
-    if resolved_tool_id and result.get("tool_id") != resolved_tool_id:
-        error(f"Sandbox session not found: {session_id}")
-    return result
 
 
 def web_command(
@@ -71,7 +62,7 @@ def web_command(
 ) -> None:
     """Return the browser URL for a sandbox session."""
     try:
-        session = _resolve_existing_session(
+        session, is_new = _resolve_web_session(
             session_id=session_id,
             tool_id=tool_id,
         )
@@ -92,5 +83,6 @@ def web_command(
             "url": url,
             "tool_id": session.get("tool_id"),
             "session_id": resolved_session_id,
+            "is_new": is_new,
         }
     )

--- a/agentkit/toolkit/cli/sandbox/git_config.py
+++ b/agentkit/toolkit/cli/sandbox/git_config.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Git config helpers for sandbox exec and shell commands."""
+
+from __future__ import annotations
+
+import configparser
+import json
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from agentkit.toolkit.cli.sandbox.cli_file import _exec_shell_command
+
+
+LOCAL_GIT_CONFIG_VALUE = "local"
+
+
+def _non_empty_string(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    resolved = str(value).strip()
+    return resolved or None
+
+
+def _extract_git_config_values(data: Mapping[str, Any]) -> tuple[str, str]:
+    name = _non_empty_string(data.get("user.name"))
+    email = _non_empty_string(data.get("user.email"))
+
+    user_section = data.get("user")
+    if isinstance(user_section, Mapping):
+        name = name or _non_empty_string(user_section.get("name"))
+        email = email or _non_empty_string(user_section.get("email"))
+
+    if not name or not email:
+        raise ValueError("Failed to resolve user.name and user.email from git config")
+
+    return name, email
+
+
+def _read_local_git_config_value(key: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", key],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError("git command not found") from exc
+
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        raise ValueError(f"Failed to resolve {key} from local git config")
+    return value
+
+
+def _read_local_git_config() -> tuple[str, str]:
+    if shutil.which("git") is None:
+        raise ValueError("git command not found")
+
+    try:
+        result = subprocess.run(
+            ["git", "config", "--list"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError("git command not found") from exc
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        if message:
+            raise ValueError(f"Failed to read local git config: {message}")
+        raise ValueError("Failed to read local git config")
+    if not result.stdout.strip():
+        raise ValueError("Local git config is empty")
+
+    return (
+        _read_local_git_config_value("user.name"),
+        _read_local_git_config_value("user.email"),
+    )
+
+
+def _read_json_git_config(path: Path) -> tuple[str, str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Failed to parse git config JSON file: {path}") from exc
+    if not isinstance(data, Mapping):
+        raise ValueError("Git config JSON file must contain an object")
+    return _extract_git_config_values(data)
+
+
+def _read_toml_git_config(path: Path) -> tuple[str, str]:
+    try:
+        import tomllib
+    except ImportError:  # pragma: no cover - Python 3.10 compatibility.
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError as exc:
+            raise ValueError(
+                "TOML git config requires Python 3.11+ or the tomli package"
+            ) from exc
+
+    try:
+        with path.open("rb") as file:
+            data = tomllib.load(file)
+    except Exception as exc:
+        raise ValueError(f"Failed to parse git config TOML file: {path}") from exc
+    return _extract_git_config_values(data)
+
+
+def _read_ini_git_config(path: Path) -> tuple[str, str]:
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        content = path.read_text(encoding="utf-8")
+        try:
+            parser.read_string(content)
+        except configparser.MissingSectionHeaderError:
+            parser.read_string(f"[__root__]\n{content}")
+    except Exception as exc:
+        raise ValueError(f"Failed to parse git config INI file: {path}") from exc
+
+    data: dict[str, object] = dict(parser.defaults())
+    if parser.has_section("__root__"):
+        data.update(dict(parser.items("__root__")))
+    if parser.has_section("user"):
+        data["user"] = dict(parser.items("user"))
+
+    return _extract_git_config_values(data)
+
+
+def resolve_git_config(git_config: Optional[str]) -> Optional[tuple[str, str]]:
+    resolved = (git_config or "").strip()
+    if not resolved:
+        return None
+
+    if resolved.lower() == LOCAL_GIT_CONFIG_VALUE:
+        return _read_local_git_config()
+
+    path = Path(resolved).expanduser()
+    if not path.exists():
+        raise ValueError(f"Git config file not found: {path}")
+    if not path.is_file():
+        raise ValueError(f"Git config path is not a file: {path}")
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return _read_json_git_config(path)
+    if suffix == ".toml":
+        return _read_toml_git_config(path)
+    return _read_ini_git_config(path)
+
+
+def build_remote_git_config_command(user_name: str, user_email: str) -> str:
+    return (
+        f"git config --global user.name {shlex.quote(user_name)}; "
+        f"git config --global user.email {shlex.quote(user_email)}"
+    )
+
+
+def _extract_shell_id(payload: Mapping[str, Any]) -> Optional[str]:
+    data = payload.get("data")
+    if not isinstance(data, Mapping):
+        return None
+    return _non_empty_string(data.get("session_id"))
+
+
+def apply_git_config_to_session(
+    session: dict[str, object],
+    git_config: Optional[str],
+    *,
+    shell_id: str = "",
+) -> Optional[str]:
+    resolved = resolve_git_config(git_config)
+    if resolved is None:
+        return shell_id or None
+
+    user_name, user_email = resolved
+    payload = _exec_shell_command(
+        session,
+        build_remote_git_config_command(user_name, user_email),
+        shell_id=shell_id,
+    )
+    resolved_shell_id = _extract_shell_id(payload)
+    if resolved_shell_id:
+        return resolved_shell_id
+    if shell_id:
+        return shell_id
+    raise ValueError("Sandbox git config update response missing session_id")

--- a/agentkit/toolkit/cli/sandbox/git_config.py
+++ b/agentkit/toolkit/cli/sandbox/git_config.py
@@ -174,32 +174,16 @@ def build_remote_git_config_command(user_name: str, user_email: str) -> str:
     )
 
 
-def _extract_shell_id(payload: Mapping[str, Any]) -> Optional[str]:
-    data = payload.get("data")
-    if not isinstance(data, Mapping):
-        return None
-    return _non_empty_string(data.get("session_id"))
-
-
 def apply_git_config_to_session(
     session: dict[str, object],
     git_config: Optional[str],
-    *,
-    shell_id: str = "",
-) -> Optional[str]:
+) -> None:
     resolved = resolve_git_config(git_config)
     if resolved is None:
-        return shell_id or None
+        return
 
     user_name, user_email = resolved
-    payload = _exec_shell_command(
+    _exec_shell_command(
         session,
         build_remote_git_config_command(user_name, user_email),
-        shell_id=shell_id,
     )
-    resolved_shell_id = _extract_shell_id(payload)
-    if resolved_shell_id:
-        return resolved_shell_id
-    if shell_id:
-        return shell_id
-    raise ValueError("Sandbox git config update response missing session_id")

--- a/agentkit/toolkit/cli/sandbox/model_config.py
+++ b/agentkit/toolkit/cli/sandbox/model_config.py
@@ -16,7 +16,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 import json
+from typing import Optional
 
 MODEL_NAME_ENV_KEYS = ("OPENCODE_MODEL", "CODEX_MODEL", "ANTHROPIC_MODEL")
 MODEL_API_KEY_ENV_KEYS = (
@@ -31,35 +34,192 @@ MODEL_BASE_URL_ENV_KEYS = (
 )
 ANTHROPIC_BASE_URL_ENV_KEYS = ("ANTHROPIC_BASE_URL",)
 MODEL_API_KEY_ENV = "MODEL_API_KEY"
+MODEL_PROVIDER_ENV = "AGENTKIT_SANDBOX_MODEL_PROVIDER"
 
 CODE_ENV_HOME = "/home/gem"
 CODE_ENV_CODEX_HOME = "/home/gem/.codex"
 CODEX_CONFIG_TOML_ENV = "CODEX_CONFIG_TOML"
 CODEX_MODEL_CATALOG_JSON_ENV = "CODEX_MODEL_CATALOG_JSON"
 CODEX_MODEL_CATALOG_PATH = f"{CODE_ENV_CODEX_HOME}/model-catalog.json"
-DEFAULT_MODEL_NAME = "deepseek-v4-flash-260425"
-DEFAULT_MODEL_NAME_LIST = (
-    DEFAULT_MODEL_NAME,
-    "deepseek-v4-pro-260425",
-    "doubao-seed-2-0-pro-260215",
-)
+
+
+class ModelProviderType(str, Enum):
+    MODEL_SQUARE = "model_square"
+    CODING_PLAN = "coding_plan"
+    AGENT_PLAN = "agent_plan"
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    supports_reasoning_summaries: bool
+    context_window: int
+
+
+@dataclass(frozen=True)
+class ModelProviderConfig:
+    model_base_url: str
+    anthropic_base_url: str
+    default_model_name: str
+    models: dict[str, ModelSpec]
+
+
 DEFAULT_MODEL_CONTEXT_WINDOW = 1000000
-MODEL_CONTEXT_WINDOW_OVERRIDES = {
-    "doubao-seed-2-0-pro-260215": 256000,
+DEFAULT_MODEL_PROVIDER = ModelProviderType.MODEL_SQUARE.value
+
+MODEL_PROVIDER_CONFIGS: dict[str, ModelProviderConfig] = {
+    ModelProviderType.MODEL_SQUARE.value: ModelProviderConfig(
+        model_base_url="https://ark.cn-beijing.volces.com/api/v3",
+        anthropic_base_url="https://ark.cn-beijing.volces.com/api/compatible",
+        default_model_name="deepseek-v4-flash-260425",
+        models={
+            "doubao-seed-2-0-pro-260215": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=256000,
+            ),
+            "deepseek-v4-flash-260425": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+            "deepseek-v4-pro-260425": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+            "glm-4-7-251222": ModelSpec(
+                supports_reasoning_summaries=False,
+                context_window=200000,
+            ),
+        },
+    ),
+    ModelProviderType.CODING_PLAN.value: ModelProviderConfig(
+        model_base_url="https://ark.cn-beijing.volces.com/api/coding/v3",
+        anthropic_base_url="https://ark.cn-beijing.volces.com/api/coding",
+        default_model_name="deepseek-v4-flash",
+        models={
+            "doubao-seed-2.0-pro": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=256000,
+            ),
+            "deepseek-v4-flash": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+            "deepseek-v4-pro": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+            "glm-5.2": ModelSpec(
+                supports_reasoning_summaries=False,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+        },
+    ),
+    ModelProviderType.AGENT_PLAN.value: ModelProviderConfig(
+        model_base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+        anthropic_base_url="https://ark.cn-beijing.volces.com/api/plan",
+        default_model_name="deepseek-v4-flash",
+        models={
+            "doubao-seed-2.0-pro": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=256000,
+            ),
+            "deepseek-v4-flash": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+            "deepseek-v4-pro": ModelSpec(
+                supports_reasoning_summaries=True,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+            "glm-5.2": ModelSpec(
+                supports_reasoning_summaries=False,
+                context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
+            ),
+        },
+    ),
 }
-DEFAULT_MODEL_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"
-DEFAULT_ANTHROPIC_BASE_URL = "https://ark.cn-beijing.volces.com/api/compatible"
+
+DEFAULT_MODEL_NAME = MODEL_PROVIDER_CONFIGS[
+    DEFAULT_MODEL_PROVIDER
+].default_model_name
+DEFAULT_MODEL_NAME_LIST = tuple(
+    dict.fromkeys(
+        (
+            DEFAULT_MODEL_NAME,
+            *MODEL_PROVIDER_CONFIGS[DEFAULT_MODEL_PROVIDER].models,
+        )
+    )
+)
+DEFAULT_MODEL_BASE_URL = MODEL_PROVIDER_CONFIGS[
+    DEFAULT_MODEL_PROVIDER
+].model_base_url
+DEFAULT_ANTHROPIC_BASE_URL = MODEL_PROVIDER_CONFIGS[
+    DEFAULT_MODEL_PROVIDER
+].anthropic_base_url
+
+
+def _model_provider_value(
+    model_provider: str | ModelProviderType | None,
+) -> Optional[str]:
+    if isinstance(model_provider, ModelProviderType):
+        return model_provider.value
+    return model_provider
+
+
+def normalize_model_provider(
+    model_provider: str | ModelProviderType | None,
+) -> str:
+    resolved = (_model_provider_value(model_provider) or DEFAULT_MODEL_PROVIDER).strip()
+    if resolved not in MODEL_PROVIDER_CONFIGS:
+        allowed = ", ".join(MODEL_PROVIDER_CONFIGS)
+        raise ValueError(f"--model-provider must be one of: {allowed}")
+    return resolved
+
+
+def get_model_provider_config(
+    model_provider: str | ModelProviderType | None,
+) -> ModelProviderConfig:
+    return MODEL_PROVIDER_CONFIGS[normalize_model_provider(model_provider)]
+
+
+def model_provider_from_env_value(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    resolved = value.strip()
+    if not resolved:
+        return None
+
+    try:
+        return normalize_model_provider(resolved)
+    except ValueError:
+        return None
+
+
+def resolve_model_name(
+    model_name: Optional[str],
+    model_provider: str | ModelProviderType | None,
+) -> str:
+    resolved_provider = normalize_model_provider(model_provider)
+    config = MODEL_PROVIDER_CONFIGS[resolved_provider]
+    resolved_model_name = (model_name or "").strip() or config.default_model_name
+    return resolved_model_name
 
 
 def _toml_quote(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-def build_codex_config_toml(model_name: str) -> str:
-    quoted_model = _toml_quote(model_name)
+def build_codex_config_toml(
+    model_name: str,
+    model_provider: str | ModelProviderType | None = None,
+) -> str:
+    resolved_provider = normalize_model_provider(model_provider)
+    config = MODEL_PROVIDER_CONFIGS[resolved_provider]
+    resolved_model_name = resolve_model_name(model_name, resolved_provider)
+    quoted_model = _toml_quote(resolved_model_name)
     return "\n".join(
         [
-            'model_provider = "codex"',
+            f"model_provider = {_toml_quote(resolved_provider)}",
             f"model = {quoted_model}",
             f"review_model = {quoted_model}",
             'approval_policy = "never"',
@@ -76,9 +236,9 @@ def build_codex_config_toml(model_name: str) -> str:
             ),
             '"""',
             "",
-            "[model_providers.codex]",
-            'name = "codex"',
-            f"base_url = {_toml_quote(DEFAULT_MODEL_BASE_URL)}",
+            f"[model_providers.{resolved_provider}]",
+            f"name = {_toml_quote(resolved_provider)}",
+            f"base_url = {_toml_quote(config.model_base_url)}",
             'wire_api = "responses"',
             'env_key = "CODEX_API_KEY"',
             "",
@@ -95,31 +255,35 @@ def build_codex_config_toml(model_name: str) -> str:
     )
 
 
-def _build_model_catalog_item(model_name: str, max_context_window: int) -> dict:
+def _reasoning_levels() -> list[dict[str, str]]:
+    return [
+        {
+            "effort": "low",
+            "description": "Fast responses with lighter reasoning",
+        },
+        {
+            "effort": "medium",
+            "description": "Balances speed and reasoning depth",
+        },
+        {
+            "effort": "high",
+            "description": "Greater reasoning depth",
+        },
+    ]
+
+
+def _build_model_catalog_item(model_name: str, spec: ModelSpec) -> dict:
     return {
         "slug": model_name,
         "display_name": model_name,
-        "supported_reasoning_levels": [
-            {
-                "effort": "low",
-                "description": "Fast responses with lighter reasoning",
-            },
-            {
-                "effort": "medium",
-                "description": "Balances speed and reasoning depth",
-            },
-            {
-                "effort": "high",
-                "description": "Greater reasoning depth",
-            },
-        ],
-        "max_context_window": max_context_window,
+        "supported_reasoning_levels": _reasoning_levels(),
+        "max_context_window": spec.context_window,
         "shell_type": "shell_command",
         "visibility": "list",
         "supported_in_api": True,
         "priority": 100,
         "base_instructions": "",
-        "supports_reasoning_summaries": True,
+        "supports_reasoning_summaries": spec.supports_reasoning_summaries,
         "support_verbosity": False,
         "truncation_policy": {"mode": "tokens", "limit": 10000},
         "supports_parallel_tool_calls": False,
@@ -127,22 +291,34 @@ def _build_model_catalog_item(model_name: str, max_context_window: int) -> dict:
     }
 
 
-def model_catalog_context_window(model_name: str) -> int:
-    return MODEL_CONTEXT_WINDOW_OVERRIDES.get(
-        model_name,
-        DEFAULT_MODEL_CONTEXT_WINDOW,
-    )
+def model_catalog_context_window(
+    model_name: str,
+    model_provider: str | ModelProviderType | None = None,
+) -> int:
+    config = get_model_provider_config(model_provider)
+    spec = config.models.get(model_name)
+    if spec:
+        return spec.context_window
+    return DEFAULT_MODEL_CONTEXT_WINDOW
 
 
-def build_codex_model_catalog_json(model_name: str) -> str:
-    deduped_model_names = list(
-        dict.fromkeys((model_name, *DEFAULT_MODEL_NAME_LIST))
+def build_codex_model_catalog_json(
+    model_name: str,
+    model_provider: str | ModelProviderType | None = None,
+) -> str:
+    resolved_provider = normalize_model_provider(model_provider)
+    config = MODEL_PROVIDER_CONFIGS[resolved_provider]
+    resolved_model_name = resolve_model_name(model_name, resolved_provider)
+    deduped_model_names = list(dict.fromkeys((resolved_model_name, *config.models)))
+    fallback_spec = ModelSpec(
+        supports_reasoning_summaries=True,
+        context_window=DEFAULT_MODEL_CONTEXT_WINDOW,
     )
     payload = {
         "models": [
             _build_model_catalog_item(
                 name,
-                model_catalog_context_window(name),
+                config.models.get(name, fallback_spec),
             )
             for name in deduped_model_names
         ]

--- a/agentkit/toolkit/cli/sandbox/session_create.py
+++ b/agentkit/toolkit/cli/sandbox/session_create.py
@@ -24,13 +24,20 @@ from typing import Optional
 from agentkit.sdk.tools.client import AgentkitToolsClient
 from agentkit.sdk.tools import types as tools_types
 from agentkit.toolkit.cli.sandbox.model_config import (
+    ANTHROPIC_BASE_URL_ENV_KEYS,
     CODEX_CONFIG_TOML_ENV,
     CODEX_MODEL_CATALOG_JSON_ENV,
     MODEL_API_KEY_ENV,
     MODEL_API_KEY_ENV_KEYS,
+    MODEL_BASE_URL_ENV_KEYS,
     MODEL_NAME_ENV_KEYS,
+    MODEL_PROVIDER_ENV,
+    ModelProviderType,
     build_codex_config_toml,
     build_codex_model_catalog_json,
+    get_model_provider_config,
+    normalize_model_provider,
+    resolve_model_name,
 )
 from agentkit.toolkit.cli.sandbox.session_sync import (
     session_info_to_result,
@@ -73,6 +80,7 @@ def _append_envs(
 def _append_codex_config_envs(
     envs: list[tools_types.EnvsItemForCreateSession],
     model_name: Optional[str],
+    model_provider: str | ModelProviderType | None,
 ) -> None:
     resolved_model_name = (model_name or "").strip()
     if not resolved_model_name:
@@ -82,11 +90,17 @@ def _append_codex_config_envs(
         [
             tools_types.EnvsItemForCreateSession(
                 key=CODEX_CONFIG_TOML_ENV,
-                value=build_codex_config_toml(resolved_model_name),
+                value=build_codex_config_toml(
+                    resolved_model_name,
+                    model_provider,
+                ),
             ),
             tools_types.EnvsItemForCreateSession(
                 key=CODEX_MODEL_CATALOG_JSON_ENV,
-                value=build_codex_model_catalog_json(resolved_model_name),
+                value=build_codex_model_catalog_json(
+                    resolved_model_name,
+                    model_provider,
+                ),
             ),
         ]
     )
@@ -96,14 +110,43 @@ def build_model_envs(
     *,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
+    model_provider: str | ModelProviderType | None = None,
     include_codex_config: bool = False,
 ) -> list[tools_types.EnvsItemForCreateSession] | None:
     envs: list[tools_types.EnvsItemForCreateSession] = []
-    resolved_model_name = (model_name or "").strip()
+    has_model_provider = bool(
+        model_provider.value if isinstance(model_provider, ModelProviderType)
+        else (model_provider or "").strip()
+    )
+    resolved_model_provider = (
+        normalize_model_provider(model_provider) if has_model_provider else None
+    )
+    resolved_model_name = (
+        resolve_model_name(model_name, resolved_model_provider)
+        if resolved_model_provider
+        else (model_name or "").strip()
+    )
+    provider_config = (
+        get_model_provider_config(resolved_model_provider)
+        if resolved_model_provider
+        else None
+    )
     resolved_model_api_key = model_api_key or os.getenv(MODEL_API_KEY_ENV)
+    _append_envs(envs, (MODEL_PROVIDER_ENV,), resolved_model_provider)
     _append_envs(envs, MODEL_NAME_ENV_KEYS, resolved_model_name)
-    if include_codex_config:
-        _append_codex_config_envs(envs, resolved_model_name)
+    if provider_config:
+        _append_envs(envs, MODEL_BASE_URL_ENV_KEYS, provider_config.model_base_url)
+        _append_envs(
+            envs,
+            ANTHROPIC_BASE_URL_ENV_KEYS,
+            provider_config.anthropic_base_url,
+        )
+    if include_codex_config and resolved_model_name:
+        _append_codex_config_envs(
+            envs,
+            resolved_model_name,
+            resolved_model_provider,
+        )
     _append_envs(envs, MODEL_API_KEY_ENV_KEYS, resolved_model_api_key)
     return envs or None
 

--- a/agentkit/toolkit/cli/sandbox/session_create.py
+++ b/agentkit/toolkit/cli/sandbox/session_create.py
@@ -382,13 +382,13 @@ def _confirm_session_after_create_start_fail(
     return None
 
 
-def ensure_sandbox_session(
+def ensure_sandbox_session_with_status(
     session_id: Optional[str] = None,
     tool_id: Optional[str] = None,
     tool_type: str = DEFAULT_SANDBOX_TOOL_TYPE,
     ttl: Optional[int] = None,
     envs: Optional[list[tools_types.EnvsItemForCreateSession]] = None,
-) -> dict[str, object]:
+) -> tuple[dict[str, object], bool]:
     resolved_session_id = session_id or str(uuid.uuid4())
     existing = find_session_result(resolved_session_id) if session_id else None
     client = AgentkitToolsClient()
@@ -422,7 +422,7 @@ def ensure_sandbox_session(
         )
         if result:
             save_session_result(result)
-            return result
+            return result, False
 
         synced_tool_id = sync_remote_sessions(
             session_id=resolved_session_id,
@@ -443,7 +443,7 @@ def ensure_sandbox_session(
             )
             if result:
                 save_session_result(result)
-                return result
+                return result, False
 
     result = _create_session(
         client,
@@ -453,4 +453,21 @@ def ensure_sandbox_session(
         envs=envs,
     )
     save_session_result(result)
+    return result, True
+
+
+def ensure_sandbox_session(
+    session_id: Optional[str] = None,
+    tool_id: Optional[str] = None,
+    tool_type: str = DEFAULT_SANDBOX_TOOL_TYPE,
+    ttl: Optional[int] = None,
+    envs: Optional[list[tools_types.EnvsItemForCreateSession]] = None,
+) -> dict[str, object]:
+    result, _is_new = ensure_sandbox_session_with_status(
+        session_id=session_id,
+        tool_id=tool_id,
+        tool_type=tool_type,
+        ttl=ttl,
+        envs=envs,
+    )
     return result

--- a/agentkit/toolkit/cli/sandbox/tool_resolve.py
+++ b/agentkit/toolkit/cli/sandbox/tool_resolve.py
@@ -24,6 +24,10 @@ from typing import Optional
 
 from agentkit.sdk.tools.client import AgentkitToolsClient
 from agentkit.sdk.tools import types as tools_types
+from agentkit.toolkit.cli.sandbox.model_config import (
+    MODEL_PROVIDER_ENV,
+    model_provider_from_env_value,
+)
 from agentkit.toolkit.cli.sandbox.utils import error
 
 SANDBOX_TOOL_STORE_PATH = Path(".agentkit") / "sandbox" / "tools.json"
@@ -92,18 +96,39 @@ def _get_tool_payload(response: object) -> object:
     return response
 
 
+def _get_tool_env_value(payload: object, key: str) -> object:
+    envs = _get_field_value(payload, "Envs", "envs") or []
+    if not isinstance(envs, list):
+        return None
+
+    for env in envs:
+        env_key = _get_field_value(env, "Key", "key")
+        if env_key == key:
+            return _get_field_value(env, "Value", "value")
+    return None
+
+
+def _get_tool_model_provider(payload: object) -> str | None:
+    return model_provider_from_env_value(
+        _get_tool_env_value(payload, MODEL_PROVIDER_ENV)
+    )
+
+
 def _build_tool_record(tool: object, tool_type: str) -> dict[str, object] | None:
     payload = _get_tool_payload(tool)
     tool_id = _get_string_field(payload, "ToolId", "tool_id")
     if not isinstance(tool_id, str) or not tool_id.strip():
         return None
-
-    return {
+    record = {
         "ToolId": tool_id.strip(),
         "ToolType": _get_field_value(payload, "ToolType", "tool_type") or tool_type,
         "Name": _get_field_value(payload, "Name", "name"),
         "Status": _get_field_value(payload, "Status", "status"),
     }
+    model_provider = _get_tool_model_provider(payload)
+    if model_provider:
+        record["ModelProvider"] = model_provider
+    return record
 
 
 def _get_string_value(result: dict[str, object], *keys: str) -> str | None:
@@ -205,12 +230,18 @@ def _normalize_tool_record(
     if not tool_id:
         error("Tool result missing ToolId")
 
-    return {
+    stored = {
         "ToolId": tool_id,
         "Name": _get_string_value(result, "Name", "name") or "",
         "Status": _get_string_value(result, "Status", "status") or "",
         "ToolType": resolved_tool_type,
     }
+    model_provider = model_provider_from_env_value(
+        _get_string_value(result, "ModelProvider", "model_provider")
+    )
+    if model_provider:
+        stored["ModelProvider"] = model_provider
+    return stored
 
 
 def save_tool_result(tool_type: str, result: dict[str, object]) -> None:
@@ -238,6 +269,39 @@ def find_tool_result(tool_type: str) -> dict[str, object] | None:
         error(f"Invalid sandbox tool record: {resolved_tool_type}")
 
     return result
+
+
+def find_tool_model_provider(
+    *,
+    tool_id: Optional[str],
+    tool_type: str | SandboxToolType | None,
+) -> str | None:
+    result = find_tool_result(normalize_tool_type(tool_type))
+    if not result:
+        return None
+
+    cached_tool_id = _get_string_value(result, "ToolId", "tool_id")
+    if tool_id and cached_tool_id != tool_id:
+        return None
+    return model_provider_from_env_value(
+        _get_string_value(result, "ModelProvider", "model_provider")
+    )
+
+
+def get_remote_tool_model_provider(
+    client: AgentkitToolsClient,
+    tool_id: str,
+    *,
+    tool_type: str | SandboxToolType | None,
+) -> str | None:
+    response = client.get_tool(tools_types.GetToolRequest(tool_id=tool_id))
+    record = _build_tool_record(response, normalize_tool_type(tool_type))
+    if record:
+        save_tool_result(normalize_tool_type(tool_type), record)
+        return model_provider_from_env_value(
+            _get_string_value(record, "ModelProvider", "model_provider")
+        )
+    return None
 
 
 def _get_cached_tool_id(tool_type: str) -> str | None:

--- a/agentkit/version.py
+++ b/agentkit/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.6.2"
+VERSION = "0.6.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentkit-sdk-python"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python SDK for transforming any AI agent into a production-ready application. Framework-agnostic primitives for runtime, memory, authentication, and tools with volcengine-managed infrastructure."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/platform/test_configuration_endpoints.py
+++ b/tests/platform/test_configuration_endpoints.py
@@ -111,6 +111,18 @@ class TestConfigurationEndpoints:
         # cr.{region}.volcengineapi.com -> cr.us-east-1.volcengineapi.com
         assert cr_ep.host == "cr.us-east-1.volcengineapi.com"
 
+    def test_explicit_region_overrides_service_specific_region(
+        self, clean_env, mock_global_config
+    ):
+        """Explicit region must win over service-specific env/config overrides."""
+        os.environ["VOLCENGINE_AGENTKIT_REGION"] = "cn-guangzhou"
+        mock_global_config.update({"services": {"agentkit": {"region": "cn-hangzhou"}}})
+
+        config = VolcConfiguration(region="cn-shanghai")
+        ep = config.get_service_endpoint("agentkit")
+
+        assert ep.region == "cn-shanghai"
+
     def test_endpoint_unknown_service(self, clean_env, mock_global_config):
         """Test that unknown service raises ValueError."""
         config = VolcConfiguration()

--- a/tests/toolkit/cli/test_cli_create_tool.py
+++ b/tests/toolkit/cli/test_cli_create_tool.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from typer.testing import CliRunner
@@ -146,12 +147,31 @@ class _FakeTOSService:
         )
 
 
+class _FakePlatformConfig:
+    endpoint_regions = {"agentkit": "cn-beijing", "tos": "cn-beijing"}
+
+    def get_service_endpoint(self, service_key):
+        return SimpleNamespace(region=self.endpoint_regions[service_key])
+
+
 def _reset_fake_tools_client():
     _FakeToolsClient.instances = []
     _FakeToolsClient.last_request = None
     _FakeToolsClient.get_statuses = ["Ready"]
     _FakeToolsClient.get_call_count = 0
     _FakeTOSService.instances = []
+    _FakePlatformConfig.endpoint_regions = {
+        "agentkit": "cn-beijing",
+        "tos": "cn-beijing",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _use_platform_config(monkeypatch):
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "VolcConfiguration", _FakePlatformConfig)
 
 
 def test_create_command_skips_tos_mount_by_default(
@@ -201,8 +221,43 @@ def test_create_command_uses_region_envs(monkeypatch):
     from agentkit.toolkit.cli.sandbox import cli_create
 
     _reset_fake_tools_client()
+    _FakePlatformConfig.endpoint_regions = {
+        "agentkit": "platform-agentkit-region",
+        "tos": "platform-tos-region",
+    }
     monkeypatch.setenv("AGENTKIT_SANDBOX_REGION", " cn-shanghai ")
     monkeypatch.setenv("AGENTKIT_SANDBOX_TOS_REGION", " cn-guangzhou ")
+    monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "--tool-name",
+            "demo-tool",
+            "--tos-bucket",
+            "my-bucket",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert _FakeToolsClient.instances[0].region == "cn-shanghai"
+    assert _FakeTOSService.instances[0].config.region == "cn-guangzhou"
+
+
+def test_create_command_falls_back_to_platform_regions(monkeypatch):
+    from agentkit.toolkit.cli.cli import app
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    _FakePlatformConfig.endpoint_regions = {
+        "agentkit": "cn-shanghai",
+        "tos": "cn-guangzhou",
+    }
+    monkeypatch.delenv("AGENTKIT_SANDBOX_REGION", raising=False)
+    monkeypatch.delenv("AGENTKIT_SANDBOX_TOS_REGION", raising=False)
     monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
     monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
 
@@ -303,7 +358,8 @@ def test_create_command_rejects_invalid_cpu(monkeypatch):
     )
 
     assert result.exit_code != 0
-    assert "--cpu must be one of: 2, 4, 8, 16" in result.output
+    assert "--cpu must be one of: 2, 4, 8" in result.output
+    assert "16" in result.output
     assert _FakeToolsClient.instances == []
     assert _FakeTOSService.instances == []
 

--- a/tests/toolkit/cli/test_cli_create_tool.py
+++ b/tests/toolkit/cli/test_cli_create_tool.py
@@ -24,6 +24,10 @@ runner = CliRunner()
 _PLACEHOLDER_A = "example-value-a"
 _PLACEHOLDER_B = "example-value-b"
 _PLACEHOLDER_MODEL_VALUE = "example-model-value"
+_DEFAULT_BROWSER_EXTRA_ARGS = (
+    "--enable-unsafe-swiftshader --use-gl=angle "
+    "--use-angle=swiftshader-webgl --ignore-gpu-blocklist"
+)
 
 
 @pytest.fixture
@@ -212,6 +216,7 @@ def test_create_command_skips_tos_mount_by_default(
             "Name": "demo-tool",
             "Status": "Ready",
             "ToolType": "SkillEnv",
+            "ModelProvider": "model_square",
         }
     }
 
@@ -389,6 +394,7 @@ def test_create_command_help_omits_model_base_url_option():
     result = runner.invoke(app, ["sandbox", "create", "--help"])
 
     assert result.exit_code == 0
+    assert "--model-provider" in result.output
     assert "--model-base-url" not in result.output
 
 
@@ -520,14 +526,15 @@ def test_build_create_tool_request_adds_model_envs(monkeypatch):
         name="demo-tool",
         tos_bucket="my-bucket",
         tos_region="cn-beijing",
-        model_name="claude-sonnet-4",
+        model_name="deepseek-v4-pro-260425",
         **{"model_" + "api_key": _PLACEHOLDER_MODEL_VALUE},
     )
 
     assert [(item.key, item.value) for item in request.envs] == [
-        ("OPENCODE_MODEL", "claude-sonnet-4"),
-        ("CODEX_MODEL", "claude-sonnet-4"),
-        ("ANTHROPIC_MODEL", "claude-sonnet-4"),
+        ("AGENTKIT_SANDBOX_MODEL_PROVIDER", "model_square"),
+        ("OPENCODE_MODEL", "deepseek-v4-pro-260425"),
+        ("CODEX_MODEL", "deepseek-v4-pro-260425"),
+        ("ANTHROPIC_MODEL", "deepseek-v4-pro-260425"),
         ("OPENCODE_API_KEY", _PLACEHOLDER_MODEL_VALUE),
         ("CODEX_API_KEY", _PLACEHOLDER_MODEL_VALUE),
         ("ANTHROPIC_AUTH_TOKEN", _PLACEHOLDER_MODEL_VALUE),
@@ -541,6 +548,7 @@ def test_build_create_tool_request_adds_model_envs(monkeypatch):
         ("DISABLE_JUPYTER", "true"),
         ("DISABLE_CODE_SERVER", "true"),
         ("DISABLE_NODEJS_REPL", "true"),
+        ("BROWSER_EXTRA_ARGS", _DEFAULT_BROWSER_EXTRA_ARGS),
     ]
 
 
@@ -555,16 +563,17 @@ def test_build_create_tool_request_adds_code_env_config_envs(monkeypatch):
         name="demo-tool",
         tos_bucket="my-bucket",
         tos_region="cn-beijing",
-        model_name="claude-sonnet-4",
+        model_name="deepseek-v4-pro-260425",
     )
 
     envs = {item.key: item.value for item in request.envs}
+    assert envs["BROWSER_EXTRA_ARGS"] == _DEFAULT_BROWSER_EXTRA_ARGS
     assert envs["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
     assert envs["HOME"] == "/home/gem"
     assert envs["CODEX_HOME"] == "/home/gem/.codex"
     config_toml = envs["CODEX_CONFIG_TOML"]
-    assert 'model = "claude-sonnet-4"' in config_toml
-    assert 'review_model = "claude-sonnet-4"' in config_toml
+    assert 'model = "deepseek-v4-pro-260425"' in config_toml
+    assert 'review_model = "deepseek-v4-pro-260425"' in config_toml
     assert 'model = "deepseek-v4-flash-260425"' not in config_toml
     assert (
         'model_catalog_json = "/home/gem/.codex/model-catalog.json"'
@@ -597,11 +606,88 @@ def test_build_create_tool_request_adds_code_env_config_envs(monkeypatch):
     assert "\n  " in catalog_json
     catalog = json.loads(catalog_json)
     models = catalog["models"]
-    assert models[0]["slug"] == "claude-sonnet-4"
-    assert models[0]["display_name"] == "claude-sonnet-4"
+    assert models[0]["slug"] == "deepseek-v4-pro-260425"
+    assert models[0]["display_name"] == "deepseek-v4-pro-260425"
     assert "deepseek-v4-flash-260425" in [model["slug"] for model in models]
     assert "doubao-seed-2-0-pro-260215" in [model["slug"] for model in models]
     assert models[0]["truncation_policy"] == {"mode": "tokens", "limit": 10000}
+
+
+def test_build_create_tool_request_uses_model_provider(monkeypatch):
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    request = cli_create._build_create_tool_request(
+        tool_type="CodeEnv",
+        name="demo-tool",
+        tos_bucket="my-bucket",
+        tos_region="cn-beijing",
+        model_provider="coding_plan",
+    )
+
+    envs = {item.key: item.value for item in request.envs}
+    assert envs["OPENCODE_MODEL"] == "deepseek-v4-flash"
+    assert envs["CODEX_MODEL"] == "deepseek-v4-flash"
+    assert envs["ANTHROPIC_MODEL"] == "deepseek-v4-flash"
+    assert envs["OPENCODE_BASE_URL"] == (
+        "https://ark.cn-beijing.volces.com/api/coding/v3"
+    )
+    assert envs["CODEX_BASE_URL"] == (
+        "https://ark.cn-beijing.volces.com/api/coding/v3"
+    )
+    assert envs["MODEL_BASE_URL"] == (
+        "https://ark.cn-beijing.volces.com/api/coding/v3"
+    )
+    assert envs["ANTHROPIC_BASE_URL"] == (
+        "https://ark.cn-beijing.volces.com/api/coding"
+    )
+    assert (
+        'base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"'
+        in envs["CODEX_CONFIG_TOML"]
+    )
+
+    catalog = json.loads(envs["CODEX_MODEL_CATALOG_JSON"])
+    models = {model["slug"]: model for model in catalog["models"]}
+    assert "deepseek-v4-flash" in models
+    assert "deepseek-v4-flash-260425" not in models
+    assert models["glm-5.2"]["supports_reasoning_summaries"] is False
+    glm_reasoning_levels = models["glm-5.2"]["supported_reasoning_levels"]
+    assert [level["effort"] for level in glm_reasoning_levels] == [
+        "low",
+        "medium",
+        "high",
+    ]
+
+
+def test_build_create_tool_request_allows_custom_model_name(monkeypatch):
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    request = cli_create._build_create_tool_request(
+        tool_type="CodeEnv",
+        name="demo-tool",
+        tos_bucket="my-bucket",
+        tos_region="cn-beijing",
+        model_provider="agent_plan",
+        model_name="deepseek-v4-flash-260428",
+    )
+
+    envs = {item.key: item.value for item in request.envs}
+    assert envs["OPENCODE_MODEL"] == "deepseek-v4-flash-260428"
+    assert envs["CODEX_MODEL"] == "deepseek-v4-flash-260428"
+    assert envs["ANTHROPIC_MODEL"] == "deepseek-v4-flash-260428"
+    assert (
+        'base_url = "https://ark.cn-beijing.volces.com/api/plan/v3"'
+        in envs["CODEX_CONFIG_TOML"]
+    )
+    catalog = json.loads(envs["CODEX_MODEL_CATALOG_JSON"])
+    assert catalog["models"][0]["slug"] == "deepseek-v4-flash-260428"
+    assert catalog["models"][0]["supports_reasoning_summaries"] is True
+    assert catalog["models"][0]["max_context_window"] == 1000000
 
 
 def test_build_create_tool_request_uses_model_api_key_env(monkeypatch):
@@ -692,6 +778,7 @@ def test_build_create_tool_request_adds_default_model_base_url(monkeypatch):
     )
 
     assert [(item.key, item.value) for item in request.envs] == [
+        ("AGENTKIT_SANDBOX_MODEL_PROVIDER", "model_square"),
         ("OPENCODE_MODEL", "deepseek-v4-flash-260425"),
         ("CODEX_MODEL", "deepseek-v4-flash-260425"),
         ("ANTHROPIC_MODEL", "deepseek-v4-flash-260425"),
@@ -705,6 +792,7 @@ def test_build_create_tool_request_adds_default_model_base_url(monkeypatch):
         ("DISABLE_JUPYTER", "true"),
         ("DISABLE_CODE_SERVER", "true"),
         ("DISABLE_NODEJS_REPL", "true"),
+        ("BROWSER_EXTRA_ARGS", _DEFAULT_BROWSER_EXTRA_ARGS),
     ]
 
 

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -674,7 +674,7 @@ def test_ensure_sandbox_session_passes_envs_to_create_session(
     )
     _patch_store_path(monkeypatch, tmp_path)
     envs = session_create.build_model_envs(
-        model_name="claude-sonnet-4",
+        model_name="deepseek-v4-pro-260425",
         **{"model_" + "api_key": "model-value"},
     )
 
@@ -686,9 +686,9 @@ def test_ensure_sandbox_session_passes_envs_to_create_session(
 
     request_envs = _FakeToolsClient.last_request.envs
     assert [(item.key, item.value) for item in request_envs] == [
-        ("OPENCODE_MODEL", "claude-sonnet-4"),
-        ("CODEX_MODEL", "claude-sonnet-4"),
-        ("ANTHROPIC_MODEL", "claude-sonnet-4"),
+        ("OPENCODE_MODEL", "deepseek-v4-pro-260425"),
+        ("CODEX_MODEL", "deepseek-v4-pro-260425"),
+        ("ANTHROPIC_MODEL", "deepseek-v4-pro-260425"),
         ("OPENCODE_API_KEY", "model-value"),
         ("CODEX_API_KEY", "model-value"),
         ("ANTHROPIC_AUTH_TOKEN", "model-value"),
@@ -700,12 +700,12 @@ def test_build_model_envs_uses_model_api_key_env(monkeypatch) -> None:
 
     monkeypatch.setenv("MODEL_API_KEY", "env-model-value")
 
-    envs = session_create.build_model_envs(model_name="claude-sonnet-4")
+    envs = session_create.build_model_envs(model_name="deepseek-v4-pro-260425")
 
     assert [(item.key, item.value) for item in envs] == [
-        ("OPENCODE_MODEL", "claude-sonnet-4"),
-        ("CODEX_MODEL", "claude-sonnet-4"),
-        ("ANTHROPIC_MODEL", "claude-sonnet-4"),
+        ("OPENCODE_MODEL", "deepseek-v4-pro-260425"),
+        ("CODEX_MODEL", "deepseek-v4-pro-260425"),
+        ("ANTHROPIC_MODEL", "deepseek-v4-pro-260425"),
         ("OPENCODE_API_KEY", "env-model-value"),
         ("CODEX_API_KEY", "env-model-value"),
         ("ANTHROPIC_AUTH_TOKEN", "env-model-value"),
@@ -2891,8 +2891,10 @@ def test_cli_exec_passes_model_options_to_session_create(
             "user-1",
             "--tool-type",
             "SkillEnv",
+            "--model-provider",
+            "coding_plan",
             "--model-name",
-            "claude-sonnet-4",
+            "glm-5.2",
             "--model-api-key",
             "model-value",
         ],
@@ -2902,16 +2904,21 @@ def test_cli_exec_passes_model_options_to_session_create(
     assert captured_session["session_id"] == "user-1"
     assert captured_session["tool_type"] == "SkillEnv"
     assert [(item.key, item.value) for item in captured_session["envs"]] == [
-        ("OPENCODE_MODEL", "claude-sonnet-4"),
-        ("CODEX_MODEL", "claude-sonnet-4"),
-        ("ANTHROPIC_MODEL", "claude-sonnet-4"),
+        ("AGENTKIT_SANDBOX_MODEL_PROVIDER", "coding_plan"),
+        ("OPENCODE_MODEL", "glm-5.2"),
+        ("CODEX_MODEL", "glm-5.2"),
+        ("ANTHROPIC_MODEL", "glm-5.2"),
+        ("OPENCODE_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+        ("CODEX_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+        ("MODEL_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+        ("ANTHROPIC_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding"),
         ("OPENCODE_API_KEY", "model-value"),
         ("CODEX_API_KEY", "model-value"),
         ("ANTHROPIC_AUTH_TOKEN", "model-value"),
     ]
 
 
-def test_cli_exec_syncs_codex_config_for_code_env_model_name(
+def test_cli_exec_model_name_without_provider_syncs_codex_config(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -2951,7 +2958,7 @@ def test_cli_exec_syncs_codex_config_for_code_env_model_name(
             "--session-id",
             "user-1",
             "--model-name",
-            "claude-sonnet-4",
+            "glm-5.2",
         ],
     )
 
@@ -2964,12 +2971,164 @@ def test_cli_exec_syncs_codex_config_for_code_env_model_name(
         "CODEX_CONFIG_TOML",
         "CODEX_MODEL_CATALOG_JSON",
     ]
-    config_toml = envs["CODEX_CONFIG_TOML"]
-    assert 'model = "claude-sonnet-4"' in config_toml
-    assert 'review_model = "claude-sonnet-4"' in config_toml
-    assert 'model = "deepseek-v4-flash-260425"' not in config_toml
+    assert envs["OPENCODE_MODEL"] == "glm-5.2"
+    assert envs["CODEX_MODEL"] == "glm-5.2"
+    assert envs["ANTHROPIC_MODEL"] == "glm-5.2"
+    assert 'model_provider = "model_square"' in envs["CODEX_CONFIG_TOML"]
+    assert '[model_providers.model_square]' in envs["CODEX_CONFIG_TOML"]
     catalog = json.loads(envs["CODEX_MODEL_CATALOG_JSON"])
-    assert catalog["models"][0]["slug"] == "claude-sonnet-4"
+    assert catalog["models"][0]["slug"] == "glm-5.2"
+
+
+def test_cli_exec_model_name_uses_cached_tool_model_provider(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
+
+    monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    store_path = _patch_store_path(monkeypatch, tmp_path)
+    tool_store_path = _patch_tool_store_path(monkeypatch, tmp_path)
+    tool_store_path.parent.mkdir(parents=True, exist_ok=True)
+    tool_store_path.write_text(
+        json.dumps(
+            {
+                "CodeEnv": {
+                    "ToolId": "tool-1",
+                    "ToolType": "CodeEnv",
+                    "Name": "agent-plan-tool",
+                    "Status": "Ready",
+                    "ModelProvider": "agent_plan",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com/?token=abc",
+    }
+    store_path.write_text(
+        json.dumps({"user-1": stored_session}),
+        encoding="utf-8",
+    )
+    captured_session = {}
+    _patch_exec_session(
+        monkeypatch,
+        cli_exec,
+        stored_session,
+        capture=captured_session,
+    )
+    monkeypatch.setattr(
+        cli_exec,
+        "_connect_terminal",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--tool-id",
+            "tool-1",
+            "--session-id",
+            "user-1",
+            "--model-name",
+            "glm-5.2",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envs = {item.key: item.value for item in captured_session["envs"]}
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "agent_plan"
+    assert envs["CODEX_MODEL"] == "glm-5.2"
+    assert envs["CODEX_BASE_URL"] == (
+        "https://ark.cn-beijing.volces.com/api/plan/v3"
+    )
+    assert (
+        'model_provider = "agent_plan"'
+        in envs["CODEX_CONFIG_TOML"]
+    )
+    assert (
+        'base_url = "https://ark.cn-beijing.volces.com/api/plan/v3"'
+        in envs["CODEX_CONFIG_TOML"]
+    )
+
+
+def test_cli_exec_model_provider_sets_default_model_and_codex_config(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
+
+    monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    store_path = _patch_store_path(monkeypatch, tmp_path)
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com/?token=abc",
+    }
+    store_path.write_text(
+        json.dumps({"user-1": stored_session}),
+        encoding="utf-8",
+    )
+    captured_session = {}
+    _patch_exec_session(
+        monkeypatch,
+        cli_exec,
+        stored_session,
+        capture=captured_session,
+    )
+    monkeypatch.setattr(
+        cli_exec,
+        "_connect_terminal",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--session-id",
+            "user-1",
+            "--model-provider",
+            "agent_plan",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envs = {item.key: item.value for item in captured_session["envs"]}
+    assert envs["OPENCODE_MODEL"] == "deepseek-v4-flash"
+    assert envs["CODEX_MODEL"] == "deepseek-v4-flash"
+    assert envs["ANTHROPIC_MODEL"] == "deepseek-v4-flash"
+    assert envs["OPENCODE_BASE_URL"] == (
+        "https://ark.cn-beijing.volces.com/api/plan/v3"
+    )
+    assert envs["ANTHROPIC_BASE_URL"] == (
+        "https://ark.cn-beijing.volces.com/api/plan"
+    )
+    assert (
+        'base_url = "https://ark.cn-beijing.volces.com/api/plan/v3"'
+        in envs["CODEX_CONFIG_TOML"]
+    )
+    catalog = json.loads(envs["CODEX_MODEL_CATALOG_JSON"])
+    models = {model["slug"]: model for model in catalog["models"]}
+    assert "deepseek-v4-flash" in models
+    assert "deepseek-v4-flash-260425" not in models
+    assert models["glm-5.2"]["supports_reasoning_summaries"] is False
+    glm_reasoning_levels = models["glm-5.2"]["supported_reasoning_levels"]
+    assert [level["effort"] for level in glm_reasoning_levels] == [
+        "low",
+        "medium",
+        "high",
+    ]
 
 
 def test_cli_exec_rejects_model_base_url_option() -> None:

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -2068,6 +2068,195 @@ def test_cli_shell_uploads_sources_before_command(monkeypatch, tmp_path) -> None
     assert payload["data"]["shell_id"] == "shell-1"
 
 
+def test_cli_shell_git_config_file_reuses_returned_shell_id(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_shell as cli_shell
+    import agentkit.toolkit.cli.sandbox.git_config as git_config
+
+    config_path = tmp_path / "git.json"
+    config_path.write_text(
+        json.dumps({"user": {"name": "Ada Lovelace", "email": "ada@example.com"}}),
+        encoding="utf-8",
+    )
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com",
+    }
+    _patch_shell_session(monkeypatch, cli_shell, stored_session)
+    events = []
+
+    def fake_exec_shell_command(session, command, *, shell_id="", **_kwargs):
+        events.append(("git-config", session, command, shell_id))
+        return {"data": {"session_id": "shell-from-git", "exit_code": 0}}
+
+    class FakeResponse:
+        text = '{"success": true}'
+
+        def json(self):
+            return {
+                "success": True,
+                "data": {
+                    "session_id": "shell-from-git",
+                    "status": "completed",
+                    "output": "done",
+                    "exit_code": 0,
+                },
+            }
+
+    def fake_post(url, json, timeout):
+        events.append(("post", url, json, timeout))
+        return FakeResponse()
+
+    monkeypatch.setattr(git_config, "_exec_shell_command", fake_exec_shell_command)
+    monkeypatch.setattr(cli_shell.requests, "post", fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "shell",
+            "--session-id",
+            "user-1",
+            "--git-config",
+            str(config_path),
+            "--command",
+            "git status",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert events == [
+        (
+            "git-config",
+            stored_session,
+            "git config --global user.name 'Ada Lovelace'; "
+            "git config --global user.email ada@example.com",
+            "",
+        ),
+        (
+            "post",
+            "https://sandbox.example.com/v1/shell/exec",
+            {"id": "shell-from-git", "exec_dir": "", "command": "git status"},
+            cli_shell.SANDBOX_EXEC_TIMEOUT_SECONDS,
+        ),
+    ]
+    payload = json.loads(result.output)
+    assert payload["data"]["shell_id"] == "shell-from-git"
+
+
+def test_cli_shell_git_config_missing_file_errors(monkeypatch, tmp_path) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_shell as cli_shell
+
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com",
+    }
+    _patch_shell_session(monkeypatch, cli_shell, stored_session)
+    posted = {"value": False}
+    monkeypatch.setattr(
+        cli_shell.requests,
+        "post",
+        lambda *_args, **_kwargs: posted.update(value=True),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "shell",
+            "--session-id",
+            "user-1",
+            "--git-config",
+            str(tmp_path / "missing.ini"),
+            "--command",
+            "git status",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Git config file not found" in result.output
+    assert posted["value"] is False
+
+
+def test_resolve_git_config_local_reads_git_values(monkeypatch) -> None:
+    import agentkit.toolkit.cli.sandbox.git_config as git_config
+
+    calls = []
+
+    class FakeCompletedProcess:
+        def __init__(self, stdout="", stderr="", returncode=0):
+            self.stdout = stdout
+            self.stderr = stderr
+            self.returncode = returncode
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        if args == ["git", "config", "--list"]:
+            return FakeCompletedProcess(
+                stdout="user.name=Ada Lovelace\nuser.email=ada@example.com\n"
+            )
+        if args == ["git", "config", "--get", "user.name"]:
+            return FakeCompletedProcess(stdout="Ada Lovelace\n")
+        if args == ["git", "config", "--get", "user.email"]:
+            return FakeCompletedProcess(stdout="ada@example.com\n")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(git_config.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(git_config.subprocess, "run", fake_run)
+
+    assert git_config.resolve_git_config("local") == (
+        "Ada Lovelace",
+        "ada@example.com",
+    )
+    assert calls == [
+        ["git", "config", "--list"],
+        ["git", "config", "--get", "user.name"],
+        ["git", "config", "--get", "user.email"],
+    ]
+
+
+def test_resolve_git_config_local_rejects_empty_git_config(monkeypatch) -> None:
+    import agentkit.toolkit.cli.sandbox.git_config as git_config
+
+    class FakeCompletedProcess:
+        stdout = ""
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(git_config.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        git_config.subprocess,
+        "run",
+        lambda *_args, **_kwargs: FakeCompletedProcess(),
+    )
+
+    with pytest.raises(ValueError, match="Local git config is empty"):
+        git_config.resolve_git_config("local")
+
+
+def test_resolve_git_config_ini_supports_flat_user_keys(tmp_path) -> None:
+    import agentkit.toolkit.cli.sandbox.git_config as git_config
+
+    config_path = tmp_path / "gitconfig"
+    config_path.write_text(
+        "user.name = Ada Lovelace\nuser.email = ada@example.com\n",
+        encoding="utf-8",
+    )
+
+    assert git_config.resolve_git_config(str(config_path)) == (
+        "Ada Lovelace",
+        "ada@example.com",
+    )
+
+
 def test_cli_shell_rejects_extra_source_without_src_dir(
     monkeypatch,
     tmp_path,
@@ -2262,6 +2451,73 @@ def test_cli_exec_runs_command_option(monkeypatch, tmp_path) -> None:
     assert result.exit_code == 0
     assert captured["ws_url"] == "ws://sandbox.example.com/v1/shell/ws?token=abc"
     assert captured["initial_command"] == "codex"
+
+
+def test_cli_exec_git_config_file_does_not_reuse_shell_exec_id_for_ws(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
+    import agentkit.toolkit.cli.sandbox.git_config as git_config
+
+    config_path = tmp_path / "git.toml"
+    config_path.write_text(
+        '[user]\nname = "Ada Lovelace"\nemail = "ada@example.com"\n',
+        encoding="utf-8",
+    )
+    store_path = _patch_store_path(monkeypatch, tmp_path)
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com/?token=abc",
+    }
+    store_path.write_text(
+        json.dumps({"user-1": stored_session}),
+        encoding="utf-8",
+    )
+    _patch_exec_session(monkeypatch, cli_exec, stored_session)
+    captured = {}
+
+    def fake_exec_shell_command(session, command, *, shell_id="", **_kwargs):
+        captured["git_config"] = (session, command, shell_id)
+        return {"data": {"session_id": "shell-from-git", "exit_code": 0}}
+
+    def fake_connect(ws_url, initial_command, on_shell_id=None):
+        captured["ws_url"] = ws_url
+        captured["initial_command"] = initial_command
+        captured["on_shell_id"] = on_shell_id
+
+    monkeypatch.setattr(git_config, "_exec_shell_command", fake_exec_shell_command)
+    monkeypatch.setattr(cli_exec, "_connect_terminal", fake_connect)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--session-id",
+            "user-1",
+            "--git-config",
+            str(config_path),
+            "--command",
+            "codex",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["git_config"] == (
+        stored_session,
+        "git config --global user.name 'Ada Lovelace'; "
+        "git config --global user.email ada@example.com",
+        "",
+    )
+    assert captured["ws_url"] == "ws://sandbox.example.com/v1/shell/ws?token=abc"
+    assert captured["initial_command"] == "codex"
+    assert captured["on_shell_id"] is not None
+    stored = json.loads(store_path.read_text(encoding="utf-8"))
+    assert "terminal_shell_id" not in stored["user-1"]
 
 
 def test_cli_exec_uploads_directory_before_connecting(

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -1635,6 +1635,7 @@ def test_cli_get_missing_session_includes_resolved_tool_id(
 def test_cli_web_returns_session_browser_url(monkeypatch, tmp_path) -> None:
     from agentkit.toolkit.cli.cli import app
     import agentkit.toolkit.cli.sandbox.cli_web as cli_web
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
 
     store_path = _patch_store_path(monkeypatch, tmp_path)
     store_path.write_text(
@@ -1651,25 +1652,18 @@ def test_cli_web_returns_session_browser_url(monkeypatch, tmp_path) -> None:
         encoding="utf-8",
     )
     monkeypatch.setattr(
-        cli_web,
+        session_create,
         "AgentkitToolsClient",
         lambda: _FakeToolsClient(),
     )
-    _FakeToolsClient.list_sessions_responses = [
-        _FakeListSessionsResponse(
-            [
-                _FakeSessionInfo(
-                    user_session_id="user-1",
-                    session_id="instance-1",
-                    endpoint=(
-                        "https://sandbox.example.com/base?"
-                        "faasInstanceName=vefaas-test-sandbox&"
-                        "Authorization=auth-token&resize=none"
-                    ),
-                )
-            ]
-        )
-    ]
+    _FakeToolsClient.get_response = _FakeGetSessionResponse()
+    _FakeToolsClient.get_response.user_session_id = "user-1"
+    _FakeToolsClient.get_response.session_id = "instance-1"
+    _FakeToolsClient.get_response.endpoint = (
+        "https://sandbox.example.com/base?"
+        "faasInstanceName=vefaas-test-sandbox&"
+        "Authorization=auth-token&resize=none"
+    )
     opened_urls = []
     monkeypatch.setattr(
         cli_web.webbrowser,
@@ -1693,6 +1687,7 @@ def test_cli_web_returns_session_browser_url(monkeypatch, tmp_path) -> None:
         ),
         "tool_id": "tool-1",
         "session_id": "user-1",
+        "is_new": False,
     }
     assert opened_urls == [json.loads(result.output)["url"]]
 
@@ -1703,6 +1698,7 @@ def test_cli_web_uses_stored_tool_id_when_tool_id_omitted(
 ) -> None:
     from agentkit.toolkit.cli.cli import app
     import agentkit.toolkit.cli.sandbox.cli_web as cli_web
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
 
     store_path = _patch_store_path(monkeypatch, tmp_path)
     store_path.write_text(
@@ -1719,21 +1715,14 @@ def test_cli_web_uses_stored_tool_id_when_tool_id_omitted(
         encoding="utf-8",
     )
     monkeypatch.setattr(
-        cli_web,
+        session_create,
         "AgentkitToolsClient",
         lambda: _FakeToolsClient(),
     )
-    _FakeToolsClient.list_sessions_responses = [
-        _FakeListSessionsResponse(
-            [
-                _FakeSessionInfo(
-                    user_session_id="user-1",
-                    session_id="instance-1",
-                    endpoint="https://sandbox.example.com",
-                )
-            ]
-        )
-    ]
+    _FakeToolsClient.get_response = _FakeGetSessionResponse()
+    _FakeToolsClient.get_response.user_session_id = "user-1"
+    _FakeToolsClient.get_response.session_id = "instance-1"
+    _FakeToolsClient.get_response.endpoint = "https://sandbox.example.com"
     opened_urls = []
     monkeypatch.setattr(
         cli_web.webbrowser,
@@ -1744,7 +1733,7 @@ def test_cli_web_uses_stored_tool_id_when_tool_id_omitted(
     result = runner.invoke(app, ["sandbox", "web", "--session-id", "user-1"])
 
     assert result.exit_code == 0
-    assert _FakeToolsClient.last_list_sessions_request.tool_id == "tool-stored"
+    assert _FakeToolsClient.last_get_request.tool_id == "tool-stored"
     assert json.loads(result.output) == {
         "url": (
             "https://sandbox.example.com/vnc/index.html?"
@@ -1752,6 +1741,7 @@ def test_cli_web_uses_stored_tool_id_when_tool_id_omitted(
         ),
         "tool_id": "tool-stored",
         "session_id": "user-1",
+        "is_new": False,
     }
     assert opened_urls == [json.loads(result.output)["url"]]
 
@@ -1762,10 +1752,11 @@ def test_cli_web_accepts_tool_id_underscore_alias(
 ) -> None:
     from agentkit.toolkit.cli.cli import app
     import agentkit.toolkit.cli.sandbox.cli_web as cli_web
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
 
     _patch_store_path(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        cli_web,
+        session_create,
         "AgentkitToolsClient",
         lambda: _FakeToolsClient(),
     )
@@ -1790,15 +1781,60 @@ def test_cli_web_accepts_tool_id_underscore_alias(
     assert result.exit_code == 0
     assert _FakeToolsClient.last_list_sessions_request.tool_id == "tool-1"
     assert json.loads(result.output)["tool_id"] == "tool-1"
+    assert json.loads(result.output)["is_new"] is False
+
+
+def test_cli_web_creates_missing_session_with_requested_id(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_web as cli_web
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
+
+    _patch_store_path(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        session_create,
+        "AgentkitToolsClient",
+        lambda: _FakeToolsClient(),
+    )
+    _FakeToolsClient.list_sessions_responses = [_FakeListSessionsResponse([])]
+
+    class CreatedResponse:
+        user_session_id = "user-1"
+        session_id = "instance-new"
+        endpoint = "https://sandbox.example.com"
+
+    _FakeToolsClient.response = CreatedResponse()
+    monkeypatch.setattr(cli_web.webbrowser, "open", lambda _url: True)
+
+    result = runner.invoke(
+        app,
+        ["sandbox", "web", "--session-id", "user-1", "--tool-id", "tool-1"],
+    )
+
+    assert result.exit_code == 0
+    assert _FakeToolsClient.create_call_count == 1
+    assert _FakeToolsClient.last_request.user_session_id == "user-1"
+    assert json.loads(result.output) == {
+        "url": (
+            "https://sandbox.example.com/vnc/index.html?"
+            "autoconnect=true&resize=scale&reconnect=1"
+        ),
+        "tool_id": "tool-1",
+        "session_id": "user-1",
+        "is_new": True,
+    }
 
 
 def test_cli_web_opens_default_browser(monkeypatch, tmp_path) -> None:
     from agentkit.toolkit.cli.cli import app
     import agentkit.toolkit.cli.sandbox.cli_web as cli_web
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
 
     _patch_store_path(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        cli_web,
+        session_create,
         "AgentkitToolsClient",
         lambda: _FakeToolsClient(),
     )
@@ -1842,16 +1878,18 @@ def test_cli_web_opens_default_browser(monkeypatch, tmp_path) -> None:
         "url": expected_url,
         "tool_id": "tool-1",
         "session_id": "user-1",
+        "is_new": False,
     }
 
 
 def test_cli_web_open_reports_browser_failure(monkeypatch, tmp_path) -> None:
     from agentkit.toolkit.cli.cli import app
     import agentkit.toolkit.cli.sandbox.cli_web as cli_web
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
 
     _patch_store_path(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        cli_web,
+        session_create,
         "AgentkitToolsClient",
         lambda: _FakeToolsClient(),
     )

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -2068,7 +2068,7 @@ def test_cli_shell_uploads_sources_before_command(monkeypatch, tmp_path) -> None
     assert payload["data"]["shell_id"] == "shell-1"
 
 
-def test_cli_shell_git_config_file_reuses_returned_shell_id(
+def test_cli_shell_git_config_file_does_not_reuse_shell_exec_id(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -2141,7 +2141,7 @@ def test_cli_shell_git_config_file_reuses_returned_shell_id(
         (
             "post",
             "https://sandbox.example.com/v1/shell/exec",
-            {"id": "shell-from-git", "exec_dir": "", "command": "git status"},
+            {"id": "", "exec_dir": "", "command": "git status"},
             cli_shell.SANDBOX_EXEC_TIMEOUT_SECONDS,
         ),
     ]

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -1035,6 +1035,19 @@ def test_sandbox_session_id_options_accept_aliases(args) -> None:
     assert "-s" in result.output
 
 
+@pytest.mark.parametrize(
+    "args",
+    [["sandbox", "shell", "--help"], ["sandbox", "exec", "--help"]],
+)
+def test_sandbox_shell_id_option_is_disabled(args) -> None:
+    from agentkit.toolkit.cli.cli import app
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0
+    assert "--shell-id" not in result.output
+
+
 def test_sandbox_commands_are_not_registered_at_top_level() -> None:
     from agentkit.toolkit.cli.cli import app
 
@@ -1995,8 +2008,6 @@ def test_cli_shell_posts_to_session_endpoint(monkeypatch, tmp_path) -> None:
             "echo 123",
             "--exec-dir",
             "/workspace",
-            "--shell-id",
-            "shell-1",
         ],
     )
 
@@ -2004,7 +2015,7 @@ def test_cli_shell_posts_to_session_endpoint(monkeypatch, tmp_path) -> None:
     assert captured_session["tool_type"] == "SkillEnv"
     assert captured["url"] == "https://sandbox.example.com/v1/shell/exec?token=abc"
     assert captured["json"] == {
-        "id": "shell-1",
+        "id": "",
         "exec_dir": "/workspace",
         "command": "echo 123",
     }
@@ -2012,6 +2023,28 @@ def test_cli_shell_posts_to_session_endpoint(monkeypatch, tmp_path) -> None:
     payload = json.loads(result.output)
     assert payload["data"]["shell_id"] == "shell-1"
     assert "session_id" not in payload["data"]
+
+
+def test_cli_shell_rejects_shell_id_option() -> None:
+    from agentkit.toolkit.cli.cli import app
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "shell",
+            "--session-id",
+            "user-1",
+            "--command",
+            "echo 123",
+            "--shell-id",
+            "shell-1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "No such option" in result.output
+    assert "--shell-id" in result.output
 
 
 def test_cli_shell_uploads_sources_before_command(monkeypatch, tmp_path) -> None:
@@ -3186,7 +3219,7 @@ def test_cli_exec_rejects_model_base_url_option() -> None:
     assert "No such option" in result.output
 
 
-def test_cli_exec_supports_shell_id_and_empty_command(
+def test_cli_exec_supports_empty_command(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -3220,8 +3253,6 @@ def test_cli_exec_supports_shell_id_and_empty_command(
             "exec",
             "--session-id",
             "user-1",
-            "--shell-id",
-            "shell-1",
             "--command",
             "",
         ],
@@ -3230,37 +3261,13 @@ def test_cli_exec_supports_shell_id_and_empty_command(
     assert result.exit_code == 0
     assert (
         captured["ws_url"]
-        == "ws://sandbox.example.com/base/v1/shell/ws?token=abc&session_id=shell-1"
+        == "ws://sandbox.example.com/base/v1/shell/ws?token=abc"
     )
     assert captured["initial_command"] == ""
 
 
-def test_cli_exec_does_not_restart_codex_for_shell_id(
-    monkeypatch,
-    tmp_path,
-) -> None:
+def test_cli_exec_rejects_shell_id_option() -> None:
     from agentkit.toolkit.cli.cli import app
-    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
-
-    store_path = _patch_store_path(monkeypatch, tmp_path)
-    stored_session = {
-        "session_id": "user-1",
-        "tool_id": "tool-1",
-        "instance_id": "session-1",
-        "endpoint": "https://sandbox.example.com/?token=abc",
-    }
-    store_path.write_text(
-        json.dumps({"user-1": stored_session}),
-        encoding="utf-8",
-    )
-    _patch_exec_session(monkeypatch, cli_exec, stored_session)
-    captured = {}
-
-    def fake_connect(ws_url, initial_command, on_shell_id=None):
-        captured["ws_url"] = ws_url
-        captured["initial_command"] = initial_command
-
-    monkeypatch.setattr(cli_exec, "_connect_terminal", fake_connect)
 
     result = runner.invoke(
         app,
@@ -3274,8 +3281,9 @@ def test_cli_exec_does_not_restart_codex_for_shell_id(
         ],
     )
 
-    assert result.exit_code == 0
-    assert captured["initial_command"] is None
+    assert result.exit_code != 0
+    assert "No such option" in result.output
+    assert "--shell-id" in result.output
 
 
 def test_cli_exec_clears_remote_shell_id_on_disconnect(
@@ -3354,51 +3362,6 @@ def test_cli_exec_does_not_clear_newer_shell_id(
     assert result.exit_code == 0
     stored = json.loads(store_path.read_text(encoding="utf-8"))
     assert stored["user-1"]["terminal_shell_id"] == ["shell-from-newer-terminal"]
-
-
-def test_cli_exec_clears_shell_id_option_on_disconnect(
-    monkeypatch,
-    tmp_path,
-) -> None:
-    from agentkit.toolkit.cli.cli import app
-    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
-
-    store_path = _patch_store_path(monkeypatch, tmp_path)
-    stored_session = {
-        "session_id": "user-1",
-        "tool_id": "tool-1",
-        "instance_id": "session-1",
-        "endpoint": "https://sandbox.example.com/?token=abc",
-        "terminal_shell_id": ["shell-from-cli"],
-    }
-    store_path.write_text(
-        json.dumps({"user-1": stored_session}, indent=2),
-        encoding="utf-8",
-    )
-    _patch_exec_session(monkeypatch, cli_exec, stored_session)
-
-    def fake_connect(_ws_url, initial_command=None, on_shell_id=None):
-        assert on_shell_id is not None
-        stored = json.loads(store_path.read_text(encoding="utf-8"))
-        assert stored["user-1"]["terminal_shell_id"] == ["shell-from-cli"]
-
-    monkeypatch.setattr(cli_exec, "_connect_terminal", fake_connect)
-
-    result = runner.invoke(
-        app,
-        [
-            "sandbox",
-            "exec",
-            "--session-id",
-            "user-1",
-            "--shell-id",
-            "shell-from-cli",
-        ],
-    )
-
-    assert result.exit_code == 0
-    stored = json.loads(store_path.read_text(encoding="utf-8"))
-    assert "terminal_shell_id" not in stored["user-1"]
 
 
 def test_cli_exec_keeps_stored_shell_ids_without_current_shell_id(


### PR DESCRIPTION
## Summary
- Cherry-pick internal 0.6.3 commits from `e783121` through `afeca46`
- Add sandbox git config injection and model provider support
- Update sandbox session creation/reuse behavior
- Bump package version from 0.6.2 to 0.6.3

## Tests
- Not run per request
- Security scan skipped per request
- `git diff --check github/main..HEAD`