### PR TITLE
feat(auth): use the login id_token as the harness-invoke Bearer (JWT …

### DIFF
--- a/agentkit/auth/session.py
+++ b/agentkit/auth/session.py
@@ -77,6 +77,26 @@ def _effective_expiry(
     return datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=duration_seconds)
 
 
+def _jwt_expired(token: str, skew_seconds: int) -> bool:
+    """True if a JWT is expired, within ``skew_seconds`` of expiry, or unreadable.
+
+    Reads only the ``exp`` claim (no signature check — the harness endpoint verifies
+    the signature; we just decide locally whether to refresh). An unparseable token or
+    a missing/invalid ``exp`` is treated as expired so we refresh rather than send a
+    token that will be rejected."""
+    try:
+        import jwt as _jwt
+
+        claims = _jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+    except Exception:
+        return True
+    exp = claims.get("exp")
+    if not isinstance(exp, (int, float)):
+        return True
+    now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+    return now >= (exp - skew_seconds)
+
+
 @dataclass(frozen=True)
 class StsCredentials:
     """Short-lived Volcengine STS credentials."""
@@ -104,11 +124,17 @@ class AuthSession:
         refresh_token: str | None = None,
         sts: StsCredentials | None = None,
         duration_seconds: int = 3600,
+        id_token: str | None = None,
+        access_token: str | None = None,
     ) -> None:
         self.profile = profile
         self._refresh_token = refresh_token
         self._sts = sts
         self._duration = duration_seconds
+        # OIDC tokens kept for data-plane (JWT) auth — the id_token is the inbound
+        # credential for `agentkit invoke harness`; access_token is stored for parity.
+        self._id_token = id_token
+        self._access_token = access_token
         self._lock = threading.Lock()
 
     # -- persistence ----------------------------------------------------------
@@ -118,6 +144,8 @@ class AuthSession:
             "profile": self.profile.name,
             "issuer": self.profile.issuer,
             "refresh_token": self._refresh_token,
+            "id_token": self._id_token,
+            "access_token": self._access_token,
             "duration_seconds": self._duration,
             "sts": None
             if sts is None
@@ -151,6 +179,8 @@ class AuthSession:
             refresh_token=blob.get("refresh_token"),
             sts=sts,
             duration_seconds=int(blob.get("duration_seconds") or 3600),
+            id_token=blob.get("id_token"),
+            access_token=blob.get("access_token"),
         )
 
     # -- credentials ----------------------------------------------------------
@@ -180,6 +210,67 @@ class AuthSession:
             assert self._sts is not None
             return self._sts
 
+    # -- data-plane JWT (id_token) --------------------------------------------
+    def valid_id_token(self, *, skew_seconds: int = 60, force_refresh: bool = False) -> str:
+        """Return a currently-valid OIDC ``id_token`` for data-plane (JWT) auth.
+
+        Used by ``agentkit invoke harness`` as the inbound Bearer credential — it never
+        touches STS. Refreshes via the ``refresh_token`` (``grant_type=refresh_token`` at
+        the UserPool token endpoint) when the cached id_token is missing, within
+        ``skew_seconds`` of expiry, or when ``force_refresh`` is set (e.g. the harness
+        returned 401). Raises :class:`AuthError` pointing at ``agentkit login`` when no
+        refresh is possible.
+        """
+        with self._lock:
+            if not force_refresh and self._id_token and not _jwt_expired(self._id_token, skew_seconds):
+                return self._id_token
+            with _profile_file_lock(self.profile.name):
+                # Re-read under the lock to pick up any sibling's rotated refresh_token /
+                # refreshed STS — so we neither refresh with a stale refresh_token nor clobber
+                # a sibling's update when we save below.
+                blob = store.load_session(self.profile.name)
+                if blob:
+                    sibling = AuthSession.from_blob(self.profile, blob)
+                    self._refresh_token = sibling._refresh_token or self._refresh_token
+                    self._sts = sibling._sts or self._sts
+                    if not force_refresh and sibling._id_token and not _jwt_expired(sibling._id_token, skew_seconds):
+                        self._id_token = sibling._id_token
+                        self._access_token = sibling._access_token or self._access_token
+                        return self._id_token
+                self._refresh_id_token_locked()
+            assert self._id_token is not None
+            return self._id_token
+
+    def _refresh_id_token_locked(self) -> None:
+        if not self._refresh_token:
+            raise AuthError(
+                "no id_token and no refresh token available; re-login required.",
+                hint="run `agentkit login` to start a new browser session.",
+            )
+        from agentkit.auth.ssl_trust import harden_default_ssl_context
+
+        harden_default_ssl_context()
+        client = OAuthClient(self.profile.issuer, self.profile.client_id, scope=self.profile.scope)
+        try:
+            token = client.refresh(self._refresh_token)
+        except AuthError as exc:
+            raise AuthError(
+                "session refresh failed — the login has expired or was revoked.",
+                hint="run `agentkit login` to log in again.",
+            ) from exc
+        id_token = str(token.get("id_token") or "")
+        if not id_token:
+            raise AuthError(
+                "refresh did not return an id_token; re-login required.",
+                hint="ensure the OAuth scope includes 'openid' (OIDC requires an ID Token).",
+            )
+        self._id_token = id_token
+        if token.get("access_token"):
+            self._access_token = str(token["access_token"])
+        if token.get("refresh_token"):
+            self._refresh_token = str(token["refresh_token"])
+        self.save()
+
     def _renew_locked(self) -> None:
         if not self._refresh_token:
             raise AuthError(
@@ -199,6 +290,10 @@ class AuthSession:
                 "refresh did not return an id_token; re-login required.",
                 hint="ensure the OAuth scope includes 'openid' (OIDC requires an ID Token).",
             )
+        # Keep the freshly-issued OIDC tokens for data-plane (JWT) auth, not just STS.
+        self._id_token = id_token
+        if token.get("access_token"):
+            self._access_token = str(token["access_token"])
         # A rotated refresh token, if returned, must replace the old one.
         if token.get("refresh_token"):
             self._refresh_token = str(token["refresh_token"])

--- a/agentkit/auth/sso.py
+++ b/agentkit/auth/sso.py
@@ -102,7 +102,15 @@ def login(
         account_id=account,
     )
     session = AuthSession(
-        prof, refresh_token=refresh_token, sts=sts, duration_seconds=duration_seconds
+        prof,
+        refresh_token=refresh_token,
+        sts=sts,
+        duration_seconds=duration_seconds,
+        # Persist the OIDC tokens so the data plane (`agentkit invoke harness`) can use
+        # the id_token as its inbound Bearer credential. Store the real id_token (not the
+        # access_token fallback used above for AssumeRoleWithOIDC).
+        id_token=token.get("id_token"),
+        access_token=token.get("access_token"),
     )
     session.save()
     # Mark this profile active so separate CLI invocations (e.g. `sandbox create`)

--- a/agentkit/toolkit/cli/cli_invoke.py
+++ b/agentkit/toolkit/cli/cli_invoke.py
@@ -713,7 +713,37 @@ def harness_command(
         raise typer.Exit(1)
 
     invoke_url = entry["url"].rstrip("/") + "/harness/invoke"
-    token = apikey or entry.get("key") or ""
+
+    # Inbound credential selection is auth-type aware — the registry records how each
+    # harness was deployed (harness/deploy.py _record_harness): a custom_jwt harness is
+    # {auth_type:"custom_jwt", no "key"}; a key_auth harness is {"key": ...}.
+    #   1. --apikey always wins (explicit manual override).
+    #   2. custom_jwt harness → the `agentkit login` id_token (OIDC JWT, auto-refreshed) —
+    #      the data plane's JWT path; refresh failure errors (re-login), never silent.
+    #   3. key_auth harness → the static "key"; a key_auth authorizer would reject a JWT,
+    #      so we never force the id_token onto it.
+    from agentkit.auth.errors import AuthError
+    from agentkit.auth.sso import load_session
+
+    is_jwt_harness = entry.get("auth_type") == "custom_jwt" or not entry.get("key")
+    auth_session = None  # set only when the login id_token is the credential (enables 401 refresh)
+    token = apikey or ""
+    if not token and is_jwt_harness:
+        try:
+            auth_session = load_session()
+        except Exception:
+            auth_session = None
+        if auth_session is not None:
+            try:
+                token = auth_session.valid_id_token()
+            except AuthError as e:
+                console.print(f"[red]❌ {e}[/red]")
+                if getattr(e, "hint", None):
+                    console.print(f"[yellow]{e.hint}[/yellow]")
+                raise typer.Exit(1)
+    if not token:
+        token = entry.get("key") or ""
+
     req_headers = {"Content-Type": "application/json"}
     if token:
         req_headers["Authorization"] = f"Bearer {token}"
@@ -739,6 +769,18 @@ def harness_command(
 
     try:
         resp = requests.post(invoke_url, json=body, headers=req_headers, timeout=300)
+        # If the harness rejects a locally-valid JWT (clock skew, mid-flight rotation,
+        # server-side revocation), force one refresh and retry exactly once.
+        if resp.status_code == 401 and auth_session is not None and not apikey:
+            try:
+                token = auth_session.valid_id_token(force_refresh=True)
+            except AuthError as e:
+                console.print(f"[red]❌ session refresh failed: {e}[/red]")
+                if getattr(e, "hint", None):
+                    console.print(f"[yellow]{e.hint}[/yellow]")
+                raise typer.Exit(1)
+            req_headers["Authorization"] = f"Bearer {token}"
+            resp = requests.post(invoke_url, json=body, headers=req_headers, timeout=300)
     except requests.RequestException as e:
         console.print(f"[red]❌ Request to {invoke_url} failed: {e}[/red]")
         raise typer.Exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "opentelemetry-sdk>=1.32.1, <=1.37.0",
     "pydantic>=2.11.9",
     "requests>=2.32.5",
+    "PyJWT>=2.10.1",
     "uvicorn>=0.37.0",
     "pyyaml",
     "python-dotenv>=1.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ opentelemetry-exporter-otlp-proto-grpc>=1.32.1, <=1.37.0
 opentelemetry-sdk>=1.32.1, <=1.37.0
 pydantic>=2.11.9
 requests>=2.32.5
+PyJWT>=2.10.1
 uvicorn>=0.37.0
 pyyaml>=6.0.2
 python-dotenv>=1.1.0

--- a/tests/auth/test_session_id_token.py
+++ b/tests/auth/test_session_id_token.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AuthSession data-plane id_token: persistence + exp-based / forced refresh."""
+
+import datetime
+
+import jwt
+import pytest
+
+from agentkit.auth.errors import AuthError
+from agentkit.auth.profile import AuthProfile
+
+
+def _id_token(exp_delta=3600, sub="u-alice"):
+    now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+    return jwt.encode({"sub": sub, "exp": int(now + exp_delta)}, "test-signing-secret-0123456789abcdef", algorithm="HS256")
+
+
+def _profile():
+    return AuthProfile(
+        name="default", issuer="https://userpool-x.example.com",
+        client_id="c1", role_trn="trn:iam::1:role/r",
+    )
+
+
+def test_session_blob_roundtrips_id_and_access_token():
+    from agentkit.auth.session import AuthSession
+
+    s = AuthSession(_profile(), refresh_token="rt", id_token="id-tok", access_token="ac-tok")
+    blob = s.to_blob()
+    assert blob["id_token"] == "id-tok"
+    assert blob["access_token"] == "ac-tok"
+    s2 = AuthSession.from_blob(_profile(), blob)
+    assert s2._id_token == "id-tok"
+    assert s2._access_token == "ac-tok"
+
+
+def test_valid_id_token_returns_cached_when_fresh(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path))
+    import agentkit.auth.session as sess_mod
+
+    def _no_refresh(self, rt):  # must NOT be called for a fresh token
+        raise AssertionError("refresh should not run for a still-valid id_token")
+
+    monkeypatch.setattr(sess_mod.OAuthClient, "refresh", _no_refresh)
+    tok = _id_token(3600)
+    s = sess_mod.AuthSession(_profile(), refresh_token="rt1", id_token=tok)
+    s.save()
+    assert s.valid_id_token() == tok
+
+
+def test_valid_id_token_refreshes_when_expired(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path))
+    monkeypatch.setattr("agentkit.auth.ssl_trust.harden_default_ssl_context", lambda *a, **k: None)
+    import agentkit.auth.session as sess_mod
+
+    tok_new = _id_token(3600, sub="refreshed")
+    monkeypatch.setattr(
+        sess_mod.OAuthClient, "refresh",
+        lambda self, rt: {"id_token": tok_new, "refresh_token": "rt-2", "access_token": "ac-2"},
+    )
+    s = sess_mod.AuthSession(_profile(), refresh_token="rt1", id_token=_id_token(-10))  # expired
+    s.save()
+    assert s.valid_id_token() == tok_new
+    assert s._refresh_token == "rt-2"  # rotation persisted
+    assert s._access_token == "ac-2"
+    # the refreshed token is written back to the store
+    from agentkit.auth import store
+    assert store.load_session("default")["id_token"] == tok_new
+
+
+def test_valid_id_token_force_refresh_even_when_fresh(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path))
+    monkeypatch.setattr("agentkit.auth.ssl_trust.harden_default_ssl_context", lambda *a, **k: None)
+    import agentkit.auth.session as sess_mod
+
+    tok_new = _id_token(3600, sub="forced")
+    monkeypatch.setattr(sess_mod.OAuthClient, "refresh", lambda self, rt: {"id_token": tok_new})
+    s = sess_mod.AuthSession(_profile(), refresh_token="rt1", id_token=_id_token(3600))
+    s.save()
+    assert s.valid_id_token(force_refresh=True) == tok_new
+
+
+def test_valid_id_token_refresh_failure_tells_relogin(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path))
+    monkeypatch.setattr("agentkit.auth.ssl_trust.harden_default_ssl_context", lambda *a, **k: None)
+    import agentkit.auth.session as sess_mod
+
+    def boom(self, rt):
+        raise AuthError("token endpoint rejected the request")
+
+    monkeypatch.setattr(sess_mod.OAuthClient, "refresh", boom)
+    s = sess_mod.AuthSession(_profile(), refresh_token="rt1", id_token=_id_token(-10))
+    s.save()
+    with pytest.raises(AuthError) as ei:
+        s.valid_id_token()
+    msg = (str(ei.value) + " " + (ei.value.hint or "")).lower()
+    assert "login" in msg
+
+
+def test_valid_id_token_no_refresh_token_tells_relogin(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path))
+    import agentkit.auth.session as sess_mod
+
+    s = sess_mod.AuthSession(_profile(), refresh_token=None, id_token=_id_token(-10))
+    s.save()
+    with pytest.raises(AuthError) as ei:
+        s.valid_id_token()
+    assert "login" in (str(ei.value) + " " + (ei.value.hint or "")).lower()
+
+
+def test_renew_locked_still_yields_sts_and_now_stores_id_token(monkeypatch, tmp_path):
+    # clause 5: STS renewal path is unchanged (still mints STS) and additionally keeps the
+    # freshly-issued id_token for the data plane.
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path))
+    monkeypatch.setattr("agentkit.auth.ssl_trust.harden_default_ssl_context", lambda *a, **k: None)
+    import agentkit.auth.session as sess_mod
+
+    tok_new = _id_token(3600, sub="renewed")
+    monkeypatch.setattr(
+        sess_mod.OAuthClient, "refresh", lambda self, rt: {"id_token": tok_new, "refresh_token": "rt-2"},
+    )
+
+    class _Assumed:
+        access_key_id = "AK"
+        secret_access_key = "SK"
+        session_token = "TOK"
+        expired_at = None
+
+    monkeypatch.setattr(sess_mod, "assume_role_with_oidc", lambda *a, **k: _Assumed())
+
+    s = sess_mod.AuthSession(_profile(), refresh_token="rt1")
+    sts = s.credentials(force_refresh=True)
+    assert sts.access_key == "AK" and sts.session_token == "TOK"  # STS still produced
+    assert s._id_token == tok_new  # id_token now kept alongside

--- a/tests/auth/test_sso_login.py
+++ b/tests/auth/test_sso_login.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""sso.login(): the OIDC id_token / access_token are persisted to the session store."""
+
+import datetime
+
+import jwt
+
+from agentkit.auth.profile import AuthProfile
+
+
+def _id_token(exp_delta=3600, sub="u"):
+    now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+    return jwt.encode(
+        {"sub": sub, "exp": int(now + exp_delta)},
+        "test-signing-secret-0123456789abcdef", algorithm="HS256",
+    )
+
+
+class _Assumed:
+    access_key_id = "AK"
+    secret_access_key = "SK"
+    session_token = "TOK"
+    expired_at = None
+
+
+def test_login_persists_id_and_access_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path))
+    import agentkit.auth.sso as sso
+
+    tok = _id_token()
+    monkeypatch.setattr(
+        sso, "run_loopback_login",
+        lambda client, **k: {"id_token": tok, "access_token": "at-1", "refresh_token": "rt-1"},
+    )
+    monkeypatch.setattr(sso, "assume_role_with_oidc", lambda *a, **k: _Assumed())
+    monkeypatch.setattr(sso, "get_caller_identity", lambda *a, **k: {"AccountId": "123"})
+
+    prof = AuthProfile(
+        name="default", issuer="https://up.example.com", client_id="c1", role_trn="trn:iam::1:role/r",
+    )
+    sess = sso.login(prof, harden_ssl=False)
+
+    # in-memory session carries the OIDC tokens (contract clause 1)
+    assert sess._id_token == tok
+    assert sess._access_token == "at-1"
+    # and they are written to the persistent store (the real id_token, not an access_token fallback)
+    from agentkit.auth import store
+    blob = store.load_session("default")
+    assert blob["id_token"] == tok
+    assert blob["access_token"] == "at-1"
+    assert blob["refresh_token"] == "rt-1"

--- a/tests/toolkit/cli/test_cli_invoke_harness.py
+++ b/tests/toolkit/cli/test_cli_invoke_harness.py
@@ -16,12 +16,23 @@
 
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from agentkit.toolkit.cli.cli import app
 from agentkit.toolkit.cli import cli_invoke
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_login_home(monkeypatch, tmp_path):
+    """Keep harness tests from reading the developer's real ~/.agentkit login session.
+
+    Points AGENTKIT_HOME at a clean per-test dir so by default no login session exists
+    (the harness then uses the harness.json key). Tests that exercise the id_token path
+    create a session explicitly via _setup_login_session()."""
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path / "_agentkit_home"))
 
 
 def _write_registry(directory, mapping):
@@ -236,3 +247,142 @@ def test_bare_message_falls_back_to_run(monkeypatch):
     assert captured.get("config_dict") is None
     assert captured["config_file"] is not None
     assert captured["payload"] == {"prompt": "hello"}
+
+
+# --- data-plane JWT: harness invoke uses the `agentkit login` id_token --------
+
+
+def _make_id_token(exp_delta=3600, sub="u-alice"):
+    import datetime
+
+    import jwt
+    now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+    return jwt.encode({"sub": sub, "exp": int(now + exp_delta)}, "test-signing-secret-0123456789abcdef", algorithm="HS256")
+
+
+def _setup_login_session(monkeypatch, tmp_path, id_token, refresh_token="rt-1"):
+    """Create an active `agentkit login` session carrying ``id_token`` under a temp home."""
+    monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path / "home"))
+    from agentkit.auth.profile import AuthProfile, save_profile, set_active_profile
+    from agentkit.auth.session import AuthSession
+
+    prof = AuthProfile(
+        name="default", issuer="https://userpool-x.example.com",
+        client_id="c1", role_trn="trn:iam::1:role/r",
+    )
+    save_profile(prof)
+    set_active_profile("default")
+    AuthSession(prof, refresh_token=refresh_token, id_token=id_token).save()
+    return prof
+
+
+def test_harness_invoke_uses_login_id_token_as_bearer(monkeypatch, tmp_path):
+    tok = _make_id_token()
+    _setup_login_session(monkeypatch, tmp_path, tok)
+    _write_registry(tmp_path, {"first": {"url": "https://h.example.com"}})  # no static key
+    captured = {}
+    _patch_post(monkeypatch, captured)
+    result = _run_harness(["first", "hi", "--directory", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert captured["headers"].get("Authorization") == f"Bearer {tok}"
+
+
+def test_harness_invoke_apikey_overrides_login_id_token(monkeypatch, tmp_path):
+    _setup_login_session(monkeypatch, tmp_path, _make_id_token())
+    _write_registry(tmp_path, {"first": {"url": "https://h.example.com"}})
+    captured = {}
+    _patch_post(monkeypatch, captured)
+    result = _run_harness(["first", "hi", "--directory", str(tmp_path), "--apikey", "explicit-key"])
+    assert result.exit_code == 0, result.output
+    assert captured["headers"].get("Authorization") == "Bearer explicit-key"
+
+
+def test_harness_invoke_refreshes_on_401_and_retries_once(monkeypatch, tmp_path):
+    tok1 = _make_id_token(sub="u1")
+    tok2 = _make_id_token(sub="u1-refreshed")
+    _setup_login_session(monkeypatch, tmp_path, tok1)
+    _write_registry(tmp_path, {"first": {"url": "https://h.example.com"}})
+
+    import agentkit.auth.session as sess_mod
+    monkeypatch.setattr("agentkit.auth.ssl_trust.harden_default_ssl_context", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sess_mod.OAuthClient, "refresh",
+        lambda self, rt: {"id_token": tok2, "refresh_token": "rt-2"},
+    )
+
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append(headers.get("Authorization"))
+        return _FakeResponse({"output": "ok"}, 401 if len(calls) == 1 else 200)
+
+    monkeypatch.setattr("requests.post", fake_post)
+    result = _run_harness(["first", "hi", "--directory", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert calls == [f"Bearer {tok1}", f"Bearer {tok2}"]  # one refresh + one retry
+
+
+def test_harness_invoke_relogin_error_when_refresh_fails_on_expired(monkeypatch, tmp_path):
+    _setup_login_session(monkeypatch, tmp_path, _make_id_token(exp_delta=-10))  # already expired
+    _write_registry(tmp_path, {"first": {"url": "https://h.example.com"}})
+
+    import agentkit.auth.session as sess_mod
+    from agentkit.auth.errors import AuthError
+    monkeypatch.setattr("agentkit.auth.ssl_trust.harden_default_ssl_context", lambda *a, **k: None)
+
+    def boom(self, rt):
+        raise AuthError("token endpoint rejected the request")
+
+    monkeypatch.setattr(sess_mod.OAuthClient, "refresh", boom)
+    result = _run_harness(["first", "hi", "--directory", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "login" in result.output.lower()
+
+
+def test_harness_invoke_keyauth_uses_key_even_when_logged_in(monkeypatch, tmp_path):
+    # P1 guard: a key_auth harness ({"key": ...}) must use the static key even when logged
+    # in — a key_auth authorizer would reject an OIDC JWT.
+    _setup_login_session(monkeypatch, tmp_path, _make_id_token())
+    _write_registry(tmp_path, {"first": {"url": "https://h.example.com", "key": "ak", "runtime_id": "r-1"}})
+    captured = {}
+    _patch_post(monkeypatch, captured)
+    result = _run_harness(["first", "hi", "--directory", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert captured["headers"].get("Authorization") == "Bearer ak"
+
+
+def test_harness_invoke_custom_jwt_entry_uses_login_id_token(monkeypatch, tmp_path):
+    tok = _make_id_token()
+    _setup_login_session(monkeypatch, tmp_path, tok)
+    _write_registry(tmp_path, {"first": {
+        "url": "https://h.example.com", "runtime_id": "r-1", "auth_type": "custom_jwt",
+        "discovery_url": "https://up/.well-known/openid-configuration", "allowed_ids": ["c1"],
+    }})
+    captured = {}
+    _patch_post(monkeypatch, captured)
+    result = _run_harness(["first", "hi", "--directory", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert captured["headers"].get("Authorization") == f"Bearer {tok}"
+
+
+def test_harness_invoke_persistent_401_stops_after_one_retry(monkeypatch, tmp_path):
+    tok1 = _make_id_token(sub="u1")
+    tok2 = _make_id_token(sub="u1-refreshed")
+    _setup_login_session(monkeypatch, tmp_path, tok1)
+    _write_registry(tmp_path, {"first": {"url": "https://h.example.com"}})
+
+    import agentkit.auth.session as sess_mod
+    monkeypatch.setattr("agentkit.auth.ssl_trust.harden_default_ssl_context", lambda *a, **k: None)
+    monkeypatch.setattr(sess_mod.OAuthClient, "refresh", lambda self, rt: {"id_token": tok2, "refresh_token": "rt-2"})
+
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append(headers.get("Authorization"))
+        return _FakeResponse({"detail": "denied"}, 401)
+
+    monkeypatch.setattr("requests.post", fake_post)
+    result = _run_harness(["first", "hi", "--directory", str(tmp_path)])
+    assert result.exit_code == 1
+    assert len(calls) == 2  # original + exactly one refresh-retry, no third
+    assert "HTTP 401" in result.output


### PR DESCRIPTION
…data plane)

`agentkit login` now persists the OIDC id_token (and access_token) in the session store alongside the refresh token, and `agentkit invoke harness` uses that id_token as its inbound Bearer credential for custom_jwt harnesses — the data plane no longer depends on a static key.

- session: AuthSession persists id_token/access_token (__init__/to_blob/from_blob); _renew_locked keeps the freshly issued id_token; new valid_id_token(skew=60, force_refresh) refreshes the id_token via the refresh token (grant_type=refresh_token, no STS) when it is missing or near expiry, re-reading the store under the lock so it neither refreshes with a stale rotated token nor clobbers a sibling's update; a clear re-login error when the refresh fails.
- login: store the real id_token (not the access_token fallback used for AssumeRoleWithOIDC).
- invoke harness: auth-type-aware credential precedence — --apikey > the login id_token (custom_jwt harness) > a static harness.json key (key_auth harness); on a 401 from the harness, force one refresh and retry exactly once.
- declare PyJWT (reads the id_token exp) as an explicit dependency.
- tests: login persists id_token; Bearer == id_token; a key_auth harness still uses its key when logged in; one-shot 401 refresh+retry; refresh-failure re-login error; STS renewal path unchanged.