### PR TITLE
fix(harness): pin codex deps so the harness image builds on glibc

### DIFF
--- a/agentkit/toolkit/executors/init_executor.py
+++ b/agentkit/toolkit/executors/init_executor.py
@@ -143,11 +143,20 @@ VOLCENGINE_SECRET_KEY=
 # Container image for the harness server. The base image's apt mirror is an
 # unreachable internal host, so apt is repointed at aliyun; the source branch is
 # cloned via the ghfast proxy with a github fallback; uv installs from aliyun.
-# `openai-codex` is installed alongside veadk so the `codex` runtime works
-# (it bundles the Codex CLI binary); without it `--runtime codex` fails.
+#
+# Codex runtime: veadk's `--runtime codex` does `import openai_codex`, which pins
+# the Codex engine binary `openai-codex-cli-bin`. Both are prereleases, so they are
+# pinned to exact versions — an exact `==` pin auto-enables that prerelease in uv,
+# so no global `--prerelease=allow` is needed. aliyun mirrors both (including the
+# `openai-codex-cli-bin==0.137.0a4` manylinux x86_64/aarch64 wheel that matches this
+# glibc image), so everything installs from the fast domestic mirror in one step.
+# `openai-codex`'s only other runtime dep, `pydantic>=2.12`, is satisfied by veadk.
 _HARNESS_DOCKERFILE = """\
 FROM agentkit-cn-beijing.cr.volces.com/base/py-simple:python3.12-bookworm-slim-latest
 ENV PYTHONUNBUFFERED=1
+# Large wheels (google-adk, the 86MB Codex engine binary) can exceed uv's 30s
+# default HTTP timeout on a slow build network; give them more headroom.
+ENV UV_HTTP_TIMEOUT=300
 RUN set -eux; \\
     rm -f /etc/apt/sources.list.d/*; \\
     printf 'deb http://mirrors.aliyun.com/debian bookworm main contrib non-free non-free-firmware\\n\\
@@ -168,7 +177,8 @@ RUN set -eux; \\
     done; \\
     test -d src/veadk
 RUN uv pip install --system --index-url https://mirrors.aliyun.com/pypi/simple/ \\
-        ./src fastapi "uvicorn[standard]" openai-codex
+        ./src fastapi "uvicorn[standard]" \\
+        openai-codex==0.1.0b3 openai-codex-cli-bin==0.137.0a4
 EXPOSE 8000
 CMD ["python", "-m", "uvicorn", "veadk.cloud.harness_app.app:app", "--host", "0.0.0.0", "--port", "8000"]
 """


### PR DESCRIPTION
## Problem

The harness Dockerfile (`init_executor._HARNESS_DOCKERFILE`) installed `openai-codex` **unpinned**, which failed the cloud build:

1. `openai-codex` is **prerelease-only** (`0.1.0bX`) → uv rejects it without an explicit version (`pre-releases weren't enabled`).
2. `--index-url` pointed only at the aliyun mirror, which **lagged the prerelease** of `openai-codex-cli-bin` and fell back to an older `0.132.0` that ships **no manylinux wheel** → platform mismatch on the glibc (bookworm) base.

## Fix

Pin both to exact versions:

```dockerfile
RUN uv pip install --system --index-url https://mirrors.aliyun.com/pypi/simple/ \
        ./src fastapi "uvicorn[standard]" \
        openai-codex==0.1.0b3 openai-codex-cli-bin==0.137.0a4
```

- An exact `==` pin **auto-enables that prerelease** in uv (no global `--prerelease=allow`).
- Forces `openai-codex-cli-bin==0.137.0a4`, whose `manylinux_2_17` x86_64/aarch64 wheel matches the glibc image. aliyun now mirrors this prerelease, so everything installs from the **single fast domestic mirror** in one step (no pypi.org fallback / no bandwidth contention).
- `ENV UV_HTTP_TIMEOUT=300` for the large (86MB) codex engine binary + google-adk on slow build networks.

## Verified end-to-end (cloud)

- Build **Succeeded** (~2:44, all aliyun); runtime created and reached **Ready**.
- `--runtime codex` invoke works: returned `2` for "1+1", and on request **executed shell commands inside the container** (`whoami` → root, `$HOME` → /root, `pwd` → /app) — confirming `import openai_codex` + the cli-bin engine + tool execution all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)