### PR TITLE
chore: sync selected internal files to GitHub

### DIFF
--- a/agentkit/sdk/tools/types.py
+++ b/agentkit/sdk/tools/types.py
@@ -506,3 +506,4 @@ class UpdateToolRequest(ToolsBaseModel):
 # UpdateTool - Response
 class UpdateToolResponse(ToolsBaseModel):
     tool_id: Optional[str] = Field(default=None, alias="ToolId")
+

--- a/agentkit/toolkit/cli/interactive_config.py
+++ b/agentkit/toolkit/cli/interactive_config.py
@@ -534,6 +534,11 @@ class AutoPromptGenerator:
                 )
                 errors.append(msg)
 
+            if rule.get("required") and (
+                not value or (isinstance(value, str) and not value.strip())
+            ):
+                errors.append("This field cannot be empty")
+
             # pattern validation
             if "pattern" in rule:
                 import re

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AgentKit CLI Tests Package

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AgentKit CLI Tests Package

--- a/tests/cli/__main__.py
+++ b/tests/cli/__main__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AgentKit CLI Tests - Main entry point
+
+This module allows running tests using:
+python -m tests.cli [options]
+"""
+
+from .framework import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/base.py
+++ b/tests/cli/base.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AgentKit CLI Test Framework - Base Components
+
+This module provides the foundational components for CLI testing,
+separated from the main business logic.
+"""
+
+import sys
+import os
+import json
+import time
+import subprocess
+from typing import Dict, List, Optional, Any, Callable
+from datetime import datetime
+from abc import ABC, abstractmethod
+
+
+class CLITestResult:
+    """Test result record class"""
+
+    def __init__(
+        self,
+        name: str,
+        success: bool,
+        duration: float,
+        command: str,
+        output: str = "",
+        error: str = "",
+    ):
+        self.name = name
+        self.success = success
+        self.duration = duration
+        self.command = command
+        self.output = output
+        self.error = error
+        self.timestamp = datetime.now()
+
+
+class CLITestRunner:
+    """CLI test runner"""
+
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+        self.results: List[CLITestResult] = []
+        self.test_resources: Dict[str, List[str]] = {}
+
+    def run_command(
+        self,
+        args: List[str],
+        test_name: str = "",
+        expected_success: bool = True,
+        timeout: int = 30,
+        capture_output: bool = True,
+        verbose: bool = False,
+    ) -> CLITestResult:
+        """Run CLI command"""
+
+        start_time = time.time()
+        command_str = f"agentkit {' '.join(args)}"
+
+        print(f"\n🧪 {test_name or 'Running: ' + ' '.join(args)}")
+        print(f"Command: {command_str}")
+
+        try:
+            # Build the full command
+            full_command = [
+                "python",
+                "-c",
+                "from agentkit.toolkit.cli.cli import app; import sys; sys.argv = ['agentkit'] + sys.argv[1:]; app()",
+            ] + args
+
+            if verbose:
+                print(f"Full command: {' '.join(full_command)}")
+
+            # Execute the command
+            if capture_output:
+                completed = subprocess.run(
+                    full_command, capture_output=True, text=True, timeout=timeout
+                )
+                output = completed.stdout + completed.stderr
+                success = (completed.returncode == 0) == expected_success
+                return_code = completed.returncode
+            else:
+                completed = subprocess.run(full_command, timeout=timeout)
+                output = ""
+                success = (completed.returncode == 0) == expected_success
+                return_code = completed.returncode
+
+            duration = time.time() - start_time
+
+            if success:
+                print(f"✅ Success ({duration:.2f}s)")
+            else:
+                print(f"❌ Failed ({duration:.2f}s, return code: {return_code})")
+
+            if output and len(output) < 1000:
+                print("Output preview:")
+                print(output[:500] + ("..." if len(output) > 500 else ""))
+
+        except subprocess.TimeoutExpired:
+            duration = time.time() - start_time
+            success = False
+            output = ""
+            return_code = -1
+            print(f"⏰ Timeout ({duration:.2f}s)")
+
+        except Exception as e:
+            duration = time.time() - start_time
+            success = False
+            output = ""
+            return_code = -1
+            print(f"💥 Exception ({duration:.2f}s): {e}")
+
+        test_result = CLITestResult(
+            name=test_name or command_str,
+            success=success,
+            duration=duration,
+            command=command_str,
+            output=output[:1000],  # Limit output length
+            error=f"Return code: {return_code}" if not success else "",
+        )
+
+        self.results.append(test_result)
+        return test_result
+
+    def add_test_resource(self, resource_type: str, resource_id: str):
+        """Add test resource for later cleanup"""
+        if resource_type not in self.test_resources:
+            self.test_resources[resource_type] = []
+        self.test_resources[resource_type].append(resource_id)
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Get test summary"""
+        total = len(self.results)
+        passed = sum(1 for r in self.results if r.success)
+        failed = total - passed
+        total_duration = sum(r.duration for r in self.results)
+
+        return {
+            "module": self.module_name,
+            "total_tests": total,
+            "passed": passed,
+            "failed": failed,
+            "success_rate": passed / total * 100 if total > 0 else 0,
+            "total_duration": total_duration,
+            "test_resources": self.test_resources,
+        }
+
+    def print_summary(self):
+        """Print test summary"""
+        summary = self.get_summary()
+
+        print(f"\n📊 {self.module_name} Module Test Summary")
+        print("=" * 50)
+        print(f"Total Tests: {summary['total_tests']}")
+        print(f"Passed: {summary['passed']}")
+        print(f"Failed: {summary['failed']}")
+        print(f"Success Rate: {summary['success_rate']:.1f}%")
+        print(f"Total Duration: {summary['total_duration']:.2f}s")
+
+        if summary["failed"] > 0:
+            print("\n❌ Failed Tests:")
+            for result in self.results:
+                if not result.success:
+                    print(f"  - {result.name}: {result.error}")
+
+
+class BaseModuleTester(ABC):
+    """Base module test class"""
+
+    def __init__(self, runner: CLITestRunner):
+        self.runner = runner
+        self.test_start_time = datetime.now()
+
+    @abstractmethod
+    def run_tests(self) -> bool:
+        """Run all tests for the module"""
+        pass
+
+    @abstractmethod
+    def cleanup_resources(self):
+        """Clean up test resources"""
+        pass
+
+
+class CLITestHelper:
+    """CLI test helper utility class"""
+
+    TEST_RESOURCE_FILE = ".agentkit_cli_test_resources.json"
+
+    def __init__(self):
+        self.test_resources = self._load_test_resources()
+
+    def _load_test_resources(self):
+        """Load existing test resources from file"""
+        if os.path.exists(self.TEST_RESOURCE_FILE):
+            try:
+                with open(self.TEST_RESOURCE_FILE, "r") as f:
+                    return json.load(f)
+            except Exception:
+                pass
+        return {
+            "tools": {},
+            "sessions": {},
+            "memories": {},
+            "knowledge": {},
+            "runtimes": {},
+        }
+
+    def _save_test_resources(self):
+        """Save test resources to file"""
+        with open(self.TEST_RESOURCE_FILE, "w") as f:
+            json.dump(self.test_resources, f, indent=2)
+
+    def add_test_resource(self, resource_type: str, resource_id: str, metadata=None):
+        """Add test resource for tracking"""
+        if resource_type not in self.test_resources:
+            self.test_resources[resource_type] = {}
+
+        self.test_resources[resource_type][resource_id] = {
+            "created_at": time.time(),
+            "metadata": metadata or {},
+        }
+        self._save_test_resources()
+        return resource_id
+
+    def get_test_resources(self, resource_type: str):
+        """Get all test resources of specific type"""
+        return self.test_resources.get(resource_type, {})
+
+    def cleanup_test_resources(self, resource_type: Optional[str] = None):
+        """Clean up test resources"""
+        if resource_type:
+            resources = self.test_resources.get(resource_type, {})
+            self.test_resources[resource_type] = {}
+        else:
+            resources = {}
+            for rt in self.test_resources:
+                resources.update(self.test_resources[rt])
+            self.test_resources = {k: {} for k in self.test_resources}
+
+        self._save_test_resources()
+        return resources
+
+    def generate_test_name(self, prefix: str = "test") -> str:
+        """Generate unique test resource name"""
+        import uuid
+
+        return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def extract_resource_id(output: str, pattern: str = r"\w+-\w+") -> Optional[str]:
+    """Extract resource ID from command output"""
+    import re
+
+    match = re.search(pattern, output)
+    return match.group() if match else None
+
+
+def validate_json_output(output: str) -> bool:
+    """Validate output is valid JSON"""
+    try:
+        json.loads(output)
+        return True
+    except json.JSONDecodeError:
+        return False
+
+
+def validate_yaml_output(output: str) -> bool:
+    """Validate output is valid YAML"""
+    try:
+        import yaml
+
+        yaml.safe_load(output)
+        return True
+    except Exception:
+        return False

--- a/tests/cli/config.py
+++ b/tests/cli/config.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AgentKit CLI Test Configuration
+
+Configuration constants and settings for CLI testing.
+"""
+
+import os
+
+# Test configuration
+TEST_CONFIG = {
+    # Default timeouts
+    "DEFAULT_TIMEOUT": 30,  # seconds
+    "FAST_TIMEOUT": 15,  # seconds for fast mode
+    # Wait times
+    "DEFAULT_WAIT_TIME": 2,  # seconds between operations
+    "FAST_WAIT_TIME": 0.5,  # seconds for fast mode
+    # Retry settings
+    "MAX_RETRIES": 3,
+    "RETRY_DELAY": 1,  # seconds
+    # Resource name prefixes
+    "TOOL_NAME_PREFIX": "test_tool",
+    "MEMORY_NAME_PREFIX": "test_memory",
+    "KNOWLEDGE_NAME_PREFIX": "test_knowledge",
+    "RUNTIME_NAME_PREFIX": "test_runtime",
+    "SESSION_NAME_PREFIX": "test_session",
+    # Test descriptions
+    "TEST_DESCRIPTION": "CLI test resource created by automated test suite",
+    "TEST_PROJECT": "cli_test_project",
+    # Resource file
+    "TEST_RESOURCE_FILE": ".agentkit_cli_test_resources.json",
+    # Python command
+    "PYTHON_CMD": os.environ.get("PYTHON_CMD", "python"),
+    # Verbose mode
+    "VERBOSE": os.environ.get("CLI_TEST_VERBOSE", "false").lower() == "true",
+    # Fast mode
+    "FAST_MODE": os.environ.get("CLI_TEST_FAST", "false").lower() == "true",
+}
+
+# Supported modules
+SUPPORTED_MODULES = ["tools", "memory", "knowledge", "runtime"]
+
+# Output formats
+OUTPUT_FORMATS = ["summary", "detailed", "json"]
+
+# Test patterns for resource ID extraction
+RESOURCE_ID_PATTERNS = {
+    "tools": r"t-[a-z0-9]+",
+    "memory": r"mem-[a-z0-9]+",
+    "knowledge": r"kb-[a-z0-9]+",
+    "runtime": r"rt-[a-z0-9]+",
+    "session": r"s-[a-z0-9]+",
+}
+
+# Error patterns to expect
+EXPECTED_ERROR_PATTERNS = {
+    "InvalidResource": "The specified resource does not exist",
+    "MissingParameter": "The required parameter .* is not supplied",
+    "AuthenticationFailed": "Invalid credentials",
+    "AuthorizationFailed": "Access denied",
+    "InvalidParameter": "Invalid parameter",
+}
+
+# Success indicators
+SUCCESS_INDICATORS = ["✅", "success", "created", "updated", "deleted", "completed"]
+
+# Failure indicators
+FAILURE_INDICATORS = ["❌", "error", "failed", "exception", "timeout"]

--- a/tests/cli/framework.py
+++ b/tests/cli/framework.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AgentKit CLI Test Framework
+
+Main framework for running CLI tests across different modules.
+"""
+
+import sys
+import os
+import json
+import time
+import argparse
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+
+# Import test modules
+from .base import CLITestRunner, BaseModuleTester
+from .module_testers import get_module_tester
+from .config import TEST_CONFIG, SUPPORTED_MODULES, OUTPUT_FORMATS
+
+
+def main():
+    """Main function"""
+    parser = argparse.ArgumentParser(
+        description="AgentKit CLI Test Framework",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Test single module
+    python -m tests.cli.framework --module tools
+    
+    # Test all modules
+    python -m tests.cli.framework --all-modules
+    
+    # Fast test mode
+    python -m tests.cli.framework --module tools --fast
+    
+    # Generate JSON report
+    python -m tests.cli.framework --all-modules --output json
+    
+    # Cleanup only
+    python -m tests.cli.framework --cleanup --module memory
+        """,
+    )
+
+    parser.add_argument(
+        "--module", "-m", choices=SUPPORTED_MODULES, help="Module to test"
+    )
+    parser.add_argument(
+        "--all-modules", "-a", action="store_true", help="Test all modules"
+    )
+    parser.add_argument("--cleanup", "-c", action="store_true", help="Cleanup only")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    parser.add_argument(
+        "--fast", action="store_true", help="Fast mode (reduced wait times)"
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="summary",
+        choices=OUTPUT_FORMATS,
+        help="Output format",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=TEST_CONFIG["DEFAULT_TIMEOUT"],
+        help="Command timeout in seconds",
+    )
+
+    args = parser.parse_args()
+
+    if not args.module and not args.all_modules:
+        print("❌ Please specify --module or --all-modules")
+        return 1
+
+    if args.all_modules:
+        modules = SUPPORTED_MODULES
+    else:
+        modules = [args.module]
+
+    all_results = {}
+    start_time = datetime.now()
+
+    try:
+        print("🚀 AgentKit CLI Test Framework Starting")
+        print(f"Start Time: {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
+        print(f"Test Modules: {', '.join(modules)}")
+        if args.fast:
+            print("⚡ Fast mode enabled")
+        print("=" * 60)
+
+        for module_name in modules:
+            print(f"\n🔍 Starting Test Module: {module_name.upper()}")
+            print("-" * 40)
+
+            # Create test runner
+            runner = CLITestRunner(module_name)
+
+            # Get module tester
+            tester = get_module_tester(module_name, runner)
+
+            if args.cleanup:
+                # Cleanup only
+                print(f"🧹 Cleaning up {module_name} module test resources...")
+                tester.cleanup_resources()
+                continue
+
+            # Run tests
+            print(f"🧪 Running {module_name} module tests...")
+            tester.run_tests()
+
+            # Cleanup resources
+            print(f"🧹 Cleaning up {module_name} module test resources...")
+            tester.cleanup_resources()
+
+            # Get results
+            all_results[module_name] = runner.get_summary()
+
+            # Print summary
+            runner.print_summary()
+
+        if not args.cleanup:
+            # Print overall summary
+            print(f"\n{'=' * 60}")
+            print("📊 Overall Test Summary")
+            print(f"{'=' * 60}")
+
+            total_tests = sum(r["total_tests"] for r in all_results.values())
+            total_passed = sum(r["passed"] for r in all_results.values())
+            total_failed = sum(r["failed"] for r in all_results.values())
+            total_duration = sum(r["total_duration"] for r in all_results.values())
+
+            end_time = datetime.now()
+            total_time = (end_time - start_time).total_seconds()
+
+            print(f"Test Modules: {len(modules)}")
+            print(f"Total Tests: {total_tests}")
+            print(f"Total Passed: {total_passed}")
+            print(f"Total Failed: {total_failed}")
+            print(f"Test Duration: {total_duration:.2f}s")
+            print(f"Total Duration: {total_time:.2f}s")
+            print(
+                f"Overall Success Rate: {total_passed / total_tests * 100:.1f}%"
+                if total_tests > 0
+                else "N/A"
+            )
+
+            # Module detailed results
+            print("\n📋 Module Results:")
+            for module_name, result in all_results.items():
+                status = "✅" if result["failed"] == 0 else "❌"
+                print(
+                    f"{status} {module_name}: {result['passed']}/{result['total_tests']} ({result['success_rate']:.1f}%)"
+                )
+
+            # Save JSON report
+            if args.output == "json":
+                report = {
+                    "timestamp": start_time.isoformat(),
+                    "end_time": end_time.isoformat(),
+                    "duration_seconds": total_time,
+                    "modules": all_results,
+                    "summary": {
+                        "total_modules": len(modules),
+                        "total_tests": total_tests,
+                        "passed": total_passed,
+                        "failed": total_failed,
+                        "success_rate": total_passed / total_tests * 100
+                        if total_tests > 0
+                        else 0,
+                        "total_duration": total_duration,
+                    },
+                }
+
+                report_file = f"test_report_{start_time.strftime('%Y%m%d_%H%M%S')}.json"
+                with open(report_file, "w", encoding="utf-8") as f:
+                    json.dump(report, f, ensure_ascii=False, indent=2)
+
+                print(f"\n📄 Detailed report saved to: {report_file}")
+
+            # Return appropriate exit code
+            return 0 if total_failed == 0 else 1
+
+    except KeyboardInterrupt:
+        print("\n⚠️ Tests interrupted by user")
+        return 130
+    except Exception as e:
+        print(f"\n💥 Test framework error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    sys.exit(exit_code)

--- a/tests/cli/module_testers.py
+++ b/tests/cli/module_testers.py
@@ -1,0 +1,480 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AgentKit CLI Module Testers
+
+Module-specific test implementations for each CLI module.
+"""
+
+import time
+from typing import Dict, List, Optional, Any
+from .base import BaseModuleTester, CLITestRunner
+from .config import TEST_CONFIG
+
+
+class ToolsModuleTester(BaseModuleTester):
+    """Tools module tester"""
+
+    def __init__(self, runner: CLITestRunner):
+        super().__init__(runner)
+        self.test_tool_name = f"{TEST_CONFIG['TOOL_NAME_PREFIX']}_{int(time.time())}"
+        self.test_session_name = (
+            f"{TEST_CONFIG['SESSION_NAME_PREFIX']}_{int(time.time())}"
+        )
+        self.created_tool_id = None
+
+    def run_tests(self) -> bool:
+        """Run Tools module tests"""
+        print("\n🔧 Starting Tools Module Tests")
+
+        # Test 1: List tools
+        self.runner.run_command(["tools", "list", "--limit", "2"], "List tools")
+
+        # Test 2: Different output formats
+        self.runner.run_command(
+            ["tools", "list", "--limit", "1", "--output", "json"], "JSON format output"
+        )
+
+        self.runner.run_command(
+            ["tools", "list", "--limit", "1", "--output", "yaml"], "YAML format output"
+        )
+
+        self.runner.run_command(
+            ["tools", "list", "--limit", "1", "--quiet"], "Quiet mode"
+        )
+
+        # Test 3: Error handling
+        self.runner.run_command(
+            ["tools", "show", "--tool-id", "t-invalid-tool-id"],
+            "Invalid tool ID handling",
+            expected_success=False,
+        )
+
+        # Test 4: Create tool (requires more parameters)
+        self.runner.run_command(
+            [
+                "tools",
+                "create",
+                "--name",
+                self.test_tool_name,
+                "--tool-type",
+                "All-in-one",
+                "--description",
+                TEST_CONFIG["TEST_DESCRIPTION"],
+            ],
+            "Create tool (expected failure - requires auth config)",
+            expected_success=False,
+        )
+
+        # Test 5: Session related operations
+        self.runner.run_command(
+            ["tools", "session", "list", "--tool-id", "t-placeholder", "--limit", "1"],
+            "Session list (expected failure - invalid tool ID)",
+            expected_success=False,
+        )
+
+        return True
+
+    def cleanup_resources(self):
+        """Clean up Tools test resources"""
+        print("\n🧹 Cleaning up Tools test resources")
+        if self.created_tool_id:
+            self.runner.run_command(
+                ["tools", "delete", "--tool-id", self.created_tool_id],
+                f"Delete test tool: {self.created_tool_id}",
+                expected_success=False,  # May already not exist
+            )
+
+
+class MemoryModuleTester(BaseModuleTester):
+    """Memory module tester"""
+
+    def __init__(self, runner: CLITestRunner):
+        super().__init__(runner)
+        self.test_memory_name = (
+            f"{TEST_CONFIG['MEMORY_NAME_PREFIX']}_{int(time.time())}"
+        )
+
+    def run_tests(self) -> bool:
+        """Run Memory module tests"""
+        print("\n🧠 Starting Memory Module Tests")
+
+        # Test 1: List memory collections
+        self.runner.run_command(
+            ["memory", "list", "--limit", "2"], "List memory collections"
+        )
+
+        # Test 2: Different output formats
+        self.runner.run_command(
+            ["memory", "list", "--limit", "1", "--output", "json"], "JSON format output"
+        )
+
+        self.runner.run_command(
+            ["memory", "list", "--limit", "1", "--quiet"], "Quiet mode"
+        )
+
+        # Test 3: Provider types
+        self.runner.run_command(["memory", "provider-types"], "List provider types")
+
+        # Test 4: Error handling
+        self.runner.run_command(
+            ["memory", "show", "--collection-id", "mem-invalid"],
+            "Invalid memory collection ID",
+            expected_success=False,
+        )
+
+        return True
+
+    def cleanup_resources(self):
+        """Clean up Memory test resources"""
+        print("\n🧹 Cleaning up Memory test resources")
+        # Add specific cleanup logic here
+
+
+class KnowledgeModuleTester(BaseModuleTester):
+    """Knowledge module tester"""
+
+    def __init__(self, runner: CLITestRunner):
+        super().__init__(runner)
+        self.test_knowledge_name = (
+            f"{TEST_CONFIG['KNOWLEDGE_NAME_PREFIX']}_{int(time.time())}"
+        )
+
+    def run_tests(self) -> bool:
+        """Run Knowledge module tests"""
+        print("\n📚 Starting Knowledge Module Tests")
+
+        # Test 1: List knowledge bases
+        self.runner.run_command(
+            ["knowledge", "list", "--limit", "2"], "List knowledge bases"
+        )
+
+        # Test 2: Different output formats
+        self.runner.run_command(
+            ["knowledge", "list", "--limit", "1", "--output", "json"],
+            "JSON format output",
+        )
+
+        self.runner.run_command(
+            ["knowledge", "list", "--limit", "1", "--quiet"], "Quiet mode"
+        )
+
+        # Test 3: Provider types
+        self.runner.run_command(["knowledge", "provider-types"], "List provider types")
+
+        # Test 4: Error handling
+        self.runner.run_command(
+            ["knowledge", "show", "--knowledge-id", "kb-invalid"],
+            "Invalid knowledge base ID",
+            expected_success=False,
+        )
+
+        return True
+
+    def cleanup_resources(self):
+        """Clean up Knowledge test resources"""
+        print("\n🧹 Cleaning up Knowledge test resources")
+
+
+class RuntimeModuleTester(BaseModuleTester):
+    """Runtime module tester"""
+
+    def __init__(self, runner: CLITestRunner):
+        super().__init__(runner)
+        self.test_runtime_name = (
+            f"{TEST_CONFIG['RUNTIME_NAME_PREFIX']}_{int(time.time())}"
+        )
+
+    def test_advanced_filters(self):
+        """Test advanced filtering functionality - verify correct API structure"""
+        print("\n🔍 Testing Runtime Advanced Filtering (API Structure Verification)")
+
+        # Test status exact filtering - should use Name field
+        self.runner.run_command(
+            ["runtime", "list", "--filter-status", "Ready", "--limit", "1"],
+            "Status exact filtering - Name=Status",
+        )
+
+        # Test status fuzzy filtering - should use NameContains field
+        self.runner.run_command(
+            ["runtime", "list", "--name-contains", "Customer", "--limit", "1"],
+            "Name fuzzy filtering - NameContains=Name",
+        )
+
+        # Test ID fuzzy filtering - should use NameContains field
+        self.runner.run_command(
+            ["runtime", "list", "--filter-id-contains", "r-", "--limit", "1"],
+            "ID fuzzy filtering - NameContains=Id",
+        )
+
+        # Test description fuzzy filtering - should use NameContains field
+        self.runner.run_command(
+            [
+                "runtime",
+                "list",
+                "--filter-description-contains",
+                "Customer",
+                "--limit",
+                "1",
+            ],
+            "Description fuzzy filtering - NameContains=Description",
+        )
+
+        # Test project filtering - use ProjectName parameter
+        self.runner.run_command(
+            ["runtime", "list", "--project-name", "default", "--limit", "1"],
+            "Project filtering - ProjectName parameter",
+        )
+
+        # Test multi-status filtering - should use Name field + multiple Values
+        self.runner.run_command(
+            ["runtime", "list", "--filter-status-in", "Ready,Creating", "--limit", "1"],
+            "Multi-status filtering - Name=Status+multiple Values",
+        )
+
+        # Test combined filtering - include both exact and fuzzy filtering
+        self.runner.run_command(
+            [
+                "runtime",
+                "list",
+                "--name",
+                "CustomerService",
+                "--filter-status",
+                "Ready",
+                "--limit",
+                "1",
+            ],
+            "Combined filtering - Name+Status exact filtering",
+        )
+
+        # Test invalid status value (expected failure)
+        self.runner.run_command(
+            ["runtime", "list", "--filter-status", "InvalidStatus"],
+            "Invalid status filtering - should fail",
+            expected_success=False,
+        )
+
+    def test_get_commands(self):
+        """Test get runtime related commands"""
+        print("\n📖 Testing Runtime Get Commands")
+
+        # First get a valid runtime ID for subsequent tests
+        result = self.runner.run_command(
+            ["runtime", "list", "--limit", "1", "--quiet"], "Get valid runtime ID"
+        )
+
+        if result:
+            # Extract runtime ID from output
+            import subprocess
+
+            try:
+                output = subprocess.check_output(
+                    ["agentkit", "runtime", "list", "--limit", "1", "--quiet"],
+                    text=True,
+                ).strip()
+                if output and not output.startswith("❌"):
+                    valid_runtime_id = output.split("\n")[0]
+
+                    # Test get runtime details
+                    self.runner.run_command(
+                        ["runtime", "get", "-r", valid_runtime_id],
+                        "Get runtime details",
+                    )
+
+                    # Test get runtime version
+                    self.runner.run_command(
+                        ["runtime", "version", "-r", valid_runtime_id],
+                        "Get runtime version",
+                    )
+
+                    # Test list versions
+                    self.runner.run_command(
+                        ["runtime", "versions", "-r", valid_runtime_id], "List versions"
+                    )
+            except Exception as e:
+                print(f"Error in test_get_commands: {e}")
+                pass
+
+    def test_create_runtime(self):
+        """Test create runtime (expected failure - requires complete configuration)"""
+        print("\n➕ Testing Runtime Create Functionality")
+
+        # Test create runtime - expected failure because complete configuration is needed
+        self.runner.run_command(
+            [
+                "runtime",
+                "create",
+                "--name",
+                f"{self.test_runtime_name}",
+                "--role-name",
+                "test-role",
+                "--artifact-type",
+                "DockerImage",
+                "--artifact-url",
+                "test-image:latest",
+            ],
+            "Create runtime (expected failure - requires complete configuration)",
+            expected_success=False,
+        )
+
+        # Test JSON format creation
+        self.runner.run_command(
+            [
+                "runtime",
+                "create",
+                "--json",
+                '{"Name": "test", "RoleName": "test-role"}',
+            ],
+            "JSON format creation (expected failure)",
+            expected_success=False,
+        )
+
+    def test_update_runtime(self):
+        """Test update runtime"""
+        print("\n✏️ Testing Runtime Update Functionality")
+
+        # Test update invalid runtime
+        self.runner.run_command(
+            [
+                "runtime",
+                "update",
+                "-r",
+                "rt-invalid-update-test",
+                "--description",
+                "Updated description",
+            ],
+            "Update invalid runtime",
+            expected_success=False,
+        )
+
+        # Test JSON format update
+        self.runner.run_command(
+            [
+                "runtime",
+                "update",
+                "-r",
+                "rt-invalid-update-test",
+                "--json",
+                '{"Description": "Updated via JSON"}',
+            ],
+            "JSON format update invalid runtime",
+            expected_success=False,
+        )
+
+    def test_delete_runtime(self):
+        """Test delete runtime"""
+        print("\n🗑️ Testing Runtime Delete Functionality")
+
+        # Test delete invalid runtime
+        self.runner.run_command(
+            ["runtime", "delete", "-r", "rt-invalid-delete-test", "--force"],
+            "Delete invalid runtime",
+            expected_success=False,
+        )
+
+        # Test delete help information
+        self.runner.run_command(["runtime", "delete", "--help"], "Delete command help")
+
+    def test_release_runtime(self):
+        """Test release runtime version"""
+        print("\n🚀 Testing Runtime Release Functionality")
+
+        # Test release invalid runtime
+        self.runner.run_command(
+            ["runtime", "release", "-r", "rt-invalid-release-test"],
+            "Release invalid runtime",
+            expected_success=False,
+        )
+
+        # Test release with specific version number
+        self.runner.run_command(
+            [
+                "runtime",
+                "release",
+                "-r",
+                "rt-invalid-release-test",
+                "--version-number",
+                "1",
+            ],
+            "Release specific version",
+            expected_success=False,
+        )
+
+    def run_tests(self) -> bool:
+        """Run Runtime module tests"""
+        print("\n⚙️ Starting Runtime Module Tests")
+
+        # Test 1: Basic listing functionality
+        self.runner.run_command(
+            ["runtime", "list", "--limit", "2"], "Basic listing functionality"
+        )
+
+        # Test 2: Different output formats
+        self.runner.run_command(
+            ["runtime", "list", "--limit", "1", "--output", "json"],
+            "JSON format output",
+        )
+
+        self.runner.run_command(
+            ["runtime", "list", "--limit", "1", "--quiet"], "Quiet mode"
+        )
+
+        # Test 3: Advanced filtering functionality
+        self.test_advanced_filters()
+
+        # Test 4: Get commands test
+        self.test_get_commands()
+
+        # Test 5: Create runtime test
+        self.test_create_runtime()
+
+        # Test 6: Update runtime test
+        self.test_update_runtime()
+
+        # Test 7: Delete runtime test
+        self.test_delete_runtime()
+
+        # Test 8: Release runtime test
+        self.test_release_runtime()
+
+        # Test 9: Error handling (using short option)
+        self.runner.run_command(
+            ["runtime", "get", "-r", "rt-invalid"],
+            "Invalid runtime ID (short option)",
+            expected_success=False,
+        )
+
+        return True
+
+    def cleanup_resources(self):
+        """Clean up Runtime test resources"""
+        print("\n🧹 Cleaning up Runtime test resources")
+
+
+def get_module_tester(module_name: str, runner: CLITestRunner) -> BaseModuleTester:
+    """Get module tester"""
+    testers = {
+        "tools": ToolsModuleTester,
+        "memory": MemoryModuleTester,
+        "knowledge": KnowledgeModuleTester,
+        "runtime": RuntimeModuleTester,
+    }
+
+    if module_name not in testers:
+        raise ValueError(
+            f"Unsupported module: {module_name}. Supported modules: {list(testers.keys())}"
+        )
+
+    return testers[module_name](runner)


### PR DESCRIPTION
## Summary
- Apply the requested repository alignment rules after moving development toward GitHub.
- Keep internal-only api_jsons/tools out of GitHub.
- Keep GitHub-only docs publishing files on GitHub; do not change docs publishing files.
- Keep selected docs files as GitHub version; no docs changes in this PR.
- Sync tests/__init__.py and tests/cli/* from internal main to GitHub.
- Sync agentkit/sdk/tools/types.py and agentkit/toolkit/cli/interactive_config.py from internal main to GitHub.

## Files changed
- agentkit/sdk/tools/types.py
- agentkit/toolkit/cli/interactive_config.py
- tests/__init__.py
- tests/cli/*

## Checks
- Sensitive scan: no matches
- uv run --with pytest --with pytest-mock pytest tests/toolkit/cli/test_interactive_hidden_fields_carry_over.py tests/toolkit/cli/test_cli_config_interactive_flow.py tests/toolkit/cli/test_cli_config_interactive_provider_resolution.py tests/toolkit/cli/test_cli_config_cloud_provider_noninteractive.py tests/toolkit/config: 24 passed
- uv run python -m compileall tests/cli agentkit/toolkit/cli/interactive_config.py agentkit/sdk/tools/types.py: passed

## Notes
- git diff --check reports whitespace inherited from internal main: trailing blank line in agentkit/sdk/tools/types.py and trailing whitespace in tests/cli/framework.py. This PR keeps those files aligned with internal main as requested.