### PR TITLE
Fix/harness a2a registry

### DIFF
--- a/agentkit/toolkit/cli/cli_add.py
+++ b/agentkit/toolkit/cli/cli_add.py
@@ -222,8 +222,13 @@ def _apply_registry_config(
         section = {}
 
     if registry is not None:
-        section.update(_parse_registry_uri(registry))
+        parsed_registry = _parse_registry_uri(registry)
+        if parsed_registry.get("space_name") and "space_id" not in parsed_registry:
+            section.pop("space_id", None)
+        section.update(parsed_registry)
 
+    if registry_space_name is not None:
+        section.pop("space_id", None)
     _set_registry_value(section, "space_id", registry_space_id)
     _set_registry_value(section, "space_name", registry_space_name)
     _set_registry_value(section, "top_k", registry_top_k)

--- a/agentkit/toolkit/cli/cli_add.py
+++ b/agentkit/toolkit/cli/cli_add.py
@@ -74,6 +74,10 @@ _REGISTRY_QUERY_KEYS = {
 _REGISTRY_INT_KEYS = {"top_k"}
 _REGISTER_NETWORK_TYPES = {"public", "private"}
 _REGISTER_DEFAULT_VERSION = "2025-10-30"
+_DEFAULT_A2A_REGISTRY_URI = (
+    "agentkit://a2a-registry?"
+    "space_name=Default&region=cn-beijing&endpoint=https://open.volcengineapi.com/"
+)
 
 
 class _A2ARegisterError(Exception):
@@ -142,9 +146,16 @@ def _parse_registry_int(key: str, value: object) -> object:
         raise ValueError(f"Registry param `{key}` must be an integer, got {value!r}.") from exc
 
 
+def _expand_default_registry_uri(value: str) -> str:
+    raw = value.strip()
+    if raw.lower() == "default":
+        return _DEFAULT_A2A_REGISTRY_URI
+    return raw
+
+
 def _parse_registry_uri(value: str) -> dict:
     """Parse the supported AgentKit A2A registry URI into a spec section."""
-    raw = value.strip()
+    raw = _expand_default_registry_uri(value)
     if raw.lower() == "disabled":
         return {"type": ""}
 
@@ -157,7 +168,7 @@ def _parse_registry_uri(value: str) -> dict:
         raise ValueError(
             "Unsupported registry URI. Currently only "
             "`agentkit://a2a-registry?space_id=xxx&top_k=3` or "
-            "`disabled` is supported."
+            "`default` / `disabled` is supported."
         )
 
     query = {
@@ -612,7 +623,10 @@ def harness_command(
     registry: Optional[str] = typer.Option(
         None,
         "--registry",
-        help='AgentKit A2A registry URI, e.g. "agentkit://a2a-registry?space_id=xxx&top_k=3".',
+        help=(
+            'AgentKit A2A registry URI, "default", or "disabled", e.g. '
+            '"agentkit://a2a-registry?space_id=xxx&top_k=3".'
+        ),
     ),
     registry_space_id: Optional[str] = typer.Option(
         None, "--registry-space-id", help="AgentKit A2A SpaceId."

--- a/agentkit/toolkit/cli/cli_add.py
+++ b/agentkit/toolkit/cli/cli_add.py
@@ -42,7 +42,7 @@ import os
 import re
 from pathlib import Path
 from typing import Any, Optional
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 import typer
 from rich.console import Console
@@ -264,6 +264,16 @@ def _apply_registry_config(
         )
 
     data["registry"] = section
+    if section.get("type") == "agentkit_a2a":
+        resolved_endpoint, resolved_region = _resolve_agentkit_openapi_target(
+            endpoint=str(section["endpoint"]) if section.get("endpoint") else None,
+            region=str(section["region"]) if section.get("region") else None,
+        )
+        _enable_a2a_space_intent(
+            str(section["space_id"]),
+            endpoint=resolved_endpoint,
+            region=resolved_region,
+        )
 
 
 def _load_spec(path: Path) -> dict:
@@ -303,6 +313,30 @@ def _default_agentkit_endpoint(region: str) -> str:
     if region == "cn-beijing":
         return "https://agentkit.cn-beijing.volcengineapi.com/"
     return f"https://agentkit.{region}.volcengineapi.com/"
+
+
+def _resolve_agentkit_openapi_target(
+    *,
+    endpoint: Optional[str],
+    region: Optional[str],
+) -> tuple[str, str]:
+    resolved_region = (
+        region
+        or os.getenv("AGENTKIT_REGION")
+        or os.getenv("VOLCENGINE_REGION")
+        or "cn-beijing"
+    )
+    resolved_endpoint = endpoint or _default_agentkit_endpoint(str(resolved_region))
+    parsed = urlparse(resolved_endpoint)
+    if (
+        parsed.scheme
+        and parsed.netloc
+        and (parsed.query or parsed.params or parsed.fragment)
+    ):
+        resolved_endpoint = urlunparse(
+            (parsed.scheme, parsed.netloc, parsed.path or "/", "", "", "")
+        )
+    return resolved_endpoint, str(resolved_region)
 
 
 def _request_id(response: dict[str, Any]) -> str | None:
@@ -383,6 +417,25 @@ def _agentkit_post(
     if "Result" not in data:
         raise _A2ARegisterError("AgentKit OpenAPI response missing Result")
     return data, duration_ms
+
+
+def _enable_a2a_space_intent(
+    space_id: str,
+    *,
+    endpoint: str,
+    region: str,
+) -> dict[str, Any]:
+    response, request_duration_ms = _agentkit_post(
+        endpoint=endpoint,
+        version=_REGISTER_DEFAULT_VERSION,
+        region=region,
+        action="UpdateA2aSpace",
+        body={"Id": space_id, "IntentEnabled": True},
+    )
+    return {
+        "request_id": _request_id(response),
+        "request_duration_ms": request_duration_ms,
+    }
 
 
 def _resolve_a2a_space_id_by_name(
@@ -918,7 +971,9 @@ def harness_command(
             registry_region,
         )
     except _A2ARegisterError as exc:
-        console.print(f"[red]Error: failed to resolve A2A space name: {exc.message}[/red]")
+        console.print(
+            f"[red]Error: failed to configure A2A registry: {exc.message}[/red]"
+        )
         if exc.diagnostics:
             console.print(json.dumps(exc.diagnostics, ensure_ascii=False, indent=2))
         raise typer.Exit(1) from exc

--- a/agentkit/toolkit/cli/cli_invoke.py
+++ b/agentkit/toolkit/cli/cli_invoke.py
@@ -662,6 +662,7 @@ def _parse_harness_registry_override(value: Optional[str]) -> dict[str, Any]:
     """Parse ``--registry`` into one-time harness registry overrides.
 
     Supported forms:
+    - default (Default space in cn-beijing via https://open.volcengineapi.com/)
     - agentkit://a2a-registry?space_id=xxx&top_k=3&region=cn-beijing
     - https://... (treated as registry_endpoint; recognized query params are
       also extracted when present)
@@ -673,6 +674,9 @@ def _parse_harness_registry_override(value: Optional[str]) -> dict[str, Any]:
     if not raw:
         return {}
 
+    from agentkit.toolkit.cli.cli_add import _expand_default_registry_uri
+
+    raw = _expand_default_registry_uri(raw)
     parsed = urlparse(raw)
     overrides: dict[str, Any] = {}
 
@@ -686,14 +690,16 @@ def _parse_harness_registry_override(value: Optional[str]) -> dict[str, Any]:
         if parsed.netloc != "a2a-registry" or parsed.path not in {"", "/"}:
             raise ValueError(
                 "Unsupported registry URI. Use "
-                '`agentkit://a2a-registry?space_id=xxx&top_k=3` or an http(s) URL.'
+                '`default`, `agentkit://a2a-registry?space_id=xxx&top_k=3`, '
+                "or an http(s) URL."
             )
     elif parsed.scheme in {"http", "https"}:
         overrides["registry_endpoint"] = raw
     else:
         raise ValueError(
             "Unsupported registry value. Use "
-            '`agentkit://a2a-registry?space_id=xxx&top_k=3` or an http(s) URL.'
+            '`default`, `agentkit://a2a-registry?space_id=xxx&top_k=3`, '
+            "or an http(s) URL."
         )
 
     unknown = sorted(set(query) - set(_INVOKE_REGISTRY_QUERY_ALIASES))
@@ -998,7 +1004,8 @@ def harness_command(
         "--registry",
         help=(
             "Override A2A registry for this invocation. Accepts "
-            "`agentkit://a2a-registry?space_id=xxx&top_k=3` or an http(s) URL."
+            "`default`, `agentkit://a2a-registry?space_id=xxx&top_k=3`, "
+            "or an http(s) URL."
         ),
     ),
     registry_top_k: int = typer.Option(

--- a/agentkit/toolkit/cli/cli_invoke.py
+++ b/agentkit/toolkit/cli/cli_invoke.py
@@ -792,6 +792,23 @@ def _merge_harness_registry_overrides(
     return overrides
 
 
+def _enable_harness_registry_intent(overrides: dict[str, Any]) -> None:
+    space_id = overrides.get("registry_space_id")
+    if not space_id:
+        return
+
+    from agentkit.toolkit.cli.cli_add import (
+        _enable_a2a_space_intent,
+        _resolve_agentkit_openapi_target,
+    )
+
+    endpoint, region = _resolve_agentkit_openapi_target(
+        endpoint=overrides.get("registry_endpoint"),
+        region=overrides.get("registry_region"),
+    )
+    _enable_a2a_space_intent(str(space_id), endpoint=endpoint, region=region)
+
+
 # Fixed ADK app name for the run_sse path. The harness loader serves its single
 # agent under any app name, so a stable constant keeps the CLI decoupled from the
 # deployed HARNESS_NAME.
@@ -1073,8 +1090,9 @@ def harness_command(
             registry_endpoint=registry_endpoint,
             registry_region=registry_region,
         )
+        _enable_harness_registry_intent(registry_overrides)
     except _A2ARegisterError as e:
-        console.print(f"[red]Error: failed to resolve A2A space name: {e}[/red]")
+        console.print(f"[red]Error: failed to configure A2A registry: {e}[/red]")
         raise typer.Exit(1)
     except ValueError as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/docs/content/2.agentkit-cli/2.commands.md
+++ b/docs/content/2.agentkit-cli/2.commands.md
@@ -388,7 +388,7 @@ agentkit add harness --name <name> [options]
 | `--runtime` | Agent 运行时后端：`adk`（默认）或 `codex`。 | `--runtime adk` |
 | `--structured-tool-calls` | 要求模型输出可执行的结构化工具调用。 | `--structured-tool-calls` |
 | `--include-tools-every-turn` | 每轮模型调用都注入工具定义，提高多轮工具调用稳定性。 | `--include-tools-every-turn` |
-| `--registry` | A2A registry URI；传 `disabled` 可显式关闭已配置的 registry。 | `--registry disabled` |
+| `--registry` | A2A registry URI；传 `default` 等价于 `agentkit://a2a-registry?space_name=Default&region=cn-beijing&endpoint=https://open.volcengineapi.com/`；传 `disabled` 可显式关闭已配置的 registry。 | `--registry default` |
 | `--registry-space-id` | A2A Registry SpaceId，传入后启用 `agentkit_a2a` registry。 | `--registry-space-id as-xxx` |
 | `--registry-space-name` | A2A Registry Space 名称，CLI 会调用 `ListA2aSpaces` 解析为 SpaceId。 | `--registry-space-name my-space` |
 | `--registry-top-k` | registry 检索候选 AgentCard 数量。 | `--registry-top-k 3` |
@@ -451,6 +451,9 @@ agentkit add harness --name my-harness \
   --registry-top-k 3 \
   --structured-tool-calls \
   --include-tools-every-turn
+
+# 使用默认 A2A Registry（Default space，cn-beijing，公网 OpenAPI 网关）
+agentkit add harness --name my-harness --registry default
 
 # 也可以使用 A2A Space 名称开启 Registry
 agentkit add harness --name my-harness \
@@ -1611,6 +1614,7 @@ agentkit invoke harness <name> [消息内容] [选项]
 - 示例：`agentkit invoke harness my-harness --system-prompt "请简洁作答。" "2+2=?"`
 
 `--registry` / `--registry-space-id` / `--registry-space-name` / `--registry-top-k` / `--registry-endpoint` / `--registry-region` 单次 registry 覆写参数
+- `--registry default` 等价于 `--registry "agentkit://a2a-registry?space_name=Default&region=cn-beijing&endpoint=https://open.volcengineapi.com/"`
 - `--registry-space-name` 和 URI 中的 `space_name` 会在本地通过 `ListA2aSpaces` 解析为 space id 后传给运行时
 - URI 中只支持 `space_name`，不支持 `registry_space_name` 等别名
 - 示例：`agentkit invoke harness my-harness --registry-space-name my-space --registry-region cn-beijing "找一个财务专家"`

--- a/docs/content/2.agentkit-cli/2.commands.md
+++ b/docs/content/2.agentkit-cli/2.commands.md
@@ -400,6 +400,8 @@ agentkit add harness --name <name> [options]
 | `--register-network-type` | 注册网络类型。 | `--register-network-type public` |
 | `--directory` | 写入 `<name>.harness.json` 的目录（默认当前目录）。 | `--directory ./my_harness` |
 
+配置 A2A registry 时，CLI 会在解析出 SpaceId 后调用 `UpdateA2aSpace`，将该空间的 `IntentEnabled` 设置为 `true`，因此调用方需要 `agentkit:UpdateA2aSpace` 权限。部署后的 Harness Runtime 会在每轮对话前用用户输入的前 2048 个 UTF-8 bytes 调用 `SearchAgentCards`，再通过 `GetA2aAgent` 把本轮命中的远程 Agent 临时挂载为 `remote_a2a_*` 动态工具。
+
 ### 组件参数
 
 每个组件通过 `--<component>-type` 选择后端，并使用对应的连接参数。空类型表示禁用该组件。
@@ -1616,6 +1618,7 @@ agentkit invoke harness <name> [消息内容] [选项]
 `--registry` / `--registry-space-id` / `--registry-space-name` / `--registry-top-k` / `--registry-endpoint` / `--registry-region` 单次 registry 覆写参数
 - `--registry default` 等价于 `--registry "agentkit://a2a-registry?space_name=Default&region=cn-beijing&endpoint=https://open.volcengineapi.com/"`
 - `--registry-space-name` 和 URI 中的 `space_name` 会在本地通过 `ListA2aSpaces` 解析为 space id 后传给运行时
+- 解析出 space id 后会调用 `UpdateA2aSpace` 开启 `IntentEnabled=true`
 - URI 中只支持 `space_name`，不支持 `registry_space_name` 等别名
 - 示例：`agentkit invoke harness my-harness --registry-space-name my-space --registry-region cn-beijing "找一个财务专家"`
 

--- a/docs/content/2.agentkit-cli/5.harness.md
+++ b/docs/content/2.agentkit-cli/5.harness.md
@@ -66,7 +66,7 @@ my-harness/
 | `--runtime` | Agent 运行时后端。 | `adk`（默认）/ `codex` |
 | `--structured-tool-calls` / `--no-structured-tool-calls` | 是否要求模型输出可执行的结构化工具调用。 | 显式传入时写入 |
 | `--include-tools-every-turn` / `--reuse-tool-context` | 是否在每轮模型调用都注入工具定义。 | 显式传入时写入 |
-| `--registry` | A2A registry URI；传 `disabled` 可显式关闭 registry。 | — |
+| `--registry` | A2A registry URI；传 `default` 使用默认 A2A registry；传 `disabled` 可显式关闭 registry。 | — |
 | `--registry-space-id` | A2A Registry SpaceId。 | — |
 | `--registry-space-name` | A2A Registry Space 名称；CLI 会调用 `ListA2aSpaces` 解析为 SpaceId 后写入配置。 | — |
 | `--registry-top-k` | registry 检索候选 AgentCard 数量。 | — |
@@ -113,6 +113,12 @@ agentkit add harness --name my-harness \
   --registry-region cn-beijing
 ```
 
+如果要使用 AgentKit 默认 A2A Registry，可以直接传 `default`。它等价于 `agentkit://a2a-registry?space_name=Default&region=cn-beijing&endpoint=https://open.volcengineapi.com/`，CLI 会把 `Default` space name 解析为 space id 后写入 spec：
+
+```bash
+agentkit add harness --name my-harness --registry default
+```
+
 `--registry-endpoint` 用于指定 Harness Runtime 后续访问 A2A Registry OpenAPI 的地址。通常不传时会按 region 推导默认 endpoint；如果部署后的运行时环境无法解析 region 专属域名，或需要统一走火山引擎公网 OpenAPI 网关，可以显式设置为 `https://open.volcengineapi.com/`：
 
 ```bash
@@ -144,17 +150,7 @@ agentkit add harness --name my-harness \
 agentkit add harness --name my-harness --registry disabled
 ```
 
-该命令会把 spec 中的 `registry.type` 置为空字符串：
-
-```json
-{
-  "registry": {
-    "type": ""
-  }
-}
-```
-
-这表示运行时不再启用 `agentkit_a2a` registry。由于 `add harness` 只修改本地 `<name>.harness.json`，关闭或重新开启 registry 后都需要重新执行 `agentkit deploy --harness <name>`，云端运行时才会使用新配置。
+该命令会让 spec 不再保留 `registry` 配置，运行时也就不再启用 `agentkit_a2a` registry。由于 `add harness` 只修改本地 `<name>.harness.json`，关闭或重新开启 registry 后都需要重新执行 `agentkit deploy --harness <name>`，云端运行时才会使用新配置。
 
 当 Harness 需要通过 registry 检索并调用其他 A2A Agent 时，建议同时开启：
 
@@ -232,6 +228,9 @@ agentkit add harness --name my-harness \
   --registry-space-name my-space \
   --registry-top-k 3 \
   --registry-region cn-beijing
+
+# 使用默认 A2A Registry
+agentkit add harness --name my-harness --registry default
 
 # 关闭已配置的 A2A Registry
 agentkit add harness --name my-harness --registry disabled
@@ -359,7 +358,7 @@ agentkit add harness --name my-harness \
 | `--tools` | 覆写工具（逗号分隔，增量加入）。 | — |
 | `--skills` | 覆写技能（逗号分隔，增量加入）。 | — |
 | `--runtime` | 覆写运行时后端。 | `adk` / `codex` |
-| `--registry` | 覆写 A2A registry。支持 `agentkit://a2a-registry?space_id=xxx&top_k=3`、`agentkit://a2a-registry?space_name=xxx` 或 `http(s)` URL。 | — |
+| `--registry` | 覆写 A2A registry。支持 `default`、`agentkit://a2a-registry?space_id=xxx&top_k=3`、`agentkit://a2a-registry?space_name=xxx` 或 `http(s)` URL。 | — |
 | `--registry-space-id` | 覆写 A2A registry space id。 | — |
 | `--registry-space-name` | 覆写 A2A registry space name。CLI 会调用 `ListA2aSpaces` 解析为 space id 后传给运行时。 | — |
 | `--registry-top-k` | 覆写 registry 检索 AgentCard 数量。 | — |
@@ -403,6 +402,11 @@ agentkit invoke harness my-harness \
 # URI 中也可以使用 space_name；不支持 registry_space_name 等别名
 agentkit invoke harness my-harness \
   --registry "agentkit://a2a-registry?space_name=my-space&top_k=1&region=cn-beijing&endpoint=https%3A%2F%2Fopen.volcengineapi.com%2F" \
+  "帮我找一个财务报销专家"
+
+# 使用默认 A2A Registry 作为本次调用覆写
+agentkit invoke harness my-harness \
+  --registry default \
   "帮我找一个财务报销专家"
 
 # 改用 invoke（非流式 /harness/invoke），并限制最大 LLM 调用次数

--- a/docs/content/2.agentkit-cli/5.harness.md
+++ b/docs/content/2.agentkit-cli/5.harness.md
@@ -119,6 +119,10 @@ agentkit add harness --name my-harness \
 agentkit add harness --name my-harness --registry default
 ```
 
+当 registry 最终解析出 A2A SpaceId 后，CLI 会额外调用 `UpdateA2aSpace` 并设置 `IntentEnabled=true`，开启该空间的语义检索能力。调用方需要具备 `agentkit:UpdateA2aSpace` 权限。
+
+部署后的 Harness Runtime 在每轮用户对话开始前，会用用户原始输入的前 2048 个 UTF-8 bytes 调用 `SearchAgentCards`；对本轮返回的每个 AgentCard，再调用 `GetA2aAgent` 获取 endpoint 与鉴权信息，并临时包装为本轮可用的 `remote_a2a_*` 工具。这些动态工具只对当前轮次生效，不写回 spec，也不污染已部署的基础 Agent。
+
 `--registry-endpoint` 用于指定 Harness Runtime 后续访问 A2A Registry OpenAPI 的地址。通常不传时会按 region 推导默认 endpoint；如果部署后的运行时环境无法解析 region 专属域名，或需要统一走火山引擎公网 OpenAPI 网关，可以显式设置为 `https://open.volcengineapi.com/`：
 
 ```bash
@@ -368,6 +372,8 @@ agentkit add harness --name my-harness \
 | `--raw` | 打印原始响应（`InvokeHarnessResponse` / SSE）。 | `false` |
 
 > `--max-llm-calls` 不属于 ADK `run_sse` 请求，故仅在 `invoke` 模式生效；在 `run_sse` 模式传入会被忽略并提示。
+
+当本次调用通过 `--registry` / `--registry-space-id` / `--registry-space-name` 指定了 A2A SpaceId 时，CLI 同样会先调用 `UpdateA2aSpace` 开启 `IntentEnabled=true`，再把 registry 覆写发送给 Harness Runtime。
 
 ```bash
 # 基础调用（run_sse，默认，流式）

--- a/tests/toolkit/cli/test_cli_add_harness.py
+++ b/tests/toolkit/cli/test_cli_add_harness.py
@@ -29,6 +29,10 @@ def _run(args):
     return runner.invoke(app, ["add", *args])
 
 
+def _squash_output(value: str) -> str:
+    return " ".join(value.split())
+
+
 def test_creates_harness_json_with_layered_structure(tmp_path):
     result = _run(
         [
@@ -247,6 +251,45 @@ def test_registry_uri_space_name_uses_uri_endpoint_and_region(tmp_path, monkeypa
     }
 
 
+def test_registry_default_resolves_default_space(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_resolve_space_name(space_name, *, endpoint, region):
+        captured.update({"space_name": space_name, "endpoint": endpoint, "region": region})
+        return "space-default"
+
+    monkeypatch.setattr(
+        "agentkit.toolkit.cli.cli_add._resolve_a2a_space_id_by_name",
+        fake_resolve_space_name,
+    )
+
+    result = _run(
+        [
+            "harness",
+            "--name",
+            "h",
+            "--registry",
+            "default",
+            "--directory",
+            str(tmp_path),
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads((tmp_path / "h.harness.json").read_text())
+    assert data["registry"] == {
+        "type": "agentkit_a2a",
+        "space_id": "space-default",
+        "endpoint": "https://open.volcengineapi.com/",
+        "region": "cn-beijing",
+    }
+    assert captured == {
+        "space_name": "Default",
+        "endpoint": "https://open.volcengineapi.com/",
+        "region": "cn-beijing",
+    }
+
+
 def test_resolve_a2a_space_id_by_name_paginates_all_spaces(monkeypatch):
     calls = []
 
@@ -296,7 +339,7 @@ def test_resolve_a2a_space_id_by_name_paginates_all_spaces(monkeypatch):
     ]
 
 
-def test_registry_disabled_turns_off_registry(tmp_path):
+def test_registry_disabled_is_pruned_from_harness_spec(tmp_path):
     result = _run(
         [
             "harness",
@@ -311,7 +354,7 @@ def test_registry_disabled_turns_off_registry(tmp_path):
 
     assert result.exit_code == 0, result.output
     data = json.loads((tmp_path / "h.harness.json").read_text())
-    assert data["registry"] == {"type": ""}
+    assert "registry" not in data
 
 
 def test_registry_off_is_not_supported(tmp_path):
@@ -328,7 +371,7 @@ def test_registry_off_is_not_supported(tmp_path):
     )
 
     assert result.exit_code == 1
-    assert "`disabled` is supported" in result.output
+    assert "`default` / `disabled` is supported" in _squash_output(result.output)
 
 
 def test_registry_config_maps_to_runtime_env():
@@ -479,7 +522,7 @@ def test_add_harness_register_self_requires_harness_json_entry(tmp_path):
     )
 
     assert result.exit_code == 1
-    assert "does not contain an entry for 'h'" in result.output
+    assert "does not contain an entry for 'h'" in _squash_output(result.output)
 
 
 def test_add_harness_register_self_requires_url_and_runtime_id(tmp_path):
@@ -499,7 +542,7 @@ def test_add_harness_register_self_requires_url_and_runtime_id(tmp_path):
     )
 
     assert result.exit_code == 1
-    assert "missing required field(s): runtime_id" in result.output
+    assert "missing required field(s): runtime_id" in _squash_output(result.output)
 
 
 def test_add_harness_register_self_rejects_invalid_network_type(tmp_path):

--- a/tests/toolkit/cli/test_cli_add_harness.py
+++ b/tests/toolkit/cli/test_cli_add_harness.py
@@ -346,6 +346,60 @@ def test_registry_default_resolves_default_space(tmp_path, monkeypatch):
     }
 
 
+def test_registry_default_overrides_existing_space_id(tmp_path, monkeypatch):
+    (tmp_path / "h.harness.json").write_text(
+        json.dumps(
+            {
+                "harness_name": "h",
+                "runtime": "adk",
+                "short_term_memory": {"type": "local"},
+                "registry": {
+                    "type": "agentkit_a2a",
+                    "space_id": "as-old",
+                    "endpoint": "https://open.volcengineapi.com/",
+                    "region": "cn-beijing",
+                },
+            }
+        )
+    )
+    captured = {}
+
+    def fake_resolve_space_name(space_name, *, endpoint, region):
+        captured.update({"space_name": space_name, "endpoint": endpoint, "region": region})
+        return "as-default"
+
+    monkeypatch.setattr(
+        "agentkit.toolkit.cli.cli_add._resolve_a2a_space_id_by_name",
+        fake_resolve_space_name,
+    )
+
+    result = _run(
+        [
+            "harness",
+            "--name",
+            "h",
+            "--registry",
+            "default",
+            "--directory",
+            str(tmp_path),
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads((tmp_path / "h.harness.json").read_text())
+    assert data["registry"] == {
+        "type": "agentkit_a2a",
+        "endpoint": "https://open.volcengineapi.com/",
+        "region": "cn-beijing",
+        "space_id": "as-default",
+    }
+    assert captured == {
+        "space_name": "Default",
+        "endpoint": "https://open.volcengineapi.com/",
+        "region": "cn-beijing",
+    }
+
+
 def test_resolve_a2a_space_id_by_name_paginates_all_spaces(monkeypatch):
     calls = []
 

--- a/tests/toolkit/cli/test_cli_add_harness.py
+++ b/tests/toolkit/cli/test_cli_add_harness.py
@@ -16,6 +16,7 @@
 
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from agentkit.toolkit.cli.cli import app
@@ -31,6 +32,16 @@ def _run(args):
 
 def _squash_output(value: str) -> str:
     return " ".join(value.split())
+
+
+@pytest.fixture(autouse=True)
+def _fake_update_a2a_space_intent(monkeypatch):
+    def fake_agentkit_post(*, endpoint, version, region, action, body):
+        if action != "UpdateA2aSpace":
+            raise AssertionError(f"unexpected AgentKit action: {action}")
+        return {"ResponseMetadata": {"RequestId": "req-update"}, "Result": {}}, 1
+
+    monkeypatch.setattr(cli_add, "_agentkit_post", fake_agentkit_post)
 
 
 def test_creates_harness_json_with_layered_structure(tmp_path):
@@ -167,6 +178,51 @@ def test_registry_flags_write_agentkit_a2a_section(tmp_path):
     }
     assert data["structured_tool_calls"] is True
     assert data["include_tools_every_turn"] is True
+
+
+def test_registry_add_enables_a2a_space_intent(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_agentkit_post(*, endpoint, version, region, action, body):
+        calls.append(
+            {
+                "endpoint": endpoint,
+                "version": version,
+                "region": region,
+                "action": action,
+                "body": body,
+            }
+        )
+        return {"ResponseMetadata": {"RequestId": "req-update"}, "Result": {}}, 1
+
+    monkeypatch.setattr(cli_add, "_agentkit_post", fake_agentkit_post)
+
+    result = _run(
+        [
+            "harness",
+            "--name",
+            "h",
+            "--registry-space-id",
+            "as-test",
+            "--registry-endpoint",
+            "https://open.volcengineapi.com/?unused=1",
+            "--registry-region",
+            "cn-beijing",
+            "--directory",
+            str(tmp_path),
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "endpoint": "https://open.volcengineapi.com/",
+            "version": "2025-10-30",
+            "region": "cn-beijing",
+            "action": "UpdateA2aSpace",
+            "body": {"Id": "as-test", "IntentEnabled": True},
+        }
+    ]
 
 
 def test_registry_space_name_resolves_to_space_id(tmp_path, monkeypatch):

--- a/tests/toolkit/cli/test_cli_invoke_harness.py
+++ b/tests/toolkit/cli/test_cli_invoke_harness.py
@@ -177,7 +177,7 @@ def test_harness_invoke_posts_registry_overrides(tmp_path, monkeypatch):
     captured = {}
     _patch_post(monkeypatch, captured)
 
-    result = _run_harness(
+    result = _run_invoke(
         [
             "first",
             "Find a finance expert.",
@@ -314,6 +314,48 @@ def test_harness_invoke_registry_uri_space_name_resolves_to_space_id(tmp_path, m
     }
     assert resolved == {
         "space_name": "space-name",
+        "endpoint": "https://open.volcengineapi.com/",
+        "region": "cn-beijing",
+    }
+
+
+def test_harness_invoke_registry_default_resolves_default_space(tmp_path, monkeypatch):
+    _write_registry(
+        tmp_path,
+        {"first": {"url": "https://x", "key": "ak", "runtime_id": "r-1"}},
+    )
+    captured = {}
+    resolved = {}
+    _patch_post(monkeypatch, captured)
+
+    def fake_resolve_space_name(space_name, *, endpoint, region):
+        resolved.update({"space_name": space_name, "endpoint": endpoint, "region": region})
+        return "space-default"
+
+    monkeypatch.setattr(
+        "agentkit.toolkit.cli.cli_add._resolve_a2a_space_id_by_name",
+        fake_resolve_space_name,
+    )
+
+    result = _run_invoke(
+        [
+            "first",
+            "Find a finance expert.",
+            "--directory",
+            str(tmp_path),
+            "--registry",
+            "default",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["json"]["harness"] == {
+        "registry_space_id": "space-default",
+        "registry_endpoint": "https://open.volcengineapi.com/",
+        "registry_region": "cn-beijing",
+    }
+    assert resolved == {
+        "space_name": "Default",
         "endpoint": "https://open.volcengineapi.com/",
         "region": "cn-beijing",
     }

--- a/tests/toolkit/cli/test_cli_invoke_harness.py
+++ b/tests/toolkit/cli/test_cli_invoke_harness.py
@@ -35,6 +35,14 @@ def _isolate_login_home(monkeypatch, tmp_path):
     monkeypatch.setenv("AGENTKIT_HOME", str(tmp_path / "_agentkit_home"))
 
 
+@pytest.fixture(autouse=True)
+def _skip_a2a_space_intent_update(monkeypatch):
+    monkeypatch.setattr(
+        "agentkit.toolkit.cli.cli_add._enable_a2a_space_intent",
+        lambda *args, **kwargs: None,
+    )
+
+
 def _write_registry(directory, mapping):
     """Write the ``harness.json`` registry that ``deploy --harness`` produces."""
     (directory / "harness.json").write_text(json.dumps(mapping))
@@ -201,6 +209,50 @@ def test_harness_invoke_posts_registry_overrides(tmp_path, monkeypatch):
         "registry_endpoint": "https://open.volcengineapi.com/",
         "registry_region": "cn-beijing",
     }
+
+
+def test_harness_invoke_registry_override_enables_space_intent(tmp_path, monkeypatch):
+    _write_registry(
+        tmp_path,
+        {"first": {"url": "https://x", "key": "ak", "runtime_id": "r-1"}},
+    )
+    captured = {}
+    intent_calls = []
+    _patch_post(monkeypatch, captured)
+
+    def fake_enable(space_id, *, endpoint, region):
+        intent_calls.append(
+            {"space_id": space_id, "endpoint": endpoint, "region": region}
+        )
+
+    monkeypatch.setattr(
+        "agentkit.toolkit.cli.cli_add._enable_a2a_space_intent",
+        fake_enable,
+    )
+
+    result = _run_invoke(
+        [
+            "first",
+            "Find a finance expert.",
+            "--directory",
+            str(tmp_path),
+            "--registry-space-id",
+            "space-override",
+            "--registry-endpoint",
+            "https://open.volcengineapi.com/?unused=1",
+            "--registry-region",
+            "cn-beijing",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert intent_calls == [
+        {
+            "space_id": "space-override",
+            "endpoint": "https://open.volcengineapi.com/",
+            "region": "cn-beijing",
+        }
+    ]
 
 
 def test_harness_invoke_registry_uri_override(tmp_path, monkeypatch):


### PR DESCRIPTION
## 变更说明

- 支持 `agentkit add harness --registry default` 和 `agentkit invoke harness --registry default`，默认使用 Default A2A Space、`cn-beijing` 和公网 OpenAPI endpoint。
- 在 registry 配置或单次 invoke 覆写解析出 SpaceId 后，自动调用 `UpdateA2aSpace` 开启 `IntentEnabled=true`，确保 A2A Space 开启语义检索功能（Default空间暂时不支持前端开启语义检索，所以增加了这部分）。
- Harness Runtime 在每轮对话开始前，会基于用户输入调用 `SearchAgentCards` 搜索匹配的远端 A2A Agent；对搜索结果再调用 `GetA2aAgent` 获取 Agent endpoint、鉴权等信息，并将这些远端 Agent 临时包装为本轮可用的 `remote_a2a_*` 动态工具。