### PR TITLE
fix(runtime): don't generate an unused API key name for custom_jwt deploys

### DIFF
--- a/agentkit/toolkit/runners/ve_agentkit.py
+++ b/agentkit/toolkit/runners/ve_agentkit.py
@@ -585,8 +585,11 @@ class VeAgentkitRuntimeRunner(Runner):
                     f"Generated role name: {config.runtime_role_name}"
                 )
 
-            # Generate API key name if not provided
-            if (
+            # Generate API key name if not provided. Skipped for custom_jwt: the
+            # gateway authorizes via JWT and never uses an API key (see
+            # _build_authorizer_config_for_create), so generating one here only
+            # produced a misleading "Generated API key name" line.
+            if config.runtime_auth_type != AUTH_TYPE_CUSTOM_JWT and (
                 config.runtime_apikey_name == AUTO_CREATE_VE
                 or not config.runtime_apikey_name
             ):

--- a/tests/toolkit/runners/test_ve_agentkit_apikey_auth.py
+++ b/tests/toolkit/runners/test_ve_agentkit_apikey_auth.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`_prepare_runtime_config` API-key-name generation is gated on auth type."""
+
+from agentkit.toolkit.config.constants import (
+    AUTH_TYPE_CUSTOM_JWT,
+    AUTH_TYPE_KEY_AUTH,
+    AUTO_CREATE_VE,
+)
+from agentkit.toolkit.runners.ve_agentkit import (
+    VeAgentkitRunnerConfig,
+    VeAgentkitRuntimeRunner,
+)
+
+
+def _config(auth_type: str) -> VeAgentkitRunnerConfig:
+    # Pin name/role so only the API-key-name branch is exercised.
+    return VeAgentkitRunnerConfig(
+        runtime_name="rt",
+        runtime_role_name="role",
+        runtime_apikey_name=AUTO_CREATE_VE,
+        runtime_auth_type=auth_type,
+    )
+
+
+def test_custom_jwt_does_not_generate_api_key_name():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _config(AUTH_TYPE_CUSTOM_JWT)
+
+    assert runner._prepare_runtime_config(cfg) is True
+    # custom_jwt authorizes via JWT, so no API key name is generated.
+    assert cfg.runtime_apikey_name == AUTO_CREATE_VE
+
+
+def test_key_auth_still_generates_api_key_name():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _config(AUTH_TYPE_KEY_AUTH)
+
+    assert runner._prepare_runtime_config(cfg) is True
+    # key_auth uses the API key name, so it is generated (no longer "Auto").
+    assert cfg.runtime_apikey_name not in (AUTO_CREATE_VE, "")


### PR DESCRIPTION
## Problem
When deploying a harness with OAuth2/JWT (`custom_jwt`), the deploy still printed:
```
✅ Generated API key name: API-KEY-xxxx
```
and the resolved config carried `runtime_apikey_name` / `runtime_apikey: Auto` alongside `runtime_auth_type: custom_jwt` — misleading, since under `custom_jwt` the gateway authorizes via JWT and the API key is never used.

## Root cause
`VeAgentkitRuntimeRunner._prepare_runtime_config` generated an API key name whenever `runtime_apikey_name == "Auto"`, **without checking the auth type**. `_build_authorizer_config_for_create` only reads `runtime_apikey_name` in the `key_auth` branch; the `custom_jwt` branch builds a JWT authorizer and ignores it. So the generated key was unused and the log line was pure noise.

## Fix
Skip API-key-name generation (and its log line) when `runtime_auth_type == custom_jwt`. `key_auth` behavior is unchanged.

## Test
`tests/toolkit/runners/test_ve_agentkit_apikey_auth.py`:
- custom_jwt → `runtime_apikey_name` stays `Auto` (not generated)
- key_auth → `runtime_apikey_name` is generated

`pytest tests/toolkit/runners/test_ve_agentkit_apikey_auth.py` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)