### PR TITLE
feat(sandbox): add IAM role and WebSearch API key config for sandbox …

### DIFF
--- a/agentkit/toolkit/cli/sandbox/cli.py
+++ b/agentkit/toolkit/cli/sandbox/cli.py
@@ -33,7 +33,10 @@ sandbox_app = typer.Typer(
     no_args_is_help=True,
 )
 
-sandbox_app.command(name="create")(create_command)
+sandbox_app.command(
+    name="create",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)(create_command)
 sandbox_app.command(name="get")(get_command)
 sandbox_app.command(name="mount")(mount_command)
 sandbox_app.command(

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -74,9 +74,7 @@ DEFAULT_BROWSER_EXTRA_ARGS = (
     "--use-angle=swiftshader-webgl --ignore-gpu-blocklist"
 )
 WEB_SEARCH_API_KEY_ENV = "WEB_SEARCH_API_KEY"
-SKILL_ROLE_TYPE_EXISTED = "existed"
-SKILL_ROLE_TYPE_NEW = "new"
-VALID_SKILL_ROLE_TYPES = (SKILL_ROLE_TYPE_EXISTED, SKILL_ROLE_TYPE_NEW)
+SKILL_ROLE_NAME_OPTION = "--skill-role-name"
 TOOL_READY_STATUS = "Ready"
 TOOL_FAILED_STATUSES = {"Error", "Failed", "CreateFailed", "Deleting", "Deleted"}
 TOOL_WAIT_INTERVAL_SECONDS = 5
@@ -361,29 +359,54 @@ def _generate_default_role_name() -> str:
 
 
 def _resolve_skill_role(
-    skill_role_type: Optional[str],
     skill_role_name: Optional[str],
+    skill_role_name_provided: bool,
     region: str,
 ) -> Optional[str]:
-    if not skill_role_type:
+    if not skill_role_name_provided:
         return None
-    resolved_type = skill_role_type.strip().lower()
-    if resolved_type not in VALID_SKILL_ROLE_TYPES:
-        allowed = ", ".join(VALID_SKILL_ROLE_TYPES)
-        raise typer.BadParameter(
-            f"--skill-role-type must be one of: {allowed}"
-        )
     resolved_name = (skill_role_name or "").strip()
     if not resolved_name:
-        if resolved_type == SKILL_ROLE_TYPE_NEW:
-            resolved_name = _generate_default_role_name()
-        else:
-            raise typer.BadParameter(
-                "--skill-role-name is required when --skill-role-type=existed"
-            )
-    if resolved_type == SKILL_ROLE_TYPE_NEW:
-        _ensure_sandbox_role(resolved_name, region)
+        resolved_name = _generate_default_role_name()
+    _ensure_sandbox_role(resolved_name, region)
     return resolved_name
+
+
+def _resolve_create_extra_args(
+    ctx: typer.Context,
+) -> tuple[Optional[str], bool]:
+    raw_args = list(ctx.args)
+    skill_role_name: Optional[str] = None
+    skill_role_name_provided = False
+    remaining_args: list[str] = []
+    index = 0
+    while index < len(raw_args):
+        current = raw_args[index]
+        if current == SKILL_ROLE_NAME_OPTION:
+            if skill_role_name_provided:
+                error(f"{SKILL_ROLE_NAME_OPTION} cannot be provided multiple times")
+            skill_role_name_provided = True
+            if index + 1 < len(raw_args) and not raw_args[index + 1].startswith("-"):
+                skill_role_name = raw_args[index + 1]
+                index += 2
+                continue
+            index += 1
+            continue
+        if current.startswith(f"{SKILL_ROLE_NAME_OPTION}="):
+            if skill_role_name_provided:
+                error(f"{SKILL_ROLE_NAME_OPTION} cannot be provided multiple times")
+            skill_role_name_provided = True
+            skill_role_name = current.split("=", 1)[1]
+            index += 1
+            continue
+        remaining_args.append(current)
+        index += 1
+
+    if remaining_args:
+        unknown = " ".join(remaining_args)
+        error(f"Unknown arguments: {unknown}")
+
+    return skill_role_name, skill_role_name_provided
 
 
 def create_tool(
@@ -396,18 +419,22 @@ def create_tool(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
-    skill_role_type: Optional[str] = None,
     skill_role_name: Optional[str] = None,
+    skill_role_name_provided: bool = False,
     websearch_apikey: Optional[str] = None,
 ) -> dict[str, object]:
     resolved_model_provider = normalize_model_provider(model_provider)
     region = _resolve_region(SANDBOX_REGION_ENV, "agentkit")
     tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV, "tos")
 
-    if skill_role_type and websearch_apikey:
-        error("--skill-role-type and --websearch-apikey are mutually exclusive")
+    if skill_role_name_provided and websearch_apikey:
+        error("--skill-role-name and --websearch-apikey are mutually exclusive")
 
-    resolved_role_name = _resolve_skill_role(skill_role_type, skill_role_name, region)
+    resolved_role_name = _resolve_skill_role(
+        skill_role_name,
+        skill_role_name_provided,
+        region,
+    )
     resolved_websearch_apikey = (websearch_apikey or "").strip() or None
 
     request = _build_create_tool_request(
@@ -438,12 +465,12 @@ def create_tool(
         "status": final_tool.status or TOOL_READY_STATUS,
         "model_provider": resolved_model_provider,
         "role_name": resolved_role_name,
-        "skill_role_type": skill_role_type,
         "websearch_apikey_set": bool(resolved_websearch_apikey),
     }
 
 
 def create_command(
+    ctx: typer.Context,
     tool_type: str = typer.Option(
         DEFAULT_CREATE_TOOL_TYPE,
         "--tool-type",
@@ -497,35 +524,25 @@ def create_command(
         "--model-provider",
         help="Model provider to use for base URLs, defaults, and model catalog.",
     ),
-    skill_role_type: Optional[str] = typer.Option(
-        None,
-        "--skill-role-type",
-        help=(
-            "Skill role type: 'existed' to use an existing role, "
-            "'new' to create one. Mutually exclusive with --websearch-apikey."
-        ),
-    ),
-    skill_role_name: Optional[str] = typer.Option(
-        None,
-        "--skill-role-name",
-        help=(
-            "IAM role name. Required when --skill-role-type=existed; "
-            "auto-generated when --skill-role-type=new and omitted."
-        ),
-    ),
     websearch_apikey: Optional[str] = typer.Option(
         None,
         "--websearch-apikey",
         help=(
             "Web search API key to inject as WEB_SEARCH_API_KEY env. "
-            "Mutually exclusive with --skill-role-type. "
-            "Use --enable-websearch-apikey in exec to toggle per session."
+            f"Mutually exclusive with {SKILL_ROLE_NAME_OPTION}. "
+            "Use --disable-websearch-apikey in exec to disable it per session."
         ),
     ),
 ) -> None:
-    """Create an AgentKit Tool with optional TOS mount."""
+    """Create an AgentKit Tool with optional TOS mount.
+
+    Extra option:
+    - --skill-role-name ROLE_NAME: reuse the role if it exists, otherwise create it
+    - --skill-role-name: create a role with an auto-generated name
+    """
     result = None
     try:
+        skill_role_name, skill_role_name_provided = _resolve_create_extra_args(ctx)
         if tos_mount is not None and not (tos_bucket or "").strip():
             error("--tos-mount requires --tos-bucket")
         result = create_tool(
@@ -537,8 +554,8 @@ def create_command(
             model_name=model_name,
             model_api_key=model_api_key,
             model_provider=model_provider.value,
-            skill_role_type=skill_role_type,
             skill_role_name=skill_role_name,
+            skill_role_name_provided=skill_role_name_provided,
             websearch_apikey=websearch_apikey,
         )
         save_tool_result(str(result["tool_type"]), result)
@@ -553,4 +570,7 @@ def create_command(
     if result.get("role_name"):
         typer.echo(f"角色名：{result['role_name']}")
     if not result.get("role_name") and not result.get("websearch_apikey_set"):
-        typer.echo("提示：未配置 WebSearch（可通过 --skill-role-type 配置 Role 或 --websearch-apikey 配置 API Key 来启用）")
+        typer.echo(
+            "提示：未配置 WebSearch（可通过 --skill-role-name 配置 Role 或 "
+            "--websearch-apikey 配置 API Key 来启用）"
+        )

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -73,6 +73,10 @@ DEFAULT_BROWSER_EXTRA_ARGS = (
     "--enable-unsafe-swiftshader --use-gl=angle "
     "--use-angle=swiftshader-webgl --ignore-gpu-blocklist"
 )
+WEB_SEARCH_API_KEY_ENV = "WEB_SEARCH_API_KEY"
+SKILL_ROLE_TYPE_EXISTED = "existed"
+SKILL_ROLE_TYPE_NEW = "new"
+VALID_SKILL_ROLE_TYPES = (SKILL_ROLE_TYPE_EXISTED, SKILL_ROLE_TYPE_NEW)
 TOOL_READY_STATUS = "Ready"
 TOOL_FAILED_STATUSES = {"Error", "Failed", "CreateFailed", "Deleting", "Deleted"}
 TOOL_WAIT_INTERVAL_SECONDS = 5
@@ -171,6 +175,7 @@ def _build_tool_model_envs(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    websearch_apikey: Optional[str] = None,
 ) -> list[tools_types.EnvsItemForCreateTool] | None:
     envs: list[tools_types.EnvsItemForCreateTool] = []
     provider_config = get_model_provider_config(model_provider)
@@ -192,6 +197,7 @@ def _build_tool_model_envs(
     )
     _append_tool_envs(envs, DISABLED_SERVICE_ENV_KEYS, "true")
     _append_tool_envs(envs, (BROWSER_EXTRA_ARGS_ENV,), DEFAULT_BROWSER_EXTRA_ARGS)
+    _append_tool_envs(envs, (WEB_SEARCH_API_KEY_ENV,), websearch_apikey)
     if tool_type.strip() == DEFAULT_CREATE_TOOL_TYPE:
         _append_code_env_tool_envs(envs, resolved_model_name, model_provider)
     return envs or None
@@ -208,6 +214,8 @@ def _build_create_tool_request(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    role_name: Optional[str] = None,
+    websearch_apikey: Optional[str] = None,
 ) -> tools_types.CreateToolRequest:
     resolved_tool_type = tool_type.strip() or DEFAULT_CREATE_TOOL_TYPE
     resolved_name = (name or "").strip() or _generate_tool_name(resolved_tool_type)
@@ -225,6 +233,7 @@ def _build_create_tool_request(
         ToolType=resolved_tool_type,
         CpuMilli=cpu_milli,
         MemoryMb=memory_mb,
+        RoleName=role_name,
         AuthorizerConfiguration=tools_types.AuthorizerForCreateTool(
             KeyAuth=tools_types.AuthorizerKeyAuthForCreateTool(
                 ApiKeyName=generate_apikey_name(),
@@ -241,6 +250,7 @@ def _build_create_tool_request(
             model_name=model_name,
             model_api_key=model_api_key,
             model_provider=model_provider,
+            websearch_apikey=websearch_apikey,
         ),
     )
 
@@ -301,6 +311,81 @@ def _wait_for_tool_ready(
         time.sleep(interval_seconds)
 
 
+def _ensure_sandbox_role(
+    role_name: str,
+    region: str,
+) -> str:
+    import json as _json
+    from agentkit.toolkit.volcengine.iam import VeIAM
+
+    iam = VeIAM(region=region)
+    existing = iam.get_role(role_name)
+    if existing is not None:
+        return role_name
+
+    agentkit_service_code = (
+        (
+            os.getenv("VOLCENGINE_AGENTKIT_SERVICE")
+            or os.getenv("VOLC_AGENTKIT_SERVICE")
+            or os.getenv("BYTEPLUS_AGENTKIT_SERVICE")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    service = "vefaas"
+    if "stg" in agentkit_service_code:
+        service = "vefaas_dev"
+    trust_policy = _json.dumps(
+        {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["sts:AssumeRole"],
+                    "Principal": {"Service": [service]},
+                }
+            ]
+        }
+    )
+    iam.create_role(role_name, trust_policy)
+    iam.attach_role_policy(
+        role_name,
+        policy_name="AgentKitSkillsSandboxAccess",
+        policy_type="System",
+    )
+    return role_name
+
+
+def _generate_default_role_name() -> str:
+    return f"agentkit-sandbox-{generate_random_id(8)}"
+
+
+def _resolve_skill_role(
+    skill_role_type: Optional[str],
+    skill_role_name: Optional[str],
+    region: str,
+) -> Optional[str]:
+    if not skill_role_type:
+        return None
+    resolved_type = skill_role_type.strip().lower()
+    if resolved_type not in VALID_SKILL_ROLE_TYPES:
+        allowed = ", ".join(VALID_SKILL_ROLE_TYPES)
+        raise typer.BadParameter(
+            f"--skill-role-type must be one of: {allowed}"
+        )
+    resolved_name = (skill_role_name or "").strip()
+    if not resolved_name:
+        if resolved_type == SKILL_ROLE_TYPE_NEW:
+            resolved_name = _generate_default_role_name()
+        else:
+            raise typer.BadParameter(
+                "--skill-role-name is required when --skill-role-type=existed"
+            )
+    if resolved_type == SKILL_ROLE_TYPE_NEW:
+        _ensure_sandbox_role(resolved_name, region)
+    return resolved_name
+
+
 def create_tool(
     *,
     tool_type: str = DEFAULT_CREATE_TOOL_TYPE,
@@ -311,10 +396,20 @@ def create_tool(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    skill_role_type: Optional[str] = None,
+    skill_role_name: Optional[str] = None,
+    websearch_apikey: Optional[str] = None,
 ) -> dict[str, object]:
     resolved_model_provider = normalize_model_provider(model_provider)
     region = _resolve_region(SANDBOX_REGION_ENV, "agentkit")
     tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV, "tos")
+
+    if skill_role_type and websearch_apikey:
+        error("--skill-role-type and --websearch-apikey are mutually exclusive")
+
+    resolved_role_name = _resolve_skill_role(skill_role_type, skill_role_name, region)
+    resolved_websearch_apikey = (websearch_apikey or "").strip() or None
+
     request = _build_create_tool_request(
         tool_type=tool_type,
         name=tool_name,
@@ -325,6 +420,8 @@ def create_tool(
         model_name=model_name,
         model_api_key=model_api_key,
         model_provider=resolved_model_provider,
+        role_name=resolved_role_name,
+        websearch_apikey=resolved_websearch_apikey,
     )
     client = AgentkitToolsClient(
         region=region,
@@ -340,6 +437,9 @@ def create_tool(
         "name": final_tool.name or request.name,
         "status": final_tool.status or TOOL_READY_STATUS,
         "model_provider": resolved_model_provider,
+        "role_name": resolved_role_name,
+        "skill_role_type": skill_role_type,
+        "websearch_apikey_set": bool(resolved_websearch_apikey),
     }
 
 
@@ -397,8 +497,34 @@ def create_command(
         "--model-provider",
         help="Model provider to use for base URLs, defaults, and model catalog.",
     ),
+    skill_role_type: Optional[str] = typer.Option(
+        None,
+        "--skill-role-type",
+        help=(
+            "Skill role type: 'existed' to use an existing role, "
+            "'new' to create one. Mutually exclusive with --websearch-apikey."
+        ),
+    ),
+    skill_role_name: Optional[str] = typer.Option(
+        None,
+        "--skill-role-name",
+        help=(
+            "IAM role name. Required when --skill-role-type=existed; "
+            "auto-generated when --skill-role-type=new and omitted."
+        ),
+    ),
+    websearch_apikey: Optional[str] = typer.Option(
+        None,
+        "--websearch-apikey",
+        help=(
+            "Web search API key to inject as WEB_SEARCH_API_KEY env. "
+            "Mutually exclusive with --skill-role-type. "
+            "Use --enable-websearch-apikey in exec to toggle per session."
+        ),
+    ),
 ) -> None:
     """Create an AgentKit Tool with optional TOS mount."""
+    result = None
     try:
         if tos_mount is not None and not (tos_bucket or "").strip():
             error("--tos-mount requires --tos-bucket")
@@ -411,6 +537,9 @@ def create_command(
             model_name=model_name,
             model_api_key=model_api_key,
             model_provider=model_provider.value,
+            skill_role_type=skill_role_type,
+            skill_role_name=skill_role_name,
+            websearch_apikey=websearch_apikey,
         )
         save_tool_result(str(result["tool_type"]), result)
     except (typer.Abort, typer.Exit):
@@ -421,3 +550,7 @@ def create_command(
     typer.echo("工具创建成功")
     typer.echo(f"工具ID：{result['tool_id']}")
     typer.echo(f"状态：{result['status']}")
+    if result.get("role_name"):
+        typer.echo(f"角色名：{result['role_name']}")
+    if not result.get("role_name") and not result.get("websearch_apikey_set"):
+        typer.echo("提示：未配置 WebSearch（可通过 --skill-role-type 配置 Role 或 --websearch-apikey 配置 API Key 来启用）")

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -492,12 +492,12 @@ def exec_command(
             "when creating a sandbox session."
         ),
     ),
-    enable_websearch_apikey: Optional[bool] = typer.Option(
-        None,
-        "--enable-websearch-apikey/--disable-websearch-apikey",
+    disable_websearch_apikey: bool = typer.Option(
+        False,
+        "--disable-websearch-apikey",
         help=(
-            "Control whether WEB_SEARCH_API_KEY is enabled for this session. "
-            "Only effective when the tool was created with --websearch-apikey."
+            "Disable WEB_SEARCH_API_KEY for this session. "
+            "Omit this option to keep the default enabled behavior."
         ),
     ),
 ) -> None:
@@ -518,22 +518,14 @@ def exec_command(
             tool_type=tool_type,
         )
         has_role = bool(ws_config and ws_config.get("has_role"))
-        tool_has_websearch = bool(ws_config and ws_config.get("websearch_apikey_set"))
 
-        disable_websearch = False
-        if enable_websearch_apikey is not None:
-            if has_role:
-                typer.echo(
-                    "警告：当前工具使用 IAM Role 模式，--enable-websearch-apikey/--disable-websearch-apikey 不会生效（WebSearch 权限由角色策略控制）。",
-                    err=True,
-                )
-            elif not tool_has_websearch:
-                error(
-                    "当前工具未配置 WebSearch API Key（创建时未指定 --websearch-apikey），"
-                    "--enable-websearch-apikey 无法生效。"
-                )
-            elif enable_websearch_apikey is False:
-                disable_websearch = True
+        disable_websearch = disable_websearch_apikey
+        if disable_websearch_apikey and has_role:
+            disable_websearch = False
+            typer.echo(
+                "警告：当前工具使用 IAM Role 模式，--disable-websearch-apikey 不会生效（WebSearch 权限由角色策略控制）。",
+                err=True,
+            )
 
         session = ensure_sandbox_session(
             session_id=session_id,

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -54,6 +54,7 @@ from agentkit.toolkit.cli.sandbox.tool_resolve import (
     SandboxToolType,
     find_tool_model_provider,
     get_remote_tool_model_provider,
+    get_tool_websearch_config,
 )
 from agentkit.toolkit.cli.sandbox.sandbox_client import (
     add_session_terminal_shell_id,
@@ -491,6 +492,14 @@ def exec_command(
             "when creating a sandbox session."
         ),
     ),
+    enable_websearch_apikey: Optional[bool] = typer.Option(
+        None,
+        "--enable-websearch-apikey/--disable-websearch-apikey",
+        help=(
+            "Control whether WEB_SEARCH_API_KEY is enabled for this session. "
+            "Only effective when the tool was created with --websearch-apikey."
+        ),
+    ),
 ) -> None:
     """Open a streaming sandbox exec session. Press Ctrl-] or type exit/exit()."""
     exec_mode = _normalize_exec_mode(mode)
@@ -502,6 +511,30 @@ def exec_command(
             model_name=model_name,
             model_provider=model_provider,
         )
+
+        resolved_tool_id = (tool_id or "").strip()
+        ws_config = get_tool_websearch_config(
+            tool_id=resolved_tool_id or None,
+            tool_type=tool_type,
+        )
+        has_role = bool(ws_config and ws_config.get("has_role"))
+        tool_has_websearch = bool(ws_config and ws_config.get("websearch_apikey_set"))
+
+        disable_websearch = False
+        if enable_websearch_apikey is not None:
+            if has_role:
+                typer.echo(
+                    "警告：当前工具使用 IAM Role 模式，--enable-websearch-apikey/--disable-websearch-apikey 不会生效（WebSearch 权限由角色策略控制）。",
+                    err=True,
+                )
+            elif not tool_has_websearch:
+                error(
+                    "当前工具未配置 WebSearch API Key（创建时未指定 --websearch-apikey），"
+                    "--enable-websearch-apikey 无法生效。"
+                )
+            elif enable_websearch_apikey is False:
+                disable_websearch = True
+
         session = ensure_sandbox_session(
             session_id=session_id,
             tool_id=tool_id,
@@ -511,6 +544,7 @@ def exec_command(
                 model_api_key=model_api_key,
                 model_provider=resolved_model_provider,
                 include_codex_config=tool_type == SandboxToolType.CODE_ENV,
+                disable_websearch_apikey=disable_websearch,
             ),
         )
     except typer.Exit:

--- a/agentkit/toolkit/cli/sandbox/session_create.py
+++ b/agentkit/toolkit/cli/sandbox/session_create.py
@@ -57,6 +57,7 @@ from agentkit.toolkit.cli.sandbox.sandbox_client import (
 DEFAULT_SANDBOX_TTL = 28800
 SANDBOX_TOOL_ID_ENV = "AGENTKIT_SANDBOX_TOOL_ID"
 SANDBOX_TTL_ENV = "AGENTKIT_SANDBOX_TTL"
+WEB_SEARCH_API_KEY_ENV = "WEB_SEARCH_API_KEY"
 CREATE_SESSION_START_FAIL_CODE = "ErrCreateSessionFail"
 CREATE_SESSION_CONFIRM_ATTEMPTS = 6
 CREATE_SESSION_CONFIRM_INTERVAL_SECONDS = 5
@@ -113,6 +114,7 @@ def build_model_envs(
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = None,
     include_codex_config: bool = False,
+    disable_websearch_apikey: bool = False,
 ) -> list[tools_types.EnvsItemForCreateSession] | None:
     envs: list[tools_types.EnvsItemForCreateSession] = []
     has_model_provider = bool(
@@ -149,6 +151,12 @@ def build_model_envs(
             resolved_model_provider,
         )
     _append_envs(envs, MODEL_API_KEY_ENV_KEYS, resolved_model_api_key)
+    if disable_websearch_apikey:
+        envs.append(
+            tools_types.EnvsItemForCreateSession(
+                key=WEB_SEARCH_API_KEY_ENV, value=""
+            )
+        )
     return envs or None
 
 
@@ -397,12 +405,13 @@ def ensure_sandbox_session_with_status(
                 save_session_result(result)
                 return result, False
 
+    session_envs = envs
     result = _create_session(
         client,
         resolved_session_id,
         resolved_tool_id,
         _resolve_ttl(ttl),
-        envs=envs,
+        envs=session_envs,
     )
     save_session_result(result)
     return result, True

--- a/agentkit/toolkit/cli/sandbox/tool_resolve.py
+++ b/agentkit/toolkit/cli/sandbox/tool_resolve.py
@@ -256,9 +256,6 @@ def _normalize_tool_record(
     role_name = _get_string_value(result, "RoleName", "role_name")
     if role_name:
         stored["RoleName"] = role_name
-    skill_role_type = _get_string_value(result, "SkillRoleType", "skill_role_type")
-    if skill_role_type:
-        stored["SkillRoleType"] = skill_role_type
     websearch_set = result.get("WebSearchApiKeySet") or result.get(
         "websearch_apikey_set"
     )

--- a/agentkit/toolkit/cli/sandbox/tool_resolve.py
+++ b/agentkit/toolkit/cli/sandbox/tool_resolve.py
@@ -119,7 +119,7 @@ def _build_tool_record(tool: object, tool_type: str) -> dict[str, object] | None
     tool_id = _get_string_field(payload, "ToolId", "tool_id")
     if not isinstance(tool_id, str) or not tool_id.strip():
         return None
-    record = {
+    record: dict[str, object] = {
         "ToolId": tool_id.strip(),
         "ToolType": _get_field_value(payload, "ToolType", "tool_type") or tool_type,
         "Name": _get_field_value(payload, "Name", "name"),
@@ -128,6 +128,18 @@ def _build_tool_record(tool: object, tool_type: str) -> dict[str, object] | None
     model_provider = _get_tool_model_provider(payload)
     if model_provider:
         record["ModelProvider"] = model_provider
+    role_name = _get_string_field(payload, "RoleName", "role_name")
+    if isinstance(role_name, str) and role_name.strip():
+        record["RoleName"] = role_name.strip()
+    envs = _get_field_value(payload, "Envs", "envs")
+    if isinstance(envs, list):
+        for env_item in envs:
+            key = _get_field_value(env_item, "Key", "key") or ""
+            if key == "WEB_SEARCH_API_KEY":
+                val = _get_field_value(env_item, "Value", "value") or ""
+                if isinstance(val, str) and val.strip():
+                    record["WebSearchApiKeySet"] = True
+                break
     return record
 
 
@@ -230,7 +242,7 @@ def _normalize_tool_record(
     if not tool_id:
         error("Tool result missing ToolId")
 
-    stored = {
+    stored: dict[str, object] = {
         "ToolId": tool_id,
         "Name": _get_string_value(result, "Name", "name") or "",
         "Status": _get_string_value(result, "Status", "status") or "",
@@ -241,6 +253,17 @@ def _normalize_tool_record(
     )
     if model_provider:
         stored["ModelProvider"] = model_provider
+    role_name = _get_string_value(result, "RoleName", "role_name")
+    if role_name:
+        stored["RoleName"] = role_name
+    skill_role_type = _get_string_value(result, "SkillRoleType", "skill_role_type")
+    if skill_role_type:
+        stored["SkillRoleType"] = skill_role_type
+    websearch_set = result.get("WebSearchApiKeySet") or result.get(
+        "websearch_apikey_set"
+    )
+    if websearch_set:
+        stored["WebSearchApiKeySet"] = True
     return stored
 
 
@@ -286,6 +309,43 @@ def find_tool_model_provider(
     return model_provider_from_env_value(
         _get_string_value(result, "ModelProvider", "model_provider")
     )
+
+
+def get_tool_websearch_config(
+    *,
+    tool_id: Optional[str],
+    tool_type: str | SandboxToolType | None,
+) -> dict[str, object] | None:
+    resolved_tool_type = normalize_tool_type(tool_type)
+    result = find_tool_result(resolved_tool_type)
+
+    if result:
+        cached_tool_id = _get_string_value(result, "ToolId", "tool_id")
+        if not tool_id or cached_tool_id == tool_id:
+            return {
+                "has_role": bool(_get_string_value(result, "RoleName", "role_name")),
+                "websearch_apikey_set": bool(result.get("WebSearchApiKeySet")),
+                "role_name": _get_string_value(result, "RoleName", "role_name"),
+            }
+
+    if not tool_id:
+        return None
+
+    try:
+        client = AgentkitToolsClient()
+        response = client.get_tool(tools_types.GetToolRequest(tool_id=tool_id))
+    except Exception:
+        return None
+
+    record = _build_tool_record(response, resolved_tool_type)
+    if not record:
+        return None
+    save_tool_result(resolved_tool_type, record)
+    return {
+        "has_role": bool(_get_string_value(record, "RoleName", "role_name")),
+        "websearch_apikey_set": bool(record.get("WebSearchApiKeySet")),
+        "role_name": _get_string_value(record, "RoleName", "role_name"),
+    }
 
 
 def get_remote_tool_model_provider(


### PR DESCRIPTION
创建 / 执行子命令
###  sandbox create（沙箱创建）
- 新增 --skill-role-type（已有 / 新建）与 --skill-role-name 参数，用于配置 IAM 角色；类型设为new时自动创建绑定AgentKitSkillsSandboxAccess 策略的角色，若角色已存在则幂等执行（不会重复创建报错）。
- 新增 --websearch-apikey 参数，用于注入环境变量 WEB_SEARCH_API_KEY；该参数与 --skill-role-type 互斥，不可同时使用。
- 仅当未配置角色、也未配置接口密钥时，才展示网页搜索相关提示。
### sandbox exec（沙箱执行）
- 新增 --enable-websearch-apikey / --disable-websearch-apikey 开关，用于单会话切换网页搜索功能；在角色模式下使用该开关仅输出警告（不阻断执行）；若工具未预先配置搜索密钥却使用该开关，则直接报错。
修复网页搜索配置拉取逻辑：当指定 --tool-id 且本地缓存信息不匹配时，从远程接口拉取最新配置，避免出现误判无配置的问题。
### session_create（会话创建）
- 在 build_model_envs 方法中新增 disable_websearch_apikey 参数；关闭网页搜索时，会清除环境变量 WEB_SEARCH_API_KEY。