### PR TITLE
feat(sandbox): codex-login — bring your own model subscription into the sandbox

### DIFF
--- a/agentkit/auth/model_login.py
+++ b/agentkit/auth/model_login.py
@@ -1,0 +1,360 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bring a user's *own* third-party model subscription into the sandbox.
+
+Many foreign models (ChatGPT/Codex, Claude Code) are used via a JWT obtained by an
+interactive SSO login, not a static API key. A user who subscribed to one of those
+plans wants the **sandbox's** codex to run on *their* subscription.
+
+The agentkit UserPool does not (and need not) federate with OpenAI/Anthropic. Codex
+already supports SSO **locally**; in the sandbox it is "remote", so the agreed design
+is dead simple and is what this module implements:
+
+    1. The user runs the provider's native SSO **on their PC** (``codex login`` for
+       Codex/ChatGPT, ``claude`` for Claude Code). That writes the provider's native
+       credential file:
+           Codex   ->  $CODEX_HOME/auth.json   (default ~/.codex/auth.json)
+           Claude  ->  ~/.claude/.credentials.json   (or the macOS Keychain)
+    2. We read that file verbatim and inject it into the **same native path inside
+       the user's private sandbox** — so the sandbox's codex finds its token exactly
+       where it natively looks. No proxy, no federation: the sandbox refreshes the
+       token itself against the provider, just like a local install would.
+
+This module is pure (stdlib only) and side-effect-light so it is unit-testable; the
+network/forwarding lives in the CLI layer (``cli_accesscontrol.py``).
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Callable, Optional
+
+# ── Codex / ChatGPT facts ────────────────────────────────────────────────────
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"  # codex CLI's public OAuth client (the id_token aud)
+CODEX_OAUTH_NAMESPACE = "https://api.openai.com/auth"  # claim namespace holding the ChatGPT plan
+DEFAULT_SANDBOX_CODEX_HOME = "/home/gem/.codex"  # informational; the shell resolves ${CODEX_HOME:-$HOME/.codex}
+CODEX_INJECT_MARKER = "AGENTKIT_CODEX_INJECTED"
+CLAUDE_INJECT_MARKER = "AGENTKIT_CLAUDE_INJECTED"
+CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+PROVIDERS = ("codex", "claude")
+
+
+class ModelLoginError(RuntimeError):
+    """A user-facing failure resolving or injecting a model subscription token."""
+
+
+# ── small helpers ────────────────────────────────────────────────────────────
+def b64(data: str | bytes) -> str:
+    """Standard base64 (single line, no newlines) — safe to embed in a shell ``printf``."""
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return base64.b64encode(data).decode("ascii")
+
+
+def _iso(epoch_seconds: int) -> str:
+    return datetime.datetime.fromtimestamp(epoch_seconds, tz=datetime.timezone.utc).isoformat()
+
+
+def decode_jwt_claims(jwt: str) -> dict:
+    """Decode (NOT verify) a JWT's payload claims. We only read non-secret metadata."""
+    parts = (jwt or "").split(".")
+    if len(parts) < 2:
+        raise ModelLoginError("malformed JWT")
+    seg = parts[1]
+    try:
+        return json.loads(base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4)))
+    except Exception as exc:  # noqa: BLE001
+        raise ModelLoginError(f"cannot decode JWT claims: {exc}") from exc
+
+
+# ── Codex (ChatGPT) ──────────────────────────────────────────────────────────
+def codex_home_path(explicit: Optional[str] = None) -> Path:
+    """Resolve the LOCAL codex home: --codex-home > $CODEX_HOME > ~/.codex."""
+    if explicit:
+        return Path(explicit).expanduser()
+    env = os.environ.get("CODEX_HOME")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".codex"
+
+
+def read_codex_auth(path: str | Path) -> dict:
+    p = Path(path)
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ModelLoginError(f"codex auth file not found: {p}") from exc
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ModelLoginError(f"cannot read codex auth file {p}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ModelLoginError(f"codex auth file {p} is not a JSON object")
+    return data
+
+
+def validate_codex_auth(data: dict) -> None:
+    """A usable codex auth has ChatGPT tokens (SSO) or an API key."""
+    tokens = data.get("tokens")
+    has_tokens = isinstance(tokens, dict) and bool(tokens.get("id_token") or tokens.get("access_token"))
+    has_key = bool(data.get("OPENAI_API_KEY"))
+    if not (has_tokens or has_key):
+        raise ModelLoginError(
+            "codex auth.json has neither ChatGPT tokens nor an API key — run `codex login` first"
+        )
+
+
+def codex_auth_summary(data: dict) -> dict:
+    """A redacted, secret-free summary (provider, plan, account, expiry) for display."""
+    tokens = data.get("tokens") or {}
+    summary: dict = {
+        "provider": "codex (ChatGPT)",
+        "auth_mode": data.get("auth_mode") or ("chatgpt" if tokens else "apikey"),
+        "has_refresh_token": bool(tokens.get("refresh_token")),
+        "account_id": tokens.get("account_id"),
+    }
+    idt = tokens.get("id_token")
+    if idt:
+        try:
+            claims = decode_jwt_claims(idt)
+        except ModelLoginError:
+            claims = {}
+        ns = claims.get(CODEX_OAUTH_NAMESPACE) or {}
+        summary["email"] = claims.get("email")
+        summary["plan"] = ns.get("chatgpt_plan_type")
+        summary["chatgpt_account_id"] = ns.get("chatgpt_account_id") or summary.get("account_id")
+        exp = claims.get("exp")
+        if isinstance(exp, int):
+            summary["id_token_expires"] = _iso(exp)
+            summary["id_token_expired"] = exp < int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+    return {k: v for k, v in summary.items() if v is not None}
+
+
+def run_codex_login(
+    *, codex_home: Optional[Path] = None, codex_bin: str = "codex", timeout: int = 300
+) -> None:
+    """Trigger codex's native local SSO (opens a browser) so it writes a fresh auth.json."""
+    import subprocess
+
+    env = dict(os.environ)
+    if codex_home:
+        env["CODEX_HOME"] = str(codex_home)
+    try:
+        subprocess.run([codex_bin, "login"], env=env, timeout=timeout, check=True)  # noqa: S603
+    except FileNotFoundError as exc:
+        raise ModelLoginError(
+            f"`{codex_bin}` not found on PATH — install the Codex CLI and run `codex login`, "
+            f"or pass --auth-file <path-to-your-auth.json>"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise ModelLoginError(f"`codex login` failed (exit {exc.returncode})") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ModelLoginError("`codex login` timed out") from exc
+
+
+def resolve_local_codex_auth(
+    *,
+    codex_home: Optional[str] = None,
+    auth_file: Optional[str] = None,
+    allow_login: bool = True,
+    login_timeout: int = 300,
+    login_runner: Optional[Callable[..., None]] = None,
+) -> tuple[Path, dict]:
+    """Return ``(path, data)`` of a usable LOCAL codex auth, running `codex login` if needed."""
+    if auth_file:
+        path = Path(auth_file).expanduser()
+        if not path.exists():
+            raise ModelLoginError(f"--auth-file not found: {path}")
+        data = read_codex_auth(path)
+        validate_codex_auth(data)
+        return path, data
+
+    home = codex_home_path(codex_home)
+    path = home / "auth.json"
+    if not path.exists():
+        if not allow_login:
+            raise ModelLoginError(
+                f"no codex auth at {path} — run `codex login` (or pass --auth-file / --no-login off)"
+            )
+        (login_runner or run_codex_login)(codex_home=home, timeout=login_timeout)
+        if not path.exists():
+            raise ModelLoginError(f"`codex login` finished but {path} is still missing")
+    data = read_codex_auth(path)
+    validate_codex_auth(data)
+    return path, data
+
+
+# ── Codex config.toml: switch the sandbox codex to the ChatGPT subscription ──
+_TOP_MODEL_PIN = re.compile(r"^\s*(model|model_provider|review_model)\s*=")
+_AUTH_METHOD = re.compile(r"^\s*preferred_auth_method\s*=")
+_TABLE_HEADER = re.compile(r"^\s*\[")
+
+
+def rewrite_codex_config_for_chatgpt(toml_text: str) -> str:
+    """Switch an existing codex config.toml to ChatGPT-subscription auth, preserving everything else.
+
+    The sandbox's default config pins a custom ``model_provider``/``model`` to a Volcengine Ark
+    endpoint that authenticates with an API key (``env_key``); in that mode codex never looks at the
+    injected ChatGPT token. To use the subscription we:
+      * drop the top-level ``model`` / ``model_provider`` / ``review_model`` pins, so codex falls back
+        to its built-in ``openai`` provider and the subscription's default model, and
+      * force ``preferred_auth_method = "chatgpt"`` so the OAuth token wins over any stray API key.
+    Tables (``[tui]``, ``[projects.*]``, ``[mcp_servers.*]``, ``[model_providers.*]``) and other
+    top-level keys (approval_policy, sandbox_mode, model_reasoning_effort, …) are kept verbatim.
+    """
+    out: list[str] = []
+    seen_table = False
+    for line in toml_text.splitlines():
+        if _TABLE_HEADER.match(line):
+            seen_table = True
+        if _AUTH_METHOD.match(line):
+            continue  # re-added at the top
+        if not seen_table and _TOP_MODEL_PIN.match(line):
+            continue
+        out.append(line)
+    body = "\n".join(out).strip("\n")
+    return 'preferred_auth_method = "chatgpt"\n' + (body + "\n" if body else "")
+
+
+def minimal_chatgpt_codex_config() -> str:
+    """A config.toml for a sandbox that has no codex config yet — ChatGPT auth, headless-friendly."""
+    return "\n".join(
+        [
+            'preferred_auth_method = "chatgpt"',
+            'approval_policy = "never"',
+            'sandbox_mode = "danger-full-access"',
+            "",
+            '[projects."/home/gem"]',
+            'trust_level = "trusted"',
+            "",
+        ]
+    )
+
+
+def read_codex_config_command() -> str:
+    """Shell command that prints the sandbox's current codex config.toml (empty if none)."""
+    return 'cat "${CODEX_HOME:-$HOME/.codex}/config.toml" 2>/dev/null || true'
+
+
+def build_codex_injection_command(*, auth_json: str, config_toml: Optional[str] = None) -> str:
+    """A single POSIX-sh command that writes auth.json (and optionally config.toml) into the
+    sandbox's native codex home (``${CODEX_HOME:-$HOME/.codex}``), 0600, and prints a marker."""
+    lines = [
+        "set -e",
+        'CH="${CODEX_HOME:-$HOME/.codex}"',
+        'mkdir -p "$CH"',
+        "umask 077",
+        f"printf %s '{b64(auth_json)}' | base64 -d > \"$CH/auth.json\"",
+        'chmod 600 "$CH/auth.json"',
+    ]
+    if config_toml is not None:
+        lines.append(f"printf %s '{b64(config_toml)}' | base64 -d > \"$CH/config.toml\"")
+    lines.append(f'echo "{CODEX_INJECT_MARKER} $CH"')
+    return "\n".join(lines)
+
+
+# ── Claude Code ──────────────────────────────────────────────────────────────
+def claude_creds_path(explicit: Optional[str] = None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / ".claude" / ".credentials.json"
+
+
+def _read_macos_keychain(service: str) -> Optional[str]:
+    import subprocess
+
+    try:
+        out = subprocess.run(  # noqa: S603
+            ["security", "find-generic-password", "-s", service, "-w"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return (out.stdout or "").strip() or None
+
+
+def read_claude_creds(*, creds_file: Optional[str] = None, allow_keychain: bool = True) -> dict:
+    """Read Claude Code subscription creds from the file, or the macOS Keychain as a fallback."""
+    path = claude_creds_path(creds_file)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise ModelLoginError(f"cannot read {path}: {exc}") from exc
+    elif creds_file:
+        raise ModelLoginError(f"--auth-file not found: {path}")
+    elif allow_keychain and sys.platform == "darwin":
+        raw = _read_macos_keychain(CLAUDE_KEYCHAIN_SERVICE)
+        if not raw:
+            raise ModelLoginError(
+                "no Claude Code credentials in ~/.claude/.credentials.json or the macOS Keychain — "
+                "run `claude` and log in with your subscription first"
+            )
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ModelLoginError("Claude Keychain entry is not valid JSON") from exc
+    else:
+        raise ModelLoginError(
+            "no Claude Code credentials at ~/.claude/.credentials.json — "
+            "run `claude` and log in with your subscription first"
+        )
+    if not isinstance(data, dict):
+        raise ModelLoginError("Claude credentials file is not a JSON object")
+    return data
+
+
+def validate_claude_creds(data: dict) -> None:
+    oauth = data.get("claudeAiOauth")
+    if not (isinstance(oauth, dict) and oauth.get("accessToken")):
+        raise ModelLoginError("Claude credentials missing claudeAiOauth.accessToken")
+
+
+def claude_creds_summary(data: dict) -> dict:
+    oauth = data.get("claudeAiOauth") or {}
+    summary: dict = {
+        "provider": "claude (Claude Code)",
+        "subscription": oauth.get("subscriptionType"),
+        "scopes": oauth.get("scopes"),
+        "has_refresh_token": bool(oauth.get("refreshToken")),
+    }
+    exp = oauth.get("expiresAt")
+    if isinstance(exp, (int, float)):
+        summary["access_token_expires"] = _iso(int(exp / 1000))  # Claude stores epoch milliseconds
+    return {k: v for k, v in summary.items() if v is not None}
+
+
+def build_claude_injection_command(*, creds_json: str) -> str:
+    """A single POSIX-sh command that writes Claude Code creds into ``$HOME/.claude``, 0600."""
+    return "\n".join(
+        [
+            "set -e",
+            'CD="$HOME/.claude"',
+            'mkdir -p "$CD"',
+            "umask 077",
+            f"printf %s '{b64(creds_json)}' | base64 -d > \"$CD/.credentials.json\"",
+            'chmod 600 "$CD/.credentials.json"',
+            f'echo "{CLAUDE_INJECT_MARKER} $CD"',
+        ]
+    )

--- a/agentkit/toolkit/cli/sandbox/cli.py
+++ b/agentkit/toolkit/cli/sandbox/cli.py
@@ -22,6 +22,7 @@ from agentkit.toolkit.cli.sandbox.cli_create import create_command
 from agentkit.toolkit.cli.sandbox.cli_exec import exec_command
 from agentkit.toolkit.cli.sandbox.cli_file import file_command
 from agentkit.toolkit.cli.sandbox.cli_get import get_command
+from agentkit.toolkit.cli.sandbox.cli_model_login import codex_login_command
 from agentkit.toolkit.cli.sandbox.cli_mount import mount_command
 from agentkit.toolkit.cli.sandbox.cli_run import run_command
 from agentkit.toolkit.cli.sandbox.cli_shell import shell_command
@@ -46,4 +47,6 @@ sandbox_app.command(
     context_settings={"allow_extra_args": True},
 )(shell_command)
 sandbox_app.command(name="web")(web_command)
+sandbox_app.command(name="codex-login")(codex_login_command)
+sandbox_app.command(name="model-login")(codex_login_command)  # provider-agnostic alias
 sandbox_app.add_typer(file_command, name="file")

--- a/agentkit/toolkit/cli/sandbox/cli_model_login.py
+++ b/agentkit/toolkit/cli/sandbox/cli_model_login.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`agentkit sandbox codex-login` — bring your own model subscription into a sandbox.
+
+Codex/ChatGPT and Claude Code are used via a JWT obtained by an interactive SSO login, not a
+static API key. Codex supports that SSO **locally**; in the sandbox it is remote. So instead of
+federating the platform UserPool with OpenAI/Anthropic, this command:
+
+  1. reads the provider's native credential the local SSO already produced
+     (``$CODEX_HOME/auth.json`` for Codex, ``~/.claude/.credentials.json`` for Claude Code), and
+  2. injects it into the **same native path inside the sandbox session**, so the sandbox's codex
+     finds its token exactly where it natively looks.
+
+The sandbox refreshes the token itself against the provider, just like a local install would. The
+heavy lifting (resolve / validate / redact / config rewrite / build the injection command) lives in
+``agentkit.auth.model_login``; this file is only the sandbox-session transport + CLI surface.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Optional
+
+import typer
+
+from agentkit.toolkit.cli.sandbox.cli_file import _exec_shell_command
+from agentkit.toolkit.cli.sandbox.session_create import (
+    SANDBOX_TOOL_ID_ENV,
+    ensure_sandbox_session,
+)
+from agentkit.toolkit.cli.sandbox.tool_resolve import SandboxToolType
+from agentkit.toolkit.cli.sandbox.sandbox_client import error
+
+
+def _shell_output(payload: dict) -> str:
+    data = payload.get("data")
+    if isinstance(data, dict):
+        out = data.get("output")
+        if isinstance(out, str):
+            return out
+    return ""
+
+
+def _redact_inject(cmd: str) -> str:
+    """Redact the base64 token blob in an injection command (for --dry-run display)."""
+    return re.sub(
+        r"printf %s '([A-Za-z0-9+/=]+)'",
+        lambda m: f"printf %s '<base64 {len(m.group(1))} bytes — redacted>'",
+        cmd,
+    )
+
+
+def codex_login_command(
+    session_id: Optional[str] = typer.Option(
+        None,
+        "--session-id",
+        "--sid",
+        "-s",
+        help=(
+            "Sandbox session to inject into. Defaults to a new session; reuse the printed id "
+            "with `agentkit sandbox exec --sid <id>`."
+        ),
+    ),
+    provider: str = typer.Option(
+        "codex",
+        "--provider",
+        "-p",
+        help="Subscription to bring in: codex (ChatGPT) or claude (Claude Code).",
+    ),
+    auth_file: Optional[str] = typer.Option(
+        None,
+        "--auth-file",
+        help=(
+            "Use a specific local credential file (codex auth.json / claude .credentials.json) "
+            "instead of running the local SSO."
+        ),
+    ),
+    codex_home: Optional[str] = typer.Option(
+        None,
+        "--codex-home",
+        help="Local codex home (default $CODEX_HOME or ~/.codex).",
+    ),
+    login: bool = typer.Option(
+        True,
+        "--login/--no-login",
+        help="If no local credential exists, trigger `codex login` (browser SSO) once.",
+    ),
+    keep_model_config: bool = typer.Option(
+        False,
+        "--keep-model-config",
+        help="Only inject the token; do not switch the sandbox codex config to subscription auth.",
+    ),
+    tool_id: Optional[str] = typer.Option(
+        None,
+        "--tool-id",
+        help=f"Sandbox tool ID. Defaults to {SANDBOX_TOOL_ID_ENV}.",
+    ),
+    tool_type: SandboxToolType = typer.Option(
+        SandboxToolType.CODE_ENV,
+        "--tool-type",
+        help="Sandbox tool type to resolve when --tool-id is omitted.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Resolve the local credential and print what would be injected (token redacted); no session.",
+    ),
+) -> None:
+    """Inject your own ChatGPT/Codex or Claude Code subscription token into a sandbox session.
+
+    Run the provider's local SSO once (codex supports it locally), then this injects the native
+    token into the sandbox's native location so the sandbox codex runs on your subscription.
+    """
+    from agentkit.auth import model_login as ml
+
+    provider = (provider or "codex").lower()
+    if provider not in ml.PROVIDERS:
+        error(f"unknown provider: {provider} (supported: {', '.join(ml.PROVIDERS)})")
+
+    # 1) resolve the LOCAL native credential (runs the provider's local SSO if needed)
+    try:
+        if provider == "codex":
+            src, data = ml.resolve_local_codex_auth(
+                codex_home=codex_home, auth_file=auth_file, allow_login=login
+            )
+            summary = ml.codex_auth_summary(data)
+        else:  # claude
+            data = ml.read_claude_creds(creds_file=auth_file)
+            ml.validate_claude_creds(data)
+            src = ml.claude_creds_path(auth_file)
+            summary = ml.claude_creds_summary(data)
+    except ml.ModelLoginError as exc:
+        error(str(exc))
+
+    typer.secho(f"\nLocal credential: {src}", fg=typer.colors.CYAN, err=True)
+    typer.echo(json.dumps(summary, indent=2, ensure_ascii=False))
+    if summary.get("id_token_expired") and not summary.get("has_refresh_token"):
+        typer.secho(
+            "  warning: token expired and has no refresh_token — re-run `codex login` locally first.",
+            fg=typer.colors.YELLOW,
+            err=True,
+        )
+
+    payload = json.dumps(data, ensure_ascii=False)
+
+    # 2) build the injection (codex also switches its config to subscription auth unless --keep-model-config)
+    if provider == "codex":
+        if dry_run:
+            typer.secho("\n— dry-run: read current sandbox codex config (read-only) —", fg=typer.colors.CYAN, err=True)
+            typer.secho(f"  $ {ml.read_codex_config_command()}", err=True)
+            cmd = ml.build_codex_injection_command(
+                auth_json=payload,
+                config_toml=None if keep_model_config else ml.minimal_chatgpt_codex_config(),
+            )
+            typer.secho("\n— dry-run: would inject (token redacted) —", fg=typer.colors.CYAN, err=True)
+            typer.secho(_redact_inject(cmd), err=True)
+            raise typer.Exit(0)
+        marker = ml.CODEX_INJECT_MARKER
+    else:  # claude
+        cmd = ml.build_claude_injection_command(creds_json=payload)
+        marker = ml.CLAUDE_INJECT_MARKER
+        if dry_run:
+            typer.secho("\n— dry-run: would inject (token redacted) —", fg=typer.colors.CYAN, err=True)
+            typer.secho(_redact_inject(cmd), err=True)
+            raise typer.Exit(0)
+
+    # 3) ensure the sandbox session, then inject over its shell-exec endpoint
+    try:
+        session = ensure_sandbox_session(
+            session_id=session_id,
+            tool_id=tool_id,
+            tool_type=tool_type.value,
+        )
+    except typer.Exit:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        error(str(exc))
+
+    sid = session.get("session_id")
+    if not isinstance(sid, str) or not sid:
+        error("sandbox session missing session_id")
+
+    if provider == "codex":
+        new_cfg = None
+        if not keep_model_config:
+            cur = _shell_output(
+                _exec_shell_command(session, ml.read_codex_config_command(), quiet_errors=True)
+            )
+            new_cfg = (
+                ml.rewrite_codex_config_for_chatgpt(cur)
+                if cur.strip()
+                else ml.minimal_chatgpt_codex_config()
+            )
+        cmd = ml.build_codex_injection_command(auth_json=payload, config_toml=new_cfg)
+
+    out = _shell_output(_exec_shell_command(session, cmd))
+    if marker not in out:
+        error(f"injection did not confirm (marker missing). sandbox output: {out[:200]}")
+    where = out.split(marker, 1)[1].strip() or "<sandbox>"
+
+    typer.secho(
+        f"\n✓ injected your {summary.get('provider', provider)} subscription into {where}",
+        fg=typer.colors.GREEN,
+        bold=True,
+        err=True,
+    )
+    typer.secho(f"  session: {sid}", fg=typer.colors.CYAN, err=True)
+    if provider == "codex":
+        typer.secho(
+            f'  next:  agentkit sandbox exec --sid {sid} --command "codex"   # codex runs on your subscription',
+            fg=typer.colors.CYAN,
+            err=True,
+        )
+        if not keep_model_config:
+            typer.secho(
+                "  (switched the sandbox codex config to ChatGPT subscription auth; keep it with --keep-model-config)",
+                fg=typer.colors.BRIGHT_BLACK,
+                err=True,
+            )
+    typer.secho(
+        "  note: the token is refreshed by codex/claude inside the sandbox; re-inject if the session is recreated.",
+        fg=typer.colors.BRIGHT_BLACK,
+        err=True,
+    )
+    typer.echo(json.dumps({"injected": True, "provider": provider, "session_id": sid, "path": where}, ensure_ascii=False))

--- a/tests/auth/test_model_login.py
+++ b/tests/auth/test_model_login.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for agentkit.auth.model_login (pure logic — no network)."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from agentkit.auth import model_login as ml
+
+
+def _b64url(obj: dict) -> str:
+    raw = json.dumps(obj).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _make_jwt(payload: dict) -> str:
+    return f"{_b64url({'alg': 'RS256'})}.{_b64url(payload)}.sig"
+
+
+# ── b64 / jwt helpers ────────────────────────────────────────────────────────
+def test_b64_roundtrip():
+    assert base64.b64decode(ml.b64("héllo")).decode() == "héllo"
+    assert "\n" not in ml.b64("x" * 1000)  # single line — safe to embed in printf
+
+
+def test_decode_jwt_claims():
+    tok = _make_jwt({"email": "a@b.com", "exp": 123})
+    assert ml.decode_jwt_claims(tok) == {"email": "a@b.com", "exp": 123}
+
+
+def test_decode_jwt_claims_malformed():
+    with pytest.raises(ml.ModelLoginError):
+        ml.decode_jwt_claims("not-a-jwt")
+
+
+# ── codex auth validation + summary ──────────────────────────────────────────
+def test_validate_codex_auth_tokens_ok():
+    ml.validate_codex_auth({"tokens": {"id_token": "x.y.z"}})
+
+
+def test_validate_codex_auth_apikey_ok():
+    ml.validate_codex_auth({"OPENAI_API_KEY": "sk-x", "tokens": None})
+
+
+def test_validate_codex_auth_empty_raises():
+    with pytest.raises(ml.ModelLoginError):
+        ml.validate_codex_auth({"tokens": {}, "OPENAI_API_KEY": None})
+
+
+def test_codex_auth_summary_redacts_and_decodes_plan():
+    idt = _make_jwt(
+        {
+            "email": "u@x.com",
+            "exp": 9999999999,
+            ml.CODEX_OAUTH_NAMESPACE: {"chatgpt_plan_type": "pro", "chatgpt_account_id": "acc-1"},
+        }
+    )
+    data = {
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": None,
+        "tokens": {"id_token": idt, "refresh_token": "r", "account_id": "acc-1"},
+    }
+    s = ml.codex_auth_summary(data)
+    assert s["plan"] == "pro"
+    assert s["email"] == "u@x.com"
+    assert s["has_refresh_token"] is True
+    assert s["account_id"] == "acc-1"
+    assert s["id_token_expired"] is False
+    # no secret material leaks into the summary
+    blob = json.dumps(s)
+    assert idt not in blob and "r" != s.get("has_refresh_token")
+
+
+def test_codex_auth_summary_expired_no_refresh():
+    idt = _make_jwt({"email": "u@x.com", "exp": 1})  # long expired
+    s = ml.codex_auth_summary({"tokens": {"id_token": idt}})
+    assert s["id_token_expired"] is True
+    assert s["has_refresh_token"] is False
+
+
+# ── config rewrite ───────────────────────────────────────────────────────────
+def test_rewrite_drops_ark_pins_keeps_tables():
+    src = "\n".join(
+        [
+            'model_provider = "codex"',
+            'model = "ark-x"',
+            'review_model = "ark-x"',
+            'model_reasoning_effort = "medium"',
+            "",
+            "[model_providers.codex]",
+            'env_key = "CODEX_API_KEY"',
+            'model = "should-not-be-removed-inside-table"',
+            "",
+            "[tui]",
+            "show_tooltips = false",
+        ]
+    )
+    out = ml.rewrite_codex_config_for_chatgpt(src)
+    assert out.startswith('preferred_auth_method = "chatgpt"\n')
+    # the top-level Ark pins are gone (the assignment lines, not the table name)
+    assert 'model_provider = "codex"' not in out
+    assert 'model = "ark-x"' not in out
+    assert 'review_model = "ark-x"' not in out
+    # non-pin keys & tables preserved verbatim
+    assert "model_reasoning_effort" in out
+    assert "[model_providers.codex]" in out  # the provider table itself is kept
+    assert "[tui]" in out
+    assert "should-not-be-removed-inside-table" in out  # `model=` inside a table is untouched
+
+
+def test_rewrite_replaces_existing_auth_method():
+    src = 'preferred_auth_method = "apikey"\nmodel_provider = "codex"\n'
+    out = ml.rewrite_codex_config_for_chatgpt(src)
+    assert out.count("preferred_auth_method") == 1
+    assert '"apikey"' not in out
+
+
+def test_minimal_config_uses_chatgpt():
+    cfg = ml.minimal_chatgpt_codex_config()
+    assert 'preferred_auth_method = "chatgpt"' in cfg
+    assert "trust_level" in cfg
+
+
+# ── injection command ────────────────────────────────────────────────────────
+def test_build_codex_injection_command():
+    auth = '{"tokens":{"id_token":"x"}}'
+    cmd = ml.build_codex_injection_command(auth_json=auth, config_toml="cfg")
+    assert ml.b64(auth) in cmd
+    assert ml.b64("cfg") in cmd
+    assert ml.CODEX_INJECT_MARKER in cmd
+    assert 'chmod 600 "$CH/auth.json"' in cmd
+    assert '${CODEX_HOME:-$HOME/.codex}' in cmd
+
+
+def test_build_codex_injection_command_no_config():
+    cmd = ml.build_codex_injection_command(auth_json="{}")
+    assert "config.toml" not in cmd
+
+
+def test_read_codex_config_command():
+    assert "config.toml" in ml.read_codex_config_command()
+
+
+# ── local resolution ─────────────────────────────────────────────────────────
+def test_read_codex_auth_missing(tmp_path):
+    with pytest.raises(ml.ModelLoginError):
+        ml.read_codex_auth(tmp_path / "nope.json")
+
+
+def test_resolve_codex_auth_file(tmp_path):
+    p = tmp_path / "auth.json"
+    p.write_text('{"tokens":{"id_token":"x.y.z"}}')
+    path, data = ml.resolve_local_codex_auth(auth_file=str(p))
+    assert path == p
+    assert data["tokens"]["id_token"] == "x.y.z"
+
+
+def test_resolve_codex_missing_no_login(tmp_path):
+    with pytest.raises(ml.ModelLoginError):
+        ml.resolve_local_codex_auth(codex_home=str(tmp_path), allow_login=False)
+
+
+def test_resolve_codex_runs_login_runner(tmp_path):
+    home = tmp_path / "codex"
+
+    def fake_login(*, codex_home, timeout):
+        codex_home.mkdir(parents=True, exist_ok=True)
+        (codex_home / "auth.json").write_text('{"tokens":{"id_token":"x"}}')
+
+    path, data = ml.resolve_local_codex_auth(
+        codex_home=str(home), allow_login=True, login_runner=fake_login
+    )
+    assert path == home / "auth.json"
+    assert data["tokens"]["id_token"] == "x"
+
+
+# ── claude ───────────────────────────────────────────────────────────────────
+def test_claude_read_validate_summary(tmp_path):
+    creds = {
+        "claudeAiOauth": {
+            "accessToken": "at",
+            "refreshToken": "rt",
+            "expiresAt": 1781797582000,  # ms
+            "scopes": ["user:inference"],
+            "subscriptionType": "max",
+        }
+    }
+    p = tmp_path / ".credentials.json"
+    p.write_text(json.dumps(creds))
+    data = ml.read_claude_creds(creds_file=str(p))
+    ml.validate_claude_creds(data)
+    s = ml.claude_creds_summary(data)
+    assert s["subscription"] == "max"
+    assert s["has_refresh_token"] is True
+    assert s["access_token_expires"].startswith("2026-")
+
+
+def test_claude_validate_missing_token():
+    with pytest.raises(ml.ModelLoginError):
+        ml.validate_claude_creds({"claudeAiOauth": {}})
+
+
+def test_claude_missing_file_raises(tmp_path):
+    with pytest.raises(ml.ModelLoginError):
+        ml.read_claude_creds(creds_file=str(tmp_path / "nope.json"))
+
+
+def test_build_claude_injection_command():
+    cmd = ml.build_claude_injection_command(creds_json='{"claudeAiOauth":{"accessToken":"x"}}')
+    assert ml.CLAUDE_INJECT_MARKER in cmd
+    assert '.credentials.json' in cmd
+    assert 'chmod 600' in cmd

--- a/tests/toolkit/cli/test_codex_login_cli.py
+++ b/tests/toolkit/cli/test_codex_login_cli.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+# Licensed under the Apache License, Version 2.0.
+
+"""CLI tests for `agentkit sandbox codex-login` (the model-subscription injector).
+
+The local credential is supplied via --auth-file; the sandbox session + shell exec are mocked so
+no network/login happens. We assert the injected payload + the ChatGPT config switch.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from typer.testing import CliRunner
+
+from agentkit.auth import model_login as ml
+from agentkit.toolkit.cli.cli import app
+from agentkit.toolkit.cli.sandbox import cli_model_login as cml
+
+runner = CliRunner()
+
+
+def _patch_sandbox(monkeypatch, captured):
+    """Mock the sandbox session + shell exec; record every command and answer it."""
+    monkeypatch.setattr(
+        cml, "ensure_sandbox_session", lambda **kw: {"session_id": "s-1", "endpoint": "https://sbx.example"}
+    )
+
+    def fake_exec(session, command, quiet_errors=False):
+        captured.append(command)
+        if "config.toml" in command and command.strip().startswith("cat"):
+            return {"data": {"output": 'model_provider = "codex"\nmodel = "ark"\n[tui]\nshow_tooltips = false\n', "exit_code": 0}}
+        if ml.CODEX_INJECT_MARKER in command:
+            return {"data": {"output": f"{ml.CODEX_INJECT_MARKER} /home/gem/.codex", "exit_code": 0}}
+        if ml.CLAUDE_INJECT_MARKER in command:
+            return {"data": {"output": f"{ml.CLAUDE_INJECT_MARKER} /home/gem/.claude", "exit_code": 0}}
+        return {"data": {"output": "", "exit_code": 0}}
+
+    monkeypatch.setattr(cml, "_exec_shell_command", fake_exec)
+
+
+def test_codex_login_injects_and_switches_config(tmp_path, monkeypatch):
+    auth = tmp_path / "auth.json"
+    auth.write_text(json.dumps({"auth_mode": "chatgpt", "tokens": {"id_token": "a.b.c", "refresh_token": "r"}}))
+    captured: list[str] = []
+    _patch_sandbox(monkeypatch, captured)
+
+    result = runner.invoke(app, ["sandbox", "codex-login", "--auth-file", str(auth)])
+    assert result.exit_code == 0, result.output
+
+    # read the current sandbox config, then inject auth.json + a ChatGPT-mode config
+    assert any(c.strip().startswith("cat") and "config.toml" in c for c in captured)
+    inject = next(c for c in captured if ml.CODEX_INJECT_MARKER in c)
+    assert ml.b64(json.dumps(json.loads(auth.read_text()), ensure_ascii=False)) in inject
+    cfg_b64 = inject.split("printf %s '")[2].split("'")[0]
+    pushed_cfg = base64.b64decode(cfg_b64).decode()
+    assert pushed_cfg.startswith('preferred_auth_method = "chatgpt"')
+    assert 'model_provider = "codex"' not in pushed_cfg
+    assert "[tui]" in pushed_cfg
+    assert "s-1" in result.output  # session id surfaced for reuse
+
+
+def test_codex_login_keep_model_config(tmp_path, monkeypatch):
+    auth = tmp_path / "auth.json"
+    auth.write_text(json.dumps({"tokens": {"id_token": "a.b.c"}}))
+    captured: list[str] = []
+    _patch_sandbox(monkeypatch, captured)
+
+    result = runner.invoke(app, ["sandbox", "codex-login", "--auth-file", str(auth), "--keep-model-config"])
+    assert result.exit_code == 0, result.output
+    assert not any(c.strip().startswith("cat") for c in captured)  # no config read
+    inject = next(c for c in captured if ml.CODEX_INJECT_MARKER in c)
+    assert "config.toml" not in inject
+
+
+def test_codex_login_dry_run_no_session(tmp_path, monkeypatch):
+    auth = tmp_path / "auth.json"
+    auth.write_text(json.dumps({"tokens": {"id_token": "a.b.c"}}))
+
+    def boom(**kw):
+        raise AssertionError("dry-run must not create a session")
+
+    monkeypatch.setattr(cml, "ensure_sandbox_session", boom)
+    result = runner.invoke(app, ["sandbox", "codex-login", "--auth-file", str(auth), "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "redacted" in result.output
+    assert "a.b.c" not in result.output  # token never printed
+
+
+def test_codex_login_missing_auth_file(monkeypatch):
+    captured: list[str] = []
+    _patch_sandbox(monkeypatch, captured)
+    result = runner.invoke(app, ["sandbox", "codex-login", "--auth-file", "/no/such/file.json"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_claude_login_injects(tmp_path, monkeypatch):
+    creds = tmp_path / ".credentials.json"
+    creds.write_text(json.dumps({"claudeAiOauth": {"accessToken": "at", "refreshToken": "rt", "subscriptionType": "max"}}))
+    captured: list[str] = []
+    _patch_sandbox(monkeypatch, captured)
+
+    result = runner.invoke(app, ["sandbox", "model-login", "--provider", "claude", "--auth-file", str(creds)])
+    assert result.exit_code == 0, result.output
+    inject = next(c for c in captured if ml.CLAUDE_INJECT_MARKER in c)
+    assert ".credentials.json" in inject
+
+
+def test_unknown_provider(monkeypatch):
+    captured: list[str] = []
+    _patch_sandbox(monkeypatch, captured)
+    result = runner.invoke(app, ["sandbox", "model-login", "--provider", "gemini"])
+    assert result.exit_code == 1
+    assert "provider" in result.output.lower()


### PR DESCRIPTION
Adds `agentkit sandbox codex-login` (alias `model-login`) so codex in a sandbox can run on the user's own ChatGPT/Codex or Claude Code subscription.

codex supports SSO locally; in the sandbox it is remote. This reads the local oauth token codex/claude wrote ($CODEX_HOME/auth.json, ~/.claude/.credentials.json or the macOS Keychain) and writes it to the same path in the sandbox session. codex refreshes the token in the sandbox.
