### PR TITLE
Feat/sandbox cli v7

### DIFF
--- a/agentkit/toolkit/cli/sandbox/README.md
+++ b/agentkit/toolkit/cli/sandbox/README.md
@@ -61,13 +61,21 @@ Options:
   `/home/gem/workspace`.
 - `--cpu`: optional. Sandbox vCPU count; allowed values are `2`, `4`, `8`, and
   `16`. Defaults to `4`. Memory is derived as 2 GiB per vCPU.
-- `--model-provider`: optional. Model provider to use for base URLs, the
-  default model, and the Codex model catalog. Supported values are
-  `model_square`, `coding_plan`, and `agent_plan`; defaults to `model_square`.
+- `--model-provider`: optional. Model provider marker to inject into
+  `AGENTKIT_SANDBOX_MODEL_PROVIDER`; defaults to `model_square`. The built-in
+  providers `model_square`, `coding_plan`, and `agent_plan` also provide base
+  URLs, default models, and Codex model catalog entries. Other provider strings
+  are passed through without built-in URL or catalog handling and require
+  `--model-base-url`.
 - `--model-name`: optional. Injected into the tool as `OPENCODE_MODEL`,
-  `CODEX_MODEL`, and `ANTHROPIC_MODEL`. If omitted, the provider's default
-  model is used. Custom model names are allowed and are added to the Codex
-  model catalog with default capabilities.
+  `CODEX_MODEL`, and `ANTHROPIC_MODEL`. If omitted for a built-in provider,
+  that provider's default model is used. Custom model names are allowed and are
+  added to the Codex model catalog with default capabilities.
+- `--model-base-url`: optional. Injected into `OPENCODE_BASE_URL`,
+  `CODEX_BASE_URL`, `MODEL_BASE_URL`, and `ANTHROPIC_BASE_URL`. When provided,
+  it takes precedence over provider base URLs and the CLI skips
+  `CODEX_CONFIG_TOML` and `CODEX_MODEL_CATALOG_JSON`. Non-Ark custom URLs
+  require `--model-provider`.
 - `--model-api-key`: optional. Injected into the tool as `OPENCODE_API_KEY`,
   `CODEX_API_KEY`, and `ANTHROPIC_AUTH_TOKEN`. If omitted, the CLI uses
   `MODEL_API_KEY` when that environment variable is set.
@@ -75,19 +83,18 @@ Options:
 The sandbox create request maps `--cpu` to `CpuMilli=<cpu * 1000>` and
 `MemoryMb=<cpu * 2048>`, so the default shape is 4 vCPU / 8 GiB.
 
-The tool injects the selected provider's Volcengine Ark compatible endpoints
-into `OPENCODE_BASE_URL`, `CODEX_BASE_URL`, `MODEL_BASE_URL`, and
+The tool injects the selected built-in provider's Volcengine Ark compatible
+endpoints into `OPENCODE_BASE_URL`, `CODEX_BASE_URL`, `MODEL_BASE_URL`, and
 `ANTHROPIC_BASE_URL`, and stores the selected provider in
-`AGENTKIT_SANDBOX_MODEL_PROVIDER`. The same provider ID and base URL are written
-into `CODEX_CONFIG_TOML`, and provider-supported models are written into
-`CODEX_MODEL_CATALOG_JSON`. The create request also injects
+`AGENTKIT_SANDBOX_MODEL_PROVIDER`. For built-in provider URLs, the same provider
+ID and base URL are written into `CODEX_CONFIG_TOML`, and provider-supported
+models are written into `CODEX_MODEL_CATALOG_JSON`. The create request also
+injects
 `BROWSER_EXTRA_ARGS` for browser startup inside the sandbox:
 
 ```sh
 --enable-unsafe-swiftshader --use-gl=angle --use-angle=swiftshader-webgl --ignore-gpu-blocklist
 ```
-
-Custom `--model-base-url` is intentionally not exposed.
 
 Provider defaults:
 
@@ -457,11 +464,17 @@ Options:
 - `--model-name`: optional. When creating a sandbox session, injects the value
   as `OPENCODE_MODEL`, `CODEX_MODEL`, and `ANTHROPIC_MODEL`. Custom model names
   are allowed.
-- `--model-provider`: optional. When creating a sandbox session, uses the
-  provider's default model if `--model-name` is omitted, injects provider base
-  URL envs, and updates `CODEX_CONFIG_TOML` / `CODEX_MODEL_CATALOG_JSON` for
-  `CodeEnv` sessions. Supported values are `model_square`, `coding_plan`, and
-  `agent_plan`.
+- `--model-provider`: optional. When creating a sandbox session, injects the
+  provider marker. The built-in providers `model_square`, `coding_plan`, and
+  `agent_plan` also provide default models, base URL envs, and
+  `CODEX_CONFIG_TOML` / `CODEX_MODEL_CATALOG_JSON` updates for `CodeEnv`
+  sessions. Other provider strings are passed through without built-in URL or
+  catalog handling and require `--model-base-url`.
+- `--model-base-url`: optional. When creating a sandbox session, injects the
+  value into `OPENCODE_BASE_URL`, `CODEX_BASE_URL`, `MODEL_BASE_URL`, and
+  `ANTHROPIC_BASE_URL`. When provided, it takes precedence over provider base
+  URLs and skips `CODEX_CONFIG_TOML` / `CODEX_MODEL_CATALOG_JSON`. Non-Ark
+  custom URLs require `--model-provider`.
 - `--model-api-key`: optional. When creating a sandbox session, injects the
   value as `OPENCODE_API_KEY`, `CODEX_API_KEY`, and `ANTHROPIC_AUTH_TOKEN`. If
   omitted, the CLI uses `MODEL_API_KEY` when that environment variable is set.
@@ -487,11 +500,12 @@ while the connection is active. Multiple live WebSocket connections under the
 same sandbox `session_id` are tracked in the same list. The CLI removes only the
 current shell ID from the list when that connection is detached or closed.
 
-When `--model-name` is provided without `--model-provider`, `exec` still updates
-`CODEX_CONFIG_TOML` / `CODEX_MODEL_CATALOG_JSON` for `CodeEnv` sessions. It
-first tries to reuse `AGENTKIT_SANDBOX_MODEL_PROVIDER` from the cached or remote
-tool configuration, then falls back to `model_square` when no marker is
-available.
+When `--model-name` is provided without `--model-provider`, `exec` first tries
+to reuse `AGENTKIT_SANDBOX_MODEL_PROVIDER` from the cached or remote tool
+configuration, then falls back to `model_square` when no marker is available.
+For built-in provider URLs, it updates `CODEX_CONFIG_TOML` /
+`CODEX_MODEL_CATALOG_JSON` for `CodeEnv` sessions. If the tool carries a custom
+model base URL, exec inherits that URL and skips those Codex config envs.
 
 Press `Ctrl-]`, or type `exit` / `exit()`, to detach from the local terminal.
 `Ctrl-C` is forwarded to the remote process, which is useful for interrupting
@@ -534,7 +548,8 @@ exec:
 Mapping entries support the same option names as `sandbox exec`, written with
 underscores, such as `session_id`, `tool_id`, `tool_type`, `command`, `mode`,
 `shell_id`, `workspace`, `dst_dir`, `git_config`, `model_name`,
-`model_api_key`, and `model_provider`. Use `src_dir` or `src_dirs` for the
+`model_api_key`, `model_provider`, and `model_base_url`. Use `src_dir` or
+`src_dirs` for the
 first uploaded source and optional additional source paths; use `extra_sources`
 for additional positional sources. Use `args` when you want to provide raw
 `sandbox exec` arguments directly.

--- a/agentkit/toolkit/cli/sandbox/README.md
+++ b/agentkit/toolkit/cli/sandbox/README.md
@@ -58,7 +58,7 @@ Options:
 - `--tos-bucket`: optional. TOS bucket to mount. If omitted, the tool is
   created without TOS mount configuration.
 - `--tos-mount`: optional. Local mount path for `--tos-bucket`; defaults to
-  `/home/gem`.
+  `/home/gem/workspace`.
 - `--cpu`: optional. Sandbox vCPU count; allowed values are `2`, `4`, `8`, and
   `16`. Defaults to `4`. Memory is derived as 2 GiB per vCPU.
 - `--model-provider`: optional. Model provider to use for base URLs, the
@@ -104,11 +104,12 @@ Volcengine configuration, including environment variables and global
 `agentkit config --global` settings.
 
 When `--tos-bucket` is set, the generated tool TOS mount uses
-`LocalMountPath: /home/gem` by default, or the path provided by `--tos-mount`:
+`LocalMountPath: /home/gem/workspace` by default, or the path provided by
+`--tos-mount`:
 
 ```text
 BucketPath: /sandbox-session/default/default
-LocalMountPath: /home/gem
+LocalMountPath: /home/gem/workspace
 Endpoint: http://tos-<region>.ivolces.com
 ```
 

--- a/agentkit/toolkit/cli/sandbox/README.md
+++ b/agentkit/toolkit/cli/sandbox/README.md
@@ -337,7 +337,9 @@ CLI renames it to `data.shell_id`.
 
 When `--src-dir` is provided, `shell` uses the same upload flow as
 `sandbox exec`: archive local sources, upload the archive to the session,
-extract it under `--workspace` plus `--dst-dir`, then execute `--command`.
+extract it under `--workspace` plus `--dst-dir`, then execute `--command`. A
+directory source is extracted as that directory under the destination; its
+contents are not flattened into the destination.
 
 ### Web
 
@@ -472,7 +474,8 @@ When `--src-dir` is provided, the command first reuses the sandbox file upload
 flow to archive the local file or directory, upload it to the session, and
 extract it into the directory resolved from `--workspace` and `--dst-dir`. The
 WebSocket exec connection is opened only after the upload and extraction
-complete.
+complete. A directory source is extracted as that directory under the
+destination; its contents are not flattened into the destination.
 
 When the resolved tool has `TosMountConfig.MountPoints` in `GetTool`, session
 creation passes those mount points to `CreateSession` and uses each returned

--- a/agentkit/toolkit/cli/sandbox/cli.py
+++ b/agentkit/toolkit/cli/sandbox/cli.py
@@ -33,7 +33,10 @@ sandbox_app = typer.Typer(
     no_args_is_help=True,
 )
 
-sandbox_app.command(name="create")(create_command)
+sandbox_app.command(
+    name="create",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)(create_command)
 sandbox_app.command(name="get")(get_command)
 sandbox_app.command(name="mount")(mount_command)
 sandbox_app.command(

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -74,9 +74,7 @@ DEFAULT_BROWSER_EXTRA_ARGS = (
     "--use-angle=swiftshader-webgl --ignore-gpu-blocklist"
 )
 WEB_SEARCH_API_KEY_ENV = "WEB_SEARCH_API_KEY"
-SKILL_ROLE_TYPE_EXISTED = "existed"
-SKILL_ROLE_TYPE_NEW = "new"
-VALID_SKILL_ROLE_TYPES = (SKILL_ROLE_TYPE_EXISTED, SKILL_ROLE_TYPE_NEW)
+SKILL_ROLE_NAME_OPTION = "--skill-role-name"
 TOOL_READY_STATUS = "Ready"
 TOOL_FAILED_STATUSES = {"Error", "Failed", "CreateFailed", "Deleting", "Deleted"}
 TOOL_WAIT_INTERVAL_SECONDS = 5
@@ -361,29 +359,54 @@ def _generate_default_role_name() -> str:
 
 
 def _resolve_skill_role(
-    skill_role_type: Optional[str],
     skill_role_name: Optional[str],
+    skill_role_name_provided: bool,
     region: str,
 ) -> Optional[str]:
-    if not skill_role_type:
+    if not skill_role_name_provided:
         return None
-    resolved_type = skill_role_type.strip().lower()
-    if resolved_type not in VALID_SKILL_ROLE_TYPES:
-        allowed = ", ".join(VALID_SKILL_ROLE_TYPES)
-        raise typer.BadParameter(
-            f"--skill-role-type must be one of: {allowed}"
-        )
     resolved_name = (skill_role_name or "").strip()
     if not resolved_name:
-        if resolved_type == SKILL_ROLE_TYPE_NEW:
-            resolved_name = _generate_default_role_name()
-        else:
-            raise typer.BadParameter(
-                "--skill-role-name is required when --skill-role-type=existed"
-            )
-    if resolved_type == SKILL_ROLE_TYPE_NEW:
-        _ensure_sandbox_role(resolved_name, region)
+        resolved_name = _generate_default_role_name()
+    _ensure_sandbox_role(resolved_name, region)
     return resolved_name
+
+
+def _resolve_create_extra_args(
+    ctx: typer.Context,
+) -> tuple[Optional[str], bool]:
+    raw_args = list(ctx.args)
+    skill_role_name: Optional[str] = None
+    skill_role_name_provided = False
+    remaining_args: list[str] = []
+    index = 0
+    while index < len(raw_args):
+        current = raw_args[index]
+        if current == SKILL_ROLE_NAME_OPTION:
+            if skill_role_name_provided:
+                error(f"{SKILL_ROLE_NAME_OPTION} cannot be provided multiple times")
+            skill_role_name_provided = True
+            if index + 1 < len(raw_args) and not raw_args[index + 1].startswith("-"):
+                skill_role_name = raw_args[index + 1]
+                index += 2
+                continue
+            index += 1
+            continue
+        if current.startswith(f"{SKILL_ROLE_NAME_OPTION}="):
+            if skill_role_name_provided:
+                error(f"{SKILL_ROLE_NAME_OPTION} cannot be provided multiple times")
+            skill_role_name_provided = True
+            skill_role_name = current.split("=", 1)[1]
+            index += 1
+            continue
+        remaining_args.append(current)
+        index += 1
+
+    if remaining_args:
+        unknown = " ".join(remaining_args)
+        error(f"Unknown arguments: {unknown}")
+
+    return skill_role_name, skill_role_name_provided
 
 
 def create_tool(
@@ -396,18 +419,22 @@ def create_tool(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
-    skill_role_type: Optional[str] = None,
     skill_role_name: Optional[str] = None,
+    skill_role_name_provided: bool = False,
     websearch_apikey: Optional[str] = None,
 ) -> dict[str, object]:
     resolved_model_provider = normalize_model_provider(model_provider)
     region = _resolve_region(SANDBOX_REGION_ENV, "agentkit")
     tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV, "tos")
 
-    if skill_role_type and websearch_apikey:
-        error("--skill-role-type and --websearch-apikey are mutually exclusive")
+    if skill_role_name_provided and websearch_apikey:
+        error("--skill-role-name and --websearch-apikey are mutually exclusive")
 
-    resolved_role_name = _resolve_skill_role(skill_role_type, skill_role_name, region)
+    resolved_role_name = _resolve_skill_role(
+        skill_role_name,
+        skill_role_name_provided,
+        region,
+    )
     resolved_websearch_apikey = (websearch_apikey or "").strip() or None
 
     request = _build_create_tool_request(
@@ -438,12 +465,12 @@ def create_tool(
         "status": final_tool.status or TOOL_READY_STATUS,
         "model_provider": resolved_model_provider,
         "role_name": resolved_role_name,
-        "skill_role_type": skill_role_type,
         "websearch_apikey_set": bool(resolved_websearch_apikey),
     }
 
 
 def create_command(
+    ctx: typer.Context,
     tool_type: str = typer.Option(
         DEFAULT_CREATE_TOOL_TYPE,
         "--tool-type",
@@ -497,35 +524,25 @@ def create_command(
         "--model-provider",
         help="Model provider to use for base URLs, defaults, and model catalog.",
     ),
-    skill_role_type: Optional[str] = typer.Option(
-        None,
-        "--skill-role-type",
-        help=(
-            "Skill role type: 'existed' to use an existing role, "
-            "'new' to create one. Mutually exclusive with --websearch-apikey."
-        ),
-    ),
-    skill_role_name: Optional[str] = typer.Option(
-        None,
-        "--skill-role-name",
-        help=(
-            "IAM role name. Required when --skill-role-type=existed; "
-            "auto-generated when --skill-role-type=new and omitted."
-        ),
-    ),
     websearch_apikey: Optional[str] = typer.Option(
         None,
         "--websearch-apikey",
         help=(
             "Web search API key to inject as WEB_SEARCH_API_KEY env. "
-            "Mutually exclusive with --skill-role-type. "
-            "Use --enable-websearch-apikey in exec to toggle per session."
+            f"Mutually exclusive with {SKILL_ROLE_NAME_OPTION}. "
+            "Use --disable-websearch-apikey in exec to disable it per session."
         ),
     ),
 ) -> None:
-    """Create an AgentKit Tool with optional TOS mount."""
+    """Create an AgentKit Tool with optional TOS mount.
+
+    Extra option:
+    - --skill-role-name ROLE_NAME: reuse the role if it exists, otherwise create it
+    - --skill-role-name: create a role with an auto-generated name
+    """
     result = None
     try:
+        skill_role_name, skill_role_name_provided = _resolve_create_extra_args(ctx)
         if tos_mount is not None and not (tos_bucket or "").strip():
             error("--tos-mount requires --tos-bucket")
         result = create_tool(
@@ -537,8 +554,8 @@ def create_command(
             model_name=model_name,
             model_api_key=model_api_key,
             model_provider=model_provider.value,
-            skill_role_type=skill_role_type,
             skill_role_name=skill_role_name,
+            skill_role_name_provided=skill_role_name_provided,
             websearch_apikey=websearch_apikey,
         )
         save_tool_result(str(result["tool_type"]), result)
@@ -553,4 +570,7 @@ def create_command(
     if result.get("role_name"):
         typer.echo(f"角色名：{result['role_name']}")
     if not result.get("role_name") and not result.get("websearch_apikey_set"):
-        typer.echo("提示：未配置 WebSearch（可通过 --skill-role-type 配置 Role 或 --websearch-apikey 配置 API Key 来启用）")
+        typer.echo(
+            "提示：未配置 WebSearch（可通过 --skill-role-name 配置 Role 或 "
+            "--websearch-apikey 配置 API Key 来启用）"
+        )

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -32,16 +32,19 @@ from agentkit.toolkit.cli.sandbox.model_config import (
     CODE_ENV_HOME,
     CODEX_CONFIG_TOML_ENV,
     CODEX_MODEL_CATALOG_JSON_ENV,
-    DEFAULT_MODEL_PROVIDER,
     ModelProviderType,
     MODEL_API_KEY_ENV,
     MODEL_API_KEY_ENV_KEYS,
     MODEL_BASE_URL_ENV_KEYS,
     MODEL_NAME_ENV_KEYS,
     MODEL_PROVIDER_ENV,
-    get_model_provider_config,
+    infer_model_provider_from_base_url,
+    normalize_model_base_url,
     normalize_model_provider,
+    resolve_model_base_urls,
     resolve_model_name,
+    should_emit_codex_model_config,
+    validate_model_provider_base_url,
     build_codex_config_toml as _shared_build_codex_config_toml,
     build_codex_model_catalog_json as _shared_build_codex_model_catalog_json,
 )
@@ -115,8 +118,7 @@ def _append_tool_envs(
         return
 
     envs.extend(
-        tools_types.EnvsItemForCreateTool(Key=key, Value=resolved)
-        for key in keys
+        tools_types.EnvsItemForCreateTool(Key=key, Value=resolved) for key in keys
     )
 
 
@@ -138,31 +140,37 @@ def _append_code_env_tool_envs(
     envs: list[tools_types.EnvsItemForCreateTool],
     model_name: str,
     model_provider: str | ModelProviderType | None,
+    *,
+    include_codex_model_config: bool = True,
 ) -> None:
-    envs.extend(
-        [
-            tools_types.EnvsItemForCreateTool(
-                Key="OPENCODE_DISABLE_AUTOUPDATE",
-                Value="1",
-            ),
-            tools_types.EnvsItemForCreateTool(
-                Key="HOME",
-                Value=CODE_ENV_HOME,
-            ),
-            tools_types.EnvsItemForCreateTool(
-                Key="CODEX_HOME",
-                Value=CODE_ENV_CODEX_HOME,
-            ),
-            tools_types.EnvsItemForCreateTool(
-                Key=CODEX_CONFIG_TOML_ENV,
-                Value=_build_codex_config_toml(model_name, model_provider),
-            ),
-            tools_types.EnvsItemForCreateTool(
-                Key=CODEX_MODEL_CATALOG_JSON_ENV,
-                Value=_build_codex_model_catalog_json(model_name, model_provider),
-            ),
-        ]
-    )
+    code_envs = [
+        tools_types.EnvsItemForCreateTool(
+            Key="OPENCODE_DISABLE_AUTOUPDATE",
+            Value="1",
+        ),
+        tools_types.EnvsItemForCreateTool(
+            Key="HOME",
+            Value=CODE_ENV_HOME,
+        ),
+        tools_types.EnvsItemForCreateTool(
+            Key="CODEX_HOME",
+            Value=CODE_ENV_CODEX_HOME,
+        ),
+    ]
+    if include_codex_model_config:
+        code_envs.extend(
+            [
+                tools_types.EnvsItemForCreateTool(
+                    Key=CODEX_CONFIG_TOML_ENV,
+                    Value=_build_codex_config_toml(model_name, model_provider),
+                ),
+                tools_types.EnvsItemForCreateTool(
+                    Key=CODEX_MODEL_CATALOG_JSON_ENV,
+                    Value=_build_codex_model_catalog_json(model_name, model_provider),
+                ),
+            ]
+        )
+    envs.extend(code_envs)
 
 
 def _build_tool_model_envs(
@@ -170,12 +178,28 @@ def _build_tool_model_envs(
     tool_type: str,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
-    model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    model_provider: str | ModelProviderType | None = None,
+    model_base_url: Optional[str] = None,
+    model_provider_was_provided: Optional[bool] = None,
+    model_base_url_was_provided: Optional[bool] = None,
 ) -> list[tools_types.EnvsItemForCreateTool] | None:
     envs: list[tools_types.EnvsItemForCreateTool] = []
-    provider_config = get_model_provider_config(model_provider)
-    resolved_model_provider = normalize_model_provider(model_provider)
-    resolved_model_name = resolve_model_name(model_name, model_provider)
+    validate_model_provider_base_url(
+        model_provider=model_provider,
+        model_base_url=model_base_url,
+        model_provider_was_provided=model_provider_was_provided,
+        model_base_url_was_provided=model_base_url_was_provided,
+    )
+    resolved_model_base_url = normalize_model_base_url(model_base_url)
+    effective_model_provider = model_provider or infer_model_provider_from_base_url(
+        resolved_model_base_url
+    )
+    resolved_model_provider = normalize_model_provider(effective_model_provider)
+    resolved_model_name = resolve_model_name(model_name, resolved_model_provider)
+    resolved_base_url, resolved_anthropic_base_url = resolve_model_base_urls(
+        model_provider=resolved_model_provider,
+        model_base_url=resolved_model_base_url,
+    )
     resolved_model_api_key = model_api_key or os.getenv(MODEL_API_KEY_ENV)
     _append_tool_envs(envs, (MODEL_PROVIDER_ENV,), resolved_model_provider)
     _append_tool_envs(envs, MODEL_NAME_ENV_KEYS, resolved_model_name)
@@ -183,17 +207,28 @@ def _build_tool_model_envs(
     _append_tool_envs(
         envs,
         MODEL_BASE_URL_ENV_KEYS,
-        provider_config.model_base_url,
+        resolved_base_url,
     )
     _append_tool_envs(
         envs,
         ANTHROPIC_BASE_URL_ENV_KEYS,
-        provider_config.anthropic_base_url,
+        resolved_anthropic_base_url,
     )
     _append_tool_envs(envs, DISABLED_SERVICE_ENV_KEYS, "true")
     _append_tool_envs(envs, (BROWSER_EXTRA_ARGS_ENV,), DEFAULT_BROWSER_EXTRA_ARGS)
     if tool_type.strip() == DEFAULT_CREATE_TOOL_TYPE:
-        _append_code_env_tool_envs(envs, resolved_model_name, model_provider)
+        _append_code_env_tool_envs(
+            envs,
+            resolved_model_name,
+            resolved_model_provider,
+            include_codex_model_config=(
+                bool(resolved_model_name)
+                and should_emit_codex_model_config(
+                    model_provider=resolved_model_provider,
+                    model_base_url=resolved_model_base_url,
+                )
+            ),
+        )
     return envs or None
 
 
@@ -207,7 +242,10 @@ def _build_create_tool_request(
     cpu: int = DEFAULT_CPU,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
-    model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    model_provider: str | ModelProviderType | None = None,
+    model_base_url: Optional[str] = None,
+    model_provider_was_provided: Optional[bool] = None,
+    model_base_url_was_provided: Optional[bool] = None,
 ) -> tools_types.CreateToolRequest:
     resolved_tool_type = tool_type.strip() or DEFAULT_CREATE_TOOL_TYPE
     resolved_name = (name or "").strip() or _generate_tool_name(resolved_tool_type)
@@ -241,6 +279,9 @@ def _build_create_tool_request(
             model_name=model_name,
             model_api_key=model_api_key,
             model_provider=model_provider,
+            model_base_url=model_base_url,
+            model_provider_was_provided=model_provider_was_provided,
+            model_base_url_was_provided=model_base_url_was_provided,
         ),
     )
 
@@ -310,9 +351,17 @@ def create_tool(
     cpu: int = DEFAULT_CPU,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
-    model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    model_provider: str | ModelProviderType | None = None,
+    model_base_url: Optional[str] = None,
 ) -> dict[str, object]:
-    resolved_model_provider = normalize_model_provider(model_provider)
+    resolved_model_base_url = normalize_model_base_url(model_base_url)
+    raw_model_provider = (
+        model_provider.value if isinstance(model_provider, ModelProviderType) else model_provider
+    )
+    effective_model_provider = raw_model_provider or infer_model_provider_from_base_url(
+        resolved_model_base_url
+    )
+    resolved_model_provider = normalize_model_provider(effective_model_provider)
     region = _resolve_region(SANDBOX_REGION_ENV, "agentkit")
     tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV, "tos")
     request = _build_create_tool_request(
@@ -324,7 +373,10 @@ def create_tool(
         cpu=cpu,
         model_name=model_name,
         model_api_key=model_api_key,
-        model_provider=resolved_model_provider,
+        model_provider=effective_model_provider,
+        model_base_url=resolved_model_base_url,
+        model_provider_was_provided=bool((raw_model_provider or "").strip()),
+        model_base_url_was_provided=bool(resolved_model_base_url),
     )
     client = AgentkitToolsClient(
         region=region,
@@ -340,6 +392,7 @@ def create_tool(
         "name": final_tool.name or request.name,
         "status": final_tool.status or TOOL_READY_STATUS,
         "model_provider": resolved_model_provider,
+        "model_base_url": resolved_model_base_url,
     }
 
 
@@ -357,10 +410,7 @@ def create_command(
     tos_bucket: Optional[str] = typer.Option(
         None,
         "--tos-bucket",
-        help=(
-            "TOS bucket to mount. "
-            "Omit to create the tool without a TOS mount."
-        ),
+        help=("TOS bucket to mount. Omit to create the tool without a TOS mount."),
     ),
     tos_mount: Optional[str] = typer.Option(
         None,
@@ -392,10 +442,18 @@ def create_command(
             "and ANTHROPIC_AUTH_TOKEN when creating a tool."
         ),
     ),
-    model_provider: ModelProviderType = typer.Option(
-        ModelProviderType.MODEL_SQUARE,
+    model_provider: Optional[str] = typer.Option(
+        None,
         "--model-provider",
         help="Model provider to use for base URLs, defaults, and model catalog.",
+    ),
+    model_base_url: Optional[str] = typer.Option(
+        None,
+        "--model-base-url",
+        help=(
+            "Custom model base URL to inject into OPENCODE_BASE_URL, "
+            "CODEX_BASE_URL, MODEL_BASE_URL, and ANTHROPIC_BASE_URL."
+        ),
     ),
 ) -> None:
     """Create an AgentKit Tool with optional TOS mount."""
@@ -410,7 +468,8 @@ def create_command(
             cpu=cpu,
             model_name=model_name,
             model_api_key=model_api_key,
-            model_provider=model_provider.value,
+            model_provider=model_provider,
+            model_base_url=model_base_url,
         )
         save_tool_result(str(result["tool_type"]), result)
     except (typer.Abort, typer.Exit):

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -73,6 +73,10 @@ DEFAULT_BROWSER_EXTRA_ARGS = (
     "--enable-unsafe-swiftshader --use-gl=angle "
     "--use-angle=swiftshader-webgl --ignore-gpu-blocklist"
 )
+WEB_SEARCH_API_KEY_ENV = "WEB_SEARCH_API_KEY"
+SKILL_ROLE_TYPE_EXISTED = "existed"
+SKILL_ROLE_TYPE_NEW = "new"
+VALID_SKILL_ROLE_TYPES = (SKILL_ROLE_TYPE_EXISTED, SKILL_ROLE_TYPE_NEW)
 TOOL_READY_STATUS = "Ready"
 TOOL_FAILED_STATUSES = {"Error", "Failed", "CreateFailed", "Deleting", "Deleted"}
 TOOL_WAIT_INTERVAL_SECONDS = 5
@@ -171,6 +175,7 @@ def _build_tool_model_envs(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    websearch_apikey: Optional[str] = None,
 ) -> list[tools_types.EnvsItemForCreateTool] | None:
     envs: list[tools_types.EnvsItemForCreateTool] = []
     provider_config = get_model_provider_config(model_provider)
@@ -192,6 +197,7 @@ def _build_tool_model_envs(
     )
     _append_tool_envs(envs, DISABLED_SERVICE_ENV_KEYS, "true")
     _append_tool_envs(envs, (BROWSER_EXTRA_ARGS_ENV,), DEFAULT_BROWSER_EXTRA_ARGS)
+    _append_tool_envs(envs, (WEB_SEARCH_API_KEY_ENV,), websearch_apikey)
     if tool_type.strip() == DEFAULT_CREATE_TOOL_TYPE:
         _append_code_env_tool_envs(envs, resolved_model_name, model_provider)
     return envs or None
@@ -208,6 +214,8 @@ def _build_create_tool_request(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    role_name: Optional[str] = None,
+    websearch_apikey: Optional[str] = None,
 ) -> tools_types.CreateToolRequest:
     resolved_tool_type = tool_type.strip() or DEFAULT_CREATE_TOOL_TYPE
     resolved_name = (name or "").strip() or _generate_tool_name(resolved_tool_type)
@@ -225,6 +233,7 @@ def _build_create_tool_request(
         ToolType=resolved_tool_type,
         CpuMilli=cpu_milli,
         MemoryMb=memory_mb,
+        RoleName=role_name,
         AuthorizerConfiguration=tools_types.AuthorizerForCreateTool(
             KeyAuth=tools_types.AuthorizerKeyAuthForCreateTool(
                 ApiKeyName=generate_apikey_name(),
@@ -241,6 +250,7 @@ def _build_create_tool_request(
             model_name=model_name,
             model_api_key=model_api_key,
             model_provider=model_provider,
+            websearch_apikey=websearch_apikey,
         ),
     )
 
@@ -301,6 +311,81 @@ def _wait_for_tool_ready(
         time.sleep(interval_seconds)
 
 
+def _ensure_sandbox_role(
+    role_name: str,
+    region: str,
+) -> str:
+    import json as _json
+    from agentkit.toolkit.volcengine.iam import VeIAM
+
+    iam = VeIAM(region=region)
+    existing = iam.get_role(role_name)
+    if existing is not None:
+        return role_name
+
+    agentkit_service_code = (
+        (
+            os.getenv("VOLCENGINE_AGENTKIT_SERVICE")
+            or os.getenv("VOLC_AGENTKIT_SERVICE")
+            or os.getenv("BYTEPLUS_AGENTKIT_SERVICE")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    service = "vefaas"
+    if "stg" in agentkit_service_code:
+        service = "vefaas_dev"
+    trust_policy = _json.dumps(
+        {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["sts:AssumeRole"],
+                    "Principal": {"Service": [service]},
+                }
+            ]
+        }
+    )
+    iam.create_role(role_name, trust_policy)
+    iam.attach_role_policy(
+        role_name,
+        policy_name="AgentKitSkillsSandboxAccess",
+        policy_type="System",
+    )
+    return role_name
+
+
+def _generate_default_role_name() -> str:
+    return f"agentkit-sandbox-{generate_random_id(8)}"
+
+
+def _resolve_skill_role(
+    skill_role_type: Optional[str],
+    skill_role_name: Optional[str],
+    region: str,
+) -> Optional[str]:
+    if not skill_role_type:
+        return None
+    resolved_type = skill_role_type.strip().lower()
+    if resolved_type not in VALID_SKILL_ROLE_TYPES:
+        allowed = ", ".join(VALID_SKILL_ROLE_TYPES)
+        raise typer.BadParameter(
+            f"--skill-role-type must be one of: {allowed}"
+        )
+    resolved_name = (skill_role_name or "").strip()
+    if not resolved_name:
+        if resolved_type == SKILL_ROLE_TYPE_NEW:
+            resolved_name = _generate_default_role_name()
+        else:
+            raise typer.BadParameter(
+                "--skill-role-name is required when --skill-role-type=existed"
+            )
+    if resolved_type == SKILL_ROLE_TYPE_NEW:
+        _ensure_sandbox_role(resolved_name, region)
+    return resolved_name
+
+
 def create_tool(
     *,
     tool_type: str = DEFAULT_CREATE_TOOL_TYPE,
@@ -311,10 +396,20 @@ def create_tool(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = DEFAULT_MODEL_PROVIDER,
+    skill_role_type: Optional[str] = None,
+    skill_role_name: Optional[str] = None,
+    websearch_apikey: Optional[str] = None,
 ) -> dict[str, object]:
     resolved_model_provider = normalize_model_provider(model_provider)
     region = _resolve_region(SANDBOX_REGION_ENV, "agentkit")
     tos_region = _resolve_region(SANDBOX_TOS_REGION_ENV, "tos")
+
+    if skill_role_type and websearch_apikey:
+        error("--skill-role-type and --websearch-apikey are mutually exclusive")
+
+    resolved_role_name = _resolve_skill_role(skill_role_type, skill_role_name, region)
+    resolved_websearch_apikey = (websearch_apikey or "").strip() or None
+
     request = _build_create_tool_request(
         tool_type=tool_type,
         name=tool_name,
@@ -325,6 +420,8 @@ def create_tool(
         model_name=model_name,
         model_api_key=model_api_key,
         model_provider=resolved_model_provider,
+        role_name=resolved_role_name,
+        websearch_apikey=resolved_websearch_apikey,
     )
     client = AgentkitToolsClient(
         region=region,
@@ -340,6 +437,9 @@ def create_tool(
         "name": final_tool.name or request.name,
         "status": final_tool.status or TOOL_READY_STATUS,
         "model_provider": resolved_model_provider,
+        "role_name": resolved_role_name,
+        "skill_role_type": skill_role_type,
+        "websearch_apikey_set": bool(resolved_websearch_apikey),
     }
 
 
@@ -397,8 +497,34 @@ def create_command(
         "--model-provider",
         help="Model provider to use for base URLs, defaults, and model catalog.",
     ),
+    skill_role_type: Optional[str] = typer.Option(
+        None,
+        "--skill-role-type",
+        help=(
+            "Skill role type: 'existed' to use an existing role, "
+            "'new' to create one. Mutually exclusive with --websearch-apikey."
+        ),
+    ),
+    skill_role_name: Optional[str] = typer.Option(
+        None,
+        "--skill-role-name",
+        help=(
+            "IAM role name. Required when --skill-role-type=existed; "
+            "auto-generated when --skill-role-type=new and omitted."
+        ),
+    ),
+    websearch_apikey: Optional[str] = typer.Option(
+        None,
+        "--websearch-apikey",
+        help=(
+            "Web search API key to inject as WEB_SEARCH_API_KEY env. "
+            "Mutually exclusive with --skill-role-type. "
+            "Use --enable-websearch-apikey in exec to toggle per session."
+        ),
+    ),
 ) -> None:
     """Create an AgentKit Tool with optional TOS mount."""
+    result = None
     try:
         if tos_mount is not None and not (tos_bucket or "").strip():
             error("--tos-mount requires --tos-bucket")
@@ -411,6 +537,9 @@ def create_command(
             model_name=model_name,
             model_api_key=model_api_key,
             model_provider=model_provider.value,
+            skill_role_type=skill_role_type,
+            skill_role_name=skill_role_name,
+            websearch_apikey=websearch_apikey,
         )
         save_tool_result(str(result["tool_type"]), result)
     except (typer.Abort, typer.Exit):
@@ -421,3 +550,7 @@ def create_command(
     typer.echo("工具创建成功")
     typer.echo(f"工具ID：{result['tool_id']}")
     typer.echo(f"状态：{result['status']}")
+    if result.get("role_name"):
+        typer.echo(f"角色名：{result['role_name']}")
+    if not result.get("role_name") and not result.get("websearch_apikey_set"):
+        typer.echo("提示：未配置 WebSearch（可通过 --skill-role-type 配置 Role 或 --websearch-apikey 配置 API Key 来启用）")

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -492,12 +492,12 @@ def exec_command(
             "when creating a sandbox session."
         ),
     ),
-    enable_websearch_apikey: Optional[bool] = typer.Option(
-        None,
-        "--enable-websearch-apikey/--disable-websearch-apikey",
+    disable_websearch_apikey: bool = typer.Option(
+        False,
+        "--disable-websearch-apikey",
         help=(
-            "Control whether WEB_SEARCH_API_KEY is enabled for this session. "
-            "Only effective when the tool was created with --websearch-apikey."
+            "Disable WEB_SEARCH_API_KEY for this session. "
+            "Omit this option to keep the default enabled behavior."
         ),
     ),
 ) -> None:
@@ -518,22 +518,14 @@ def exec_command(
             tool_type=tool_type,
         )
         has_role = bool(ws_config and ws_config.get("has_role"))
-        tool_has_websearch = bool(ws_config and ws_config.get("websearch_apikey_set"))
 
-        disable_websearch = False
-        if enable_websearch_apikey is not None:
-            if has_role:
-                typer.echo(
-                    "警告：当前工具使用 IAM Role 模式，--enable-websearch-apikey/--disable-websearch-apikey 不会生效（WebSearch 权限由角色策略控制）。",
-                    err=True,
-                )
-            elif not tool_has_websearch:
-                error(
-                    "当前工具未配置 WebSearch API Key（创建时未指定 --websearch-apikey），"
-                    "--enable-websearch-apikey 无法生效。"
-                )
-            elif enable_websearch_apikey is False:
-                disable_websearch = True
+        disable_websearch = disable_websearch_apikey
+        if disable_websearch_apikey and has_role:
+            disable_websearch = False
+            typer.echo(
+                "警告：当前工具使用 IAM Role 模式，--disable-websearch-apikey 不会生效（WebSearch 权限由角色策略控制）。",
+                err=True,
+            )
 
         session = ensure_sandbox_session(
             session_id=session_id,

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -50,7 +50,7 @@ from agentkit.toolkit.cli.sandbox.session_create import (
 )
 from agentkit.toolkit.cli.sandbox.git_config import apply_git_config_to_session
 from agentkit.toolkit.cli.sandbox.model_config import ModelProviderType
-from agentkit.toolkit.cli.sandbox.tos_config import DEFAULT_TOS_LOCAL_PATH
+from agentkit.toolkit.cli.sandbox.tos_config import DEFAULT_SANDBOX_WORKSPACE
 from agentkit.toolkit.cli.sandbox.tool_resolve import (
     SandboxToolType,
     find_tool_model_provider,
@@ -167,8 +167,7 @@ def _connect_terminal(
         import websocket
     except ImportError:
         error(
-            "websocket-client is required. "
-            "Install with: pip install websocket-client"
+            "websocket-client is required. Install with: pip install websocket-client"
         )
 
     stop_event = threading.Event()
@@ -259,7 +258,7 @@ def _resolve_exec_dst_dir(
     workspace: Optional[str],
     dst_dir: Optional[str],
 ) -> str:
-    resolved_workspace = _normalize_workspace(workspace) or DEFAULT_TOS_LOCAL_PATH
+    resolved_workspace = _normalize_workspace(workspace) or DEFAULT_SANDBOX_WORKSPACE
     raw_dst_dir = (dst_dir or "").strip()
     if not raw_dst_dir:
         return resolved_workspace
@@ -447,7 +446,7 @@ def exec_command(
         ),
     ),
     workspace: str = typer.Option(
-        DEFAULT_TOS_LOCAL_PATH,
+        DEFAULT_SANDBOX_WORKSPACE,
         "--workspace",
         help=(
             "Sandbox workspace root. Relative --dst-dir values are "
@@ -457,9 +456,7 @@ def exec_command(
     src_dir: Optional[Path] = typer.Option(
         None,
         "--src-dir",
-        help=(
-            "Local file or directory to upload before opening the exec session."
-        ),
+        help=("Local file or directory to upload before opening the exec session."),
     ),
     dst_dir: Optional[str] = typer.Option(
         None,

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -48,11 +48,16 @@ from agentkit.toolkit.cli.sandbox.session_create import (
     ensure_sandbox_session,
 )
 from agentkit.toolkit.cli.sandbox.git_config import apply_git_config_to_session
-from agentkit.toolkit.cli.sandbox.model_config import ModelProviderType
+from agentkit.toolkit.cli.sandbox.model_config import (
+    is_custom_model_base_url,
+    normalize_model_base_url,
+)
 from agentkit.toolkit.cli.sandbox.tos_config import DEFAULT_SANDBOX_WORKSPACE
 from agentkit.toolkit.cli.sandbox.tool_resolve import (
     SandboxToolType,
+    find_tool_model_base_urls,
     find_tool_model_provider,
+    get_remote_tool_model_base_urls,
     get_remote_tool_model_provider,
 )
 from agentkit.toolkit.cli.sandbox.sandbox_client import (
@@ -329,17 +334,14 @@ def _upload_source_before_exec(
     return resolved_dst_dir
 
 
-def _resolve_exec_model_provider(
+def _resolve_exec_model_tool_id(
     *,
     session_id: Optional[str],
     tool_id: Optional[str],
-    tool_type: SandboxToolType,
     model_name: Optional[str],
-    model_provider: Optional[ModelProviderType],
-) -> str | ModelProviderType | None:
-    if model_provider or not (model_name or "").strip():
-        return model_provider
-
+) -> str | None:
+    if not (model_name or "").strip():
+        return None
     resolved_tool_id = (tool_id or "").strip()
     if not resolved_tool_id and session_id:
         existing = find_session_result(session_id)
@@ -348,9 +350,30 @@ def _resolve_exec_model_provider(
             if isinstance(existing_tool_id, str):
                 resolved_tool_id = existing_tool_id.strip()
 
-    if not resolved_tool_id:
-        return None
+    return resolved_tool_id or None
 
+
+def _resolve_exec_model_provider(
+    *,
+    session_id: Optional[str],
+    tool_id: Optional[str],
+    tool_type: SandboxToolType,
+    model_name: Optional[str],
+    model_provider: Optional[str],
+) -> str | None:
+    if model_provider or not (model_name or "").strip():
+        return model_provider
+
+    resolved_tool_id = _resolve_exec_model_tool_id(
+        session_id=session_id,
+        tool_id=tool_id,
+        model_name=model_name,
+    )
+    if not resolved_tool_id:
+        return find_tool_model_provider(
+            tool_id=None,
+            tool_type=tool_type,
+        )
     cached_model_provider = find_tool_model_provider(
         tool_id=resolved_tool_id,
         tool_type=tool_type,
@@ -369,6 +392,60 @@ def _resolve_exec_model_provider(
         )
     except Exception:
         return None
+
+
+def _resolve_exec_inherited_model_base_url(
+    *,
+    session_id: Optional[str],
+    tool_id: Optional[str],
+    tool_type: SandboxToolType,
+    model_name: Optional[str],
+    model_provider: Optional[str],
+    model_base_url: Optional[str],
+) -> str | None:
+    if normalize_model_base_url(model_base_url) or not (model_name or "").strip():
+        return None
+
+    resolved_tool_id = _resolve_exec_model_tool_id(
+        session_id=session_id,
+        tool_id=tool_id,
+        model_name=model_name,
+    )
+    cached_model_base_url, cached_anthropic_base_url = find_tool_model_base_urls(
+        tool_id=resolved_tool_id,
+        tool_type=tool_type,
+    )
+    if cached_model_base_url and is_custom_model_base_url(
+        model_provider=model_provider,
+        model_base_url=cached_model_base_url,
+        anthropic_base_url=cached_anthropic_base_url,
+    ):
+        return cached_model_base_url
+
+    if not resolved_tool_id:
+        return None
+
+    if not (tool_id or "").strip():
+        return None
+
+    try:
+        remote_model_base_url, remote_anthropic_base_url = (
+            get_remote_tool_model_base_urls(
+                AgentkitToolsClient(),
+                resolved_tool_id,
+                tool_type=tool_type,
+            )
+        )
+    except Exception:
+        return None
+
+    if remote_model_base_url and is_custom_model_base_url(
+        model_provider=model_provider,
+        model_base_url=remote_model_base_url,
+        anthropic_base_url=remote_anthropic_base_url,
+    ):
+        return remote_model_base_url
+    return None
 
 
 def _normalize_exec_mode(mode: Optional[str]) -> Optional[str]:
@@ -483,11 +560,20 @@ def exec_command(
             "and ANTHROPIC_AUTH_TOKEN when creating a sandbox session."
         ),
     ),
-    model_provider: Optional[ModelProviderType] = typer.Option(
+    model_provider: Optional[str] = typer.Option(
         None,
         "--model-provider",
         help=(
             "Model provider to use for base URLs, defaults, and model catalog "
+            "when creating a sandbox session."
+        ),
+    ),
+    model_base_url: Optional[str] = typer.Option(
+        None,
+        "--model-base-url",
+        help=(
+            "Custom model base URL to inject into OPENCODE_BASE_URL, "
+            "CODEX_BASE_URL, MODEL_BASE_URL, and ANTHROPIC_BASE_URL "
             "when creating a sandbox session."
         ),
     ),
@@ -502,6 +588,17 @@ def exec_command(
             model_name=model_name,
             model_provider=model_provider,
         )
+        explicit_model_provider = bool((model_provider or "").strip())
+        resolved_model_base_url = normalize_model_base_url(model_base_url)
+        if not resolved_model_base_url and not explicit_model_provider:
+            resolved_model_base_url = _resolve_exec_inherited_model_base_url(
+                session_id=session_id,
+                tool_id=tool_id,
+                tool_type=tool_type,
+                model_name=model_name,
+                model_provider=resolved_model_provider,
+                model_base_url=model_base_url,
+            )
         session = ensure_sandbox_session(
             session_id=session_id,
             tool_id=tool_id,
@@ -510,6 +607,11 @@ def exec_command(
                 model_name=model_name,
                 model_api_key=model_api_key,
                 model_provider=resolved_model_provider,
+                model_base_url=resolved_model_base_url,
+                model_provider_was_provided=explicit_model_provider,
+                model_base_url_was_provided=bool(
+                    normalize_model_base_url(model_base_url)
+                ),
                 include_codex_config=tool_type == SandboxToolType.CODE_ENV,
             ),
         )

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -54,6 +54,7 @@ from agentkit.toolkit.cli.sandbox.tool_resolve import (
     SandboxToolType,
     find_tool_model_provider,
     get_remote_tool_model_provider,
+    get_tool_websearch_config,
 )
 from agentkit.toolkit.cli.sandbox.sandbox_client import (
     add_session_terminal_shell_id,
@@ -491,6 +492,14 @@ def exec_command(
             "when creating a sandbox session."
         ),
     ),
+    enable_websearch_apikey: Optional[bool] = typer.Option(
+        None,
+        "--enable-websearch-apikey/--disable-websearch-apikey",
+        help=(
+            "Control whether WEB_SEARCH_API_KEY is enabled for this session. "
+            "Only effective when the tool was created with --websearch-apikey."
+        ),
+    ),
 ) -> None:
     """Open a streaming sandbox exec session. Press Ctrl-] or type exit/exit()."""
     exec_mode = _normalize_exec_mode(mode)
@@ -502,6 +511,30 @@ def exec_command(
             model_name=model_name,
             model_provider=model_provider,
         )
+
+        resolved_tool_id = (tool_id or "").strip()
+        ws_config = get_tool_websearch_config(
+            tool_id=resolved_tool_id or None,
+            tool_type=tool_type,
+        )
+        has_role = bool(ws_config and ws_config.get("has_role"))
+        tool_has_websearch = bool(ws_config and ws_config.get("websearch_apikey_set"))
+
+        disable_websearch = False
+        if enable_websearch_apikey is not None:
+            if has_role:
+                typer.echo(
+                    "警告：当前工具使用 IAM Role 模式，--enable-websearch-apikey/--disable-websearch-apikey 不会生效（WebSearch 权限由角色策略控制）。",
+                    err=True,
+                )
+            elif not tool_has_websearch:
+                error(
+                    "当前工具未配置 WebSearch API Key（创建时未指定 --websearch-apikey），"
+                    "--enable-websearch-apikey 无法生效。"
+                )
+            elif enable_websearch_apikey is False:
+                disable_websearch = True
+
         session = ensure_sandbox_session(
             session_id=session_id,
             tool_id=tool_id,
@@ -511,6 +544,7 @@ def exec_command(
                 model_api_key=model_api_key,
                 model_provider=resolved_model_provider,
                 include_codex_config=tool_type == SandboxToolType.CODE_ENV,
+                disable_websearch_apikey=disable_websearch,
             ),
         )
     except typer.Exit:

--- a/agentkit/toolkit/cli/sandbox/cli_exec.py
+++ b/agentkit/toolkit/cli/sandbox/cli_exec.py
@@ -35,7 +35,6 @@ import typer
 from agentkit.sdk.tools.client import AgentkitToolsClient
 from agentkit.toolkit.cli.sandbox.cli_file import (
     _build_remote_extract_command,
-    _create_upload_archive,
     _create_sources_upload_archive,
     _exec_shell_command,
     _new_remote_archive_path,
@@ -310,13 +309,7 @@ def _upload_source_before_exec(
         dst_dir=dst_dir,
     )
     resolved_sources = _resolve_exec_upload_sources(src_dirs)
-    if len(resolved_sources) == 1 and resolved_sources[0].is_dir():
-        archive_path = _create_upload_archive(
-            upload_dir=resolved_sources[0],
-            upload_files=[],
-        )
-    else:
-        archive_path = _create_sources_upload_archive(resolved_sources)
+    archive_path = _create_sources_upload_archive(resolved_sources)
     remote_archive_path = _new_remote_archive_path("agentkit-upload")
     try:
         _upload_remote_file(

--- a/agentkit/toolkit/cli/sandbox/cli_file.py
+++ b/agentkit/toolkit/cli/sandbox/cli_file.py
@@ -358,17 +358,23 @@ def _add_directory_contents(tar: tarfile.TarFile, directory: Path) -> None:
         )
 
 
+def _archive_source_name(source: Path) -> str:
+    return source.name or source.resolve().name
+
+
 def _add_source_to_archive(tar: tarfile.TarFile, source: Path) -> None:
+    source_name = _archive_source_name(source)
     if source.is_dir():
+        tar.add(source, arcname=source_name, recursive=False)
         for path in sorted(source.rglob("*")):
             relative_path = path.relative_to(source).as_posix()
             tar.add(
                 path,
-                arcname=posixpath.join(source.name, relative_path),
+                arcname=posixpath.join(source_name, relative_path),
                 recursive=False,
             )
         return
-    tar.add(source, arcname=source.name, recursive=False)
+    tar.add(source, arcname=source_name, recursive=False)
 
 
 def _create_sources_upload_archive(sources: list[Path]) -> Path:

--- a/agentkit/toolkit/cli/sandbox/cli_run.py
+++ b/agentkit/toolkit/cli/sandbox/cli_run.py
@@ -54,6 +54,7 @@ _OPTION_FIELDS = {
     "model_name": "--model-name",
     "model_api_key": "--model-api-key",
     "model_provider": "--model-provider",
+    "model_base_url": "--model-base-url",
 }
 
 
@@ -158,10 +159,7 @@ def _build_exec_args(entry: dict[str, Any], *, entry_index: int) -> list[str]:
     )
     unknown_keys = sorted(key for key in entry if key not in consumed_keys)
     if unknown_keys:
-        error(
-            f"Unknown key(s) in exec entry #{entry_index}: "
-            f"{', '.join(unknown_keys)}"
-        )
+        error(f"Unknown key(s) in exec entry #{entry_index}: {', '.join(unknown_keys)}")
 
     for field_name, option_name in _OPTION_FIELDS.items():
         if field_name == "command":
@@ -177,9 +175,13 @@ def _build_exec_args(entry: dict[str, Any], *, entry_index: int) -> list[str]:
         args.extend(src_dirs[1:])
 
     for source_key in _SOURCE_KEYS:
-        args.extend(_string_list(entry.get(source_key), f"exec[{entry_index}].{source_key}"))
+        args.extend(
+            _string_list(entry.get(source_key), f"exec[{entry_index}].{source_key}")
+        )
     for extra_key in _EXTRA_ARG_KEYS:
-        args.extend(_string_list(entry.get(extra_key), f"exec[{entry_index}].{extra_key}"))
+        args.extend(
+            _string_list(entry.get(extra_key), f"exec[{entry_index}].{extra_key}")
+        )
 
     _append_option(args, "--command", entry.get("command"))
 
@@ -229,8 +231,7 @@ def _build_tmux_grid_script(
     scripts_dir: Path,
 ) -> str:
     pane_scripts = [
-        scripts_dir / f"pane-{index}.zsh"
-        for index in range(1, len(commands) + 1)
+        scripts_dir / f"pane-{index}.zsh" for index in range(1, len(commands) + 1)
     ]
     for command, pane_script in zip(commands, pane_scripts):
         _write_executable_script(pane_script, _build_pane_script(command))
@@ -253,12 +254,12 @@ def _build_tmux_grid_script(
         "trap pause_on_error EXIT",
         f"TMUX_BIN={quoted_tmux}",
         f"SESSION_NAME={quoted_session}",
-        '"${TMUX_BIN}" new-session -d -s "${SESSION_NAME}" ' f"{first_pane}",
+        f'"${{TMUX_BIN}}" new-session -d -s "${{SESSION_NAME}}" {first_pane}',
     ]
     for pane_script in pane_scripts[1:]:
         pane_command = shlex.quote(shlex.join(["/bin/zsh", str(pane_script)]))
         lines.append(
-            '"${TMUX_BIN}" split-window -t "${SESSION_NAME}" ' f"{pane_command}"
+            f'"${{TMUX_BIN}}" split-window -t "${{SESSION_NAME}}" {pane_command}'
         )
     lines.extend(
         [
@@ -329,6 +330,15 @@ def _open_terminal_tabs(commands: list[str]) -> None:
     _open_macos_terminal_tabs(commands)
 
 
+def _run_single_command_inline(command: str) -> None:
+    try:
+        subprocess.run(["/bin/sh", "-c", command], check=True)
+    except FileNotFoundError:
+        error("/bin/sh is required to run sandbox exec commands inline")
+    except subprocess.CalledProcessError as exc:
+        raise typer.Exit(exc.returncode) from exc
+
+
 def run_command(
     config: Path = typer.Option(
         DEFAULT_RUN_CONFIG,
@@ -360,6 +370,10 @@ def run_command(
     if dry_run:
         for command in commands:
             typer.echo(command)
+        return
+
+    if platform.system() != "Darwin" and len(commands) == 1:
+        _run_single_command_inline(commands[0])
         return
 
     _open_terminal_tabs(commands)

--- a/agentkit/toolkit/cli/sandbox/cli_shell.py
+++ b/agentkit/toolkit/cli/sandbox/cli_shell.py
@@ -31,7 +31,7 @@ from agentkit.toolkit.cli.sandbox.session_create import (
     ensure_sandbox_session,
 )
 from agentkit.toolkit.cli.sandbox.git_config import apply_git_config_to_session
-from agentkit.toolkit.cli.sandbox.tos_config import DEFAULT_TOS_LOCAL_PATH
+from agentkit.toolkit.cli.sandbox.tos_config import DEFAULT_SANDBOX_WORKSPACE
 from agentkit.toolkit.cli.sandbox.tool_resolve import SandboxToolType
 from agentkit.toolkit.cli.sandbox.sandbox_client import (
     SANDBOX_EXEC_TIMEOUT_SECONDS,
@@ -75,7 +75,7 @@ def shell_command(
         help="Execution directory.",
     ),
     workspace: str = typer.Option(
-        DEFAULT_TOS_LOCAL_PATH,
+        DEFAULT_SANDBOX_WORKSPACE,
         "--workspace",
         help=(
             "Sandbox workspace root. Relative --dst-dir values are "
@@ -85,9 +85,7 @@ def shell_command(
     src_dir: Optional[Path] = typer.Option(
         None,
         "--src-dir",
-        help=(
-            "Local file or directory to upload before executing the command."
-        ),
+        help=("Local file or directory to upload before executing the command."),
     ),
     dst_dir: Optional[str] = typer.Option(
         None,

--- a/agentkit/toolkit/cli/sandbox/model_config.py
+++ b/agentkit/toolkit/cli/sandbox/model_config.py
@@ -127,9 +127,7 @@ MODEL_PROVIDER_CONFIGS: dict[str, ModelProviderConfig] = {
     ),
 }
 
-DEFAULT_MODEL_NAME = MODEL_PROVIDER_CONFIGS[
-    DEFAULT_MODEL_PROVIDER
-].default_model_name
+DEFAULT_MODEL_NAME = MODEL_PROVIDER_CONFIGS[DEFAULT_MODEL_PROVIDER].default_model_name
 DEFAULT_MODEL_NAME_LIST = tuple(
     dict.fromkeys(
         (
@@ -138,12 +136,17 @@ DEFAULT_MODEL_NAME_LIST = tuple(
         )
     )
 )
-DEFAULT_MODEL_BASE_URL = MODEL_PROVIDER_CONFIGS[
-    DEFAULT_MODEL_PROVIDER
-].model_base_url
+DEFAULT_MODEL_BASE_URL = MODEL_PROVIDER_CONFIGS[DEFAULT_MODEL_PROVIDER].model_base_url
 DEFAULT_ANTHROPIC_BASE_URL = MODEL_PROVIDER_CONFIGS[
     DEFAULT_MODEL_PROVIDER
 ].anthropic_base_url
+BUILTIN_MODEL_BASE_URL_PROVIDERS = {
+    config.model_base_url: provider
+    for provider, config in MODEL_PROVIDER_CONFIGS.items()
+}
+BUILTIN_MODEL_BASE_URLS = tuple(
+    BUILTIN_MODEL_BASE_URL_PROVIDERS,
+)
 
 
 def _model_provider_value(
@@ -158,16 +161,88 @@ def normalize_model_provider(
     model_provider: str | ModelProviderType | None,
 ) -> str:
     resolved = (_model_provider_value(model_provider) or DEFAULT_MODEL_PROVIDER).strip()
-    if resolved not in MODEL_PROVIDER_CONFIGS:
-        allowed = ", ".join(MODEL_PROVIDER_CONFIGS)
-        raise ValueError(f"--model-provider must be one of: {allowed}")
     return resolved
+
+
+def normalize_optional_model_provider(
+    model_provider: str | ModelProviderType | None,
+) -> str | None:
+    resolved = (_model_provider_value(model_provider) or "").strip()
+    return resolved or None
+
+
+def normalize_model_base_url(model_base_url: Optional[str]) -> str | None:
+    resolved = (model_base_url or "").strip()
+    return resolved or None
+
+
+def is_builtin_model_base_url(model_base_url: Optional[str]) -> bool:
+    resolved = normalize_model_base_url(model_base_url)
+    return bool(resolved and resolved in BUILTIN_MODEL_BASE_URLS)
+
+
+def infer_model_provider_from_base_url(model_base_url: Optional[str]) -> str | None:
+    resolved = normalize_model_base_url(model_base_url)
+    if not resolved:
+        return None
+    return BUILTIN_MODEL_BASE_URL_PROVIDERS.get(resolved)
+
+
+def validate_model_provider_base_url(
+    *,
+    model_provider: str | ModelProviderType | None,
+    model_base_url: Optional[str],
+    model_provider_was_provided: Optional[bool] = None,
+    model_base_url_was_provided: Optional[bool] = None,
+) -> None:
+    resolved_model_provider = normalize_optional_model_provider(model_provider)
+    resolved_model_base_url = normalize_model_base_url(model_base_url)
+    provider_was_provided = (
+        bool(resolved_model_provider)
+        if model_provider_was_provided is None
+        else model_provider_was_provided
+    )
+    base_url_was_provided = (
+        bool(resolved_model_base_url)
+        if model_base_url_was_provided is None
+        else model_base_url_was_provided
+    )
+
+    if (
+        provider_was_provided
+        and resolved_model_provider
+        and resolved_model_provider not in MODEL_PROVIDER_CONFIGS
+        and not resolved_model_base_url
+    ):
+        raise ValueError("--model-provider requires --model-base-url for custom providers")
+
+    if (
+        base_url_was_provided
+        and resolved_model_base_url
+        and not is_builtin_model_base_url(resolved_model_base_url)
+        and not provider_was_provided
+    ):
+        raise ValueError(
+            "--model-base-url requires --model-provider for non-Ark base URLs"
+        )
+
+
+def get_model_provider_config_if_known(
+    model_provider: str | ModelProviderType | None,
+) -> ModelProviderConfig | None:
+    return MODEL_PROVIDER_CONFIGS.get(normalize_model_provider(model_provider))
 
 
 def get_model_provider_config(
     model_provider: str | ModelProviderType | None,
 ) -> ModelProviderConfig:
-    return MODEL_PROVIDER_CONFIGS[normalize_model_provider(model_provider)]
+    resolved_provider = normalize_model_provider(model_provider)
+    config = MODEL_PROVIDER_CONFIGS.get(resolved_provider)
+    if config is None:
+        raise ValueError(
+            f"--model-provider has no built-in configuration: {resolved_provider}"
+        )
+    return config
 
 
 def model_provider_from_env_value(value: object) -> str | None:
@@ -177,11 +252,7 @@ def model_provider_from_env_value(value: object) -> str | None:
     resolved = value.strip()
     if not resolved:
         return None
-
-    try:
-        return normalize_model_provider(resolved)
-    except ValueError:
-        return None
+    return resolved
 
 
 def resolve_model_name(
@@ -189,9 +260,65 @@ def resolve_model_name(
     model_provider: str | ModelProviderType | None,
 ) -> str:
     resolved_provider = normalize_model_provider(model_provider)
-    config = MODEL_PROVIDER_CONFIGS[resolved_provider]
-    resolved_model_name = (model_name or "").strip() or config.default_model_name
-    return resolved_model_name
+    config = MODEL_PROVIDER_CONFIGS.get(resolved_provider)
+    resolved_model_name = (model_name or "").strip()
+    if resolved_model_name:
+        return resolved_model_name
+    if config:
+        return config.default_model_name
+    return ""
+
+
+def resolve_model_base_urls(
+    *,
+    model_provider: str | ModelProviderType | None,
+    model_base_url: Optional[str] = None,
+) -> tuple[str | None, str | None]:
+    resolved_model_base_url = normalize_model_base_url(model_base_url)
+    if resolved_model_base_url:
+        return resolved_model_base_url, resolved_model_base_url
+
+    config = get_model_provider_config_if_known(model_provider)
+    if not config:
+        return None, None
+    return config.model_base_url, config.anthropic_base_url
+
+
+def should_emit_codex_model_config(
+    *,
+    model_provider: str | ModelProviderType | None,
+    model_base_url: Optional[str] = None,
+) -> bool:
+    if normalize_model_base_url(model_base_url):
+        return False
+
+    resolved_provider = normalize_optional_model_provider(model_provider)
+    return resolved_provider is None or resolved_provider in MODEL_PROVIDER_CONFIGS
+
+
+def is_custom_model_base_url(
+    *,
+    model_provider: str | ModelProviderType | None,
+    model_base_url: Optional[str],
+    anthropic_base_url: Optional[str] = None,
+) -> bool:
+    resolved_model_base_url = normalize_model_base_url(model_base_url)
+    if not resolved_model_base_url:
+        return False
+
+    config = get_model_provider_config_if_known(model_provider)
+    if not config:
+        return True
+
+    resolved_anthropic_base_url = normalize_model_base_url(anthropic_base_url)
+    if resolved_model_base_url != config.model_base_url:
+        return True
+    if (
+        resolved_anthropic_base_url
+        and resolved_anthropic_base_url != config.anthropic_base_url
+    ):
+        return True
+    return False
 
 
 def _toml_quote(value: str) -> str:
@@ -203,7 +330,7 @@ def build_codex_config_toml(
     model_provider: str | ModelProviderType | None = None,
 ) -> str:
     resolved_provider = normalize_model_provider(model_provider)
-    config = MODEL_PROVIDER_CONFIGS[resolved_provider]
+    config = get_model_provider_config(resolved_provider)
     resolved_model_name = resolve_model_name(model_name, resolved_provider)
     quoted_model = _toml_quote(resolved_model_name)
     return "\n".join(
@@ -282,9 +409,8 @@ def _build_model_catalog_item(model_name: str, spec: ModelSpec) -> dict:
 
 def infer_model_spec(model_name: str) -> ModelSpec:
     normalized_model_name = model_name.strip().lower()
-    if (
-        normalized_model_name == "glm-5.2"
-        or normalized_model_name.startswith("deepseek-v4")
+    if normalized_model_name == "glm-5.2" or normalized_model_name.startswith(
+        "deepseek-v4"
     ):
         context_window = DEFAULT_MODEL_CONTEXT_WINDOW
     else:
@@ -300,8 +426,8 @@ def model_catalog_context_window(
     model_name: str,
     model_provider: str | ModelProviderType | None = None,
 ) -> int:
-    config = get_model_provider_config(model_provider)
-    spec = config.models.get(model_name)
+    config = get_model_provider_config_if_known(model_provider)
+    spec = config.models.get(model_name) if config else None
     if spec:
         return spec.context_window
     return infer_model_spec(model_name).context_window
@@ -312,7 +438,7 @@ def build_codex_model_catalog_json(
     model_provider: str | ModelProviderType | None = None,
 ) -> str:
     resolved_provider = normalize_model_provider(model_provider)
-    config = MODEL_PROVIDER_CONFIGS[resolved_provider]
+    config = get_model_provider_config(resolved_provider)
     resolved_model_name = resolve_model_name(model_name, resolved_provider)
     deduped_model_names = list(dict.fromkeys((resolved_model_name, *config.models)))
     payload = {

--- a/agentkit/toolkit/cli/sandbox/session_create.py
+++ b/agentkit/toolkit/cli/sandbox/session_create.py
@@ -57,6 +57,7 @@ from agentkit.toolkit.cli.sandbox.sandbox_client import (
 DEFAULT_SANDBOX_TTL = 28800
 SANDBOX_TOOL_ID_ENV = "AGENTKIT_SANDBOX_TOOL_ID"
 SANDBOX_TTL_ENV = "AGENTKIT_SANDBOX_TTL"
+WEB_SEARCH_API_KEY_ENV = "WEB_SEARCH_API_KEY"
 CREATE_SESSION_START_FAIL_CODE = "ErrCreateSessionFail"
 CREATE_SESSION_CONFIRM_ATTEMPTS = 6
 CREATE_SESSION_CONFIRM_INTERVAL_SECONDS = 5
@@ -113,6 +114,7 @@ def build_model_envs(
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = None,
     include_codex_config: bool = False,
+    disable_websearch_apikey: bool = False,
 ) -> list[tools_types.EnvsItemForCreateSession] | None:
     envs: list[tools_types.EnvsItemForCreateSession] = []
     has_model_provider = bool(
@@ -149,6 +151,12 @@ def build_model_envs(
             resolved_model_provider,
         )
     _append_envs(envs, MODEL_API_KEY_ENV_KEYS, resolved_model_api_key)
+    if disable_websearch_apikey:
+        envs.append(
+            tools_types.EnvsItemForCreateSession(
+                key=WEB_SEARCH_API_KEY_ENV, value=""
+            )
+        )
     return envs or None
 
 
@@ -397,12 +405,13 @@ def ensure_sandbox_session_with_status(
                 save_session_result(result)
                 return result, False
 
+    session_envs = envs
     result = _create_session(
         client,
         resolved_session_id,
         resolved_tool_id,
         _resolve_ttl(ttl),
-        envs=envs,
+        envs=session_envs,
     )
     save_session_result(result)
     return result, True

--- a/agentkit/toolkit/cli/sandbox/session_create.py
+++ b/agentkit/toolkit/cli/sandbox/session_create.py
@@ -35,9 +35,13 @@ from agentkit.toolkit.cli.sandbox.model_config import (
     ModelProviderType,
     build_codex_config_toml,
     build_codex_model_catalog_json,
-    get_model_provider_config,
-    normalize_model_provider,
+    infer_model_provider_from_base_url,
+    normalize_model_base_url,
+    normalize_optional_model_provider,
+    resolve_model_base_urls,
     resolve_model_name,
+    should_emit_codex_model_config,
+    validate_model_provider_base_url,
 )
 from agentkit.toolkit.cli.sandbox.session_sync import (
     session_info_to_result,
@@ -73,8 +77,7 @@ def _append_envs(
         return
 
     envs.extend(
-        tools_types.EnvsItemForCreateSession(key=key, value=resolved)
-        for key in keys
+        tools_types.EnvsItemForCreateSession(key=key, value=resolved) for key in keys
     )
 
 
@@ -112,37 +115,55 @@ def build_model_envs(
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
     model_provider: str | ModelProviderType | None = None,
+    model_base_url: Optional[str] = None,
+    model_provider_was_provided: Optional[bool] = None,
+    model_base_url_was_provided: Optional[bool] = None,
     include_codex_config: bool = False,
 ) -> list[tools_types.EnvsItemForCreateSession] | None:
     envs: list[tools_types.EnvsItemForCreateSession] = []
-    has_model_provider = bool(
-        model_provider.value if isinstance(model_provider, ModelProviderType)
-        else (model_provider or "").strip()
+    validate_model_provider_base_url(
+        model_provider=model_provider,
+        model_base_url=model_base_url,
+        model_provider_was_provided=model_provider_was_provided,
+        model_base_url_was_provided=model_base_url_was_provided,
     )
-    resolved_model_provider = (
-        normalize_model_provider(model_provider) if has_model_provider else None
+    resolved_model_base_url = normalize_model_base_url(model_base_url)
+    effective_model_provider = model_provider or infer_model_provider_from_base_url(
+        resolved_model_base_url
     )
+    resolved_model_provider = normalize_optional_model_provider(effective_model_provider)
     resolved_model_name = (
         resolve_model_name(model_name, resolved_model_provider)
         if resolved_model_provider
         else (model_name or "").strip()
     )
-    provider_config = (
-        get_model_provider_config(resolved_model_provider)
-        if resolved_model_provider
-        else None
+    resolved_base_url, resolved_anthropic_base_url = (
+        resolve_model_base_urls(
+            model_provider=resolved_model_provider,
+            model_base_url=resolved_model_base_url,
+        )
+        if resolved_model_provider or resolved_model_base_url
+        else (None, None)
     )
     resolved_model_api_key = model_api_key or os.getenv(MODEL_API_KEY_ENV)
     _append_envs(envs, (MODEL_PROVIDER_ENV,), resolved_model_provider)
     _append_envs(envs, MODEL_NAME_ENV_KEYS, resolved_model_name)
-    if provider_config:
-        _append_envs(envs, MODEL_BASE_URL_ENV_KEYS, provider_config.model_base_url)
+    if resolved_base_url:
+        _append_envs(envs, MODEL_BASE_URL_ENV_KEYS, resolved_base_url)
+    if resolved_anthropic_base_url:
         _append_envs(
             envs,
             ANTHROPIC_BASE_URL_ENV_KEYS,
-            provider_config.anthropic_base_url,
+            resolved_anthropic_base_url,
         )
-    if include_codex_config and resolved_model_name:
+    if (
+        include_codex_config
+        and resolved_model_name
+        and should_emit_codex_model_config(
+            model_provider=resolved_model_provider,
+            model_base_url=resolved_model_base_url,
+        )
+    ):
         _append_codex_config_envs(
             envs,
             resolved_model_name,

--- a/agentkit/toolkit/cli/sandbox/tool_resolve.py
+++ b/agentkit/toolkit/cli/sandbox/tool_resolve.py
@@ -256,9 +256,6 @@ def _normalize_tool_record(
     role_name = _get_string_value(result, "RoleName", "role_name")
     if role_name:
         stored["RoleName"] = role_name
-    skill_role_type = _get_string_value(result, "SkillRoleType", "skill_role_type")
-    if skill_role_type:
-        stored["SkillRoleType"] = skill_role_type
     websearch_set = result.get("WebSearchApiKeySet") or result.get(
         "websearch_apikey_set"
     )

--- a/agentkit/toolkit/cli/sandbox/tool_resolve.py
+++ b/agentkit/toolkit/cli/sandbox/tool_resolve.py
@@ -119,7 +119,7 @@ def _build_tool_record(tool: object, tool_type: str) -> dict[str, object] | None
     tool_id = _get_string_field(payload, "ToolId", "tool_id")
     if not isinstance(tool_id, str) or not tool_id.strip():
         return None
-    record = {
+    record: dict[str, object] = {
         "ToolId": tool_id.strip(),
         "ToolType": _get_field_value(payload, "ToolType", "tool_type") or tool_type,
         "Name": _get_field_value(payload, "Name", "name"),
@@ -128,6 +128,18 @@ def _build_tool_record(tool: object, tool_type: str) -> dict[str, object] | None
     model_provider = _get_tool_model_provider(payload)
     if model_provider:
         record["ModelProvider"] = model_provider
+    role_name = _get_string_field(payload, "RoleName", "role_name")
+    if isinstance(role_name, str) and role_name.strip():
+        record["RoleName"] = role_name.strip()
+    envs = _get_field_value(payload, "Envs", "envs")
+    if isinstance(envs, list):
+        for env_item in envs:
+            key = _get_field_value(env_item, "Key", "key") or ""
+            if key == "WEB_SEARCH_API_KEY":
+                val = _get_field_value(env_item, "Value", "value") or ""
+                if isinstance(val, str) and val.strip():
+                    record["WebSearchApiKeySet"] = True
+                break
     return record
 
 
@@ -230,7 +242,7 @@ def _normalize_tool_record(
     if not tool_id:
         error("Tool result missing ToolId")
 
-    stored = {
+    stored: dict[str, object] = {
         "ToolId": tool_id,
         "Name": _get_string_value(result, "Name", "name") or "",
         "Status": _get_string_value(result, "Status", "status") or "",
@@ -241,6 +253,17 @@ def _normalize_tool_record(
     )
     if model_provider:
         stored["ModelProvider"] = model_provider
+    role_name = _get_string_value(result, "RoleName", "role_name")
+    if role_name:
+        stored["RoleName"] = role_name
+    skill_role_type = _get_string_value(result, "SkillRoleType", "skill_role_type")
+    if skill_role_type:
+        stored["SkillRoleType"] = skill_role_type
+    websearch_set = result.get("WebSearchApiKeySet") or result.get(
+        "websearch_apikey_set"
+    )
+    if websearch_set:
+        stored["WebSearchApiKeySet"] = True
     return stored
 
 
@@ -286,6 +309,43 @@ def find_tool_model_provider(
     return model_provider_from_env_value(
         _get_string_value(result, "ModelProvider", "model_provider")
     )
+
+
+def get_tool_websearch_config(
+    *,
+    tool_id: Optional[str],
+    tool_type: str | SandboxToolType | None,
+) -> dict[str, object] | None:
+    resolved_tool_type = normalize_tool_type(tool_type)
+    result = find_tool_result(resolved_tool_type)
+
+    if result:
+        cached_tool_id = _get_string_value(result, "ToolId", "tool_id")
+        if not tool_id or cached_tool_id == tool_id:
+            return {
+                "has_role": bool(_get_string_value(result, "RoleName", "role_name")),
+                "websearch_apikey_set": bool(result.get("WebSearchApiKeySet")),
+                "role_name": _get_string_value(result, "RoleName", "role_name"),
+            }
+
+    if not tool_id:
+        return None
+
+    try:
+        client = AgentkitToolsClient()
+        response = client.get_tool(tools_types.GetToolRequest(tool_id=tool_id))
+    except Exception:
+        return None
+
+    record = _build_tool_record(response, resolved_tool_type)
+    if not record:
+        return None
+    save_tool_result(resolved_tool_type, record)
+    return {
+        "has_role": bool(_get_string_value(record, "RoleName", "role_name")),
+        "websearch_apikey_set": bool(record.get("WebSearchApiKeySet")),
+        "role_name": _get_string_value(record, "RoleName", "role_name"),
+    }
 
 
 def get_remote_tool_model_provider(

--- a/agentkit/toolkit/cli/sandbox/tool_resolve.py
+++ b/agentkit/toolkit/cli/sandbox/tool_resolve.py
@@ -25,6 +25,8 @@ from typing import Optional
 from agentkit.sdk.tools.client import AgentkitToolsClient
 from agentkit.sdk.tools import types as tools_types
 from agentkit.toolkit.cli.sandbox.model_config import (
+    ANTHROPIC_BASE_URL_ENV_KEYS,
+    MODEL_BASE_URL_ENV_KEYS,
     MODEL_PROVIDER_ENV,
     model_provider_from_env_value,
 )
@@ -46,10 +48,7 @@ def normalize_tool_type(tool_type: str | SandboxToolType | None) -> str:
     value = tool_type.value if isinstance(tool_type, SandboxToolType) else tool_type
     resolved = (value or DEFAULT_SANDBOX_TOOL_TYPE).strip()
     if resolved not in VALID_SANDBOX_TOOL_TYPES:
-        error(
-            "--tool-type must be one of: "
-            + ", ".join(VALID_SANDBOX_TOOL_TYPES)
-        )
+        error("--tool-type must be one of: " + ", ".join(VALID_SANDBOX_TOOL_TYPES))
     return resolved
 
 
@@ -114,6 +113,22 @@ def _get_tool_model_provider(payload: object) -> str | None:
     )
 
 
+def _get_first_tool_env_value(payload: object, keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = _get_tool_env_value(payload, key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _get_tool_model_base_url(payload: object) -> str | None:
+    return _get_first_tool_env_value(payload, MODEL_BASE_URL_ENV_KEYS)
+
+
+def _get_tool_anthropic_base_url(payload: object) -> str | None:
+    return _get_first_tool_env_value(payload, ANTHROPIC_BASE_URL_ENV_KEYS)
+
+
 def _build_tool_record(tool: object, tool_type: str) -> dict[str, object] | None:
     payload = _get_tool_payload(tool)
     tool_id = _get_string_field(payload, "ToolId", "tool_id")
@@ -128,6 +143,12 @@ def _build_tool_record(tool: object, tool_type: str) -> dict[str, object] | None
     model_provider = _get_tool_model_provider(payload)
     if model_provider:
         record["ModelProvider"] = model_provider
+    model_base_url = _get_tool_model_base_url(payload)
+    if model_base_url:
+        record["ModelBaseUrl"] = model_base_url
+    anthropic_base_url = _get_tool_anthropic_base_url(payload)
+    if anthropic_base_url:
+        record["AnthropicBaseUrl"] = anthropic_base_url
     return record
 
 
@@ -241,6 +262,16 @@ def _normalize_tool_record(
     )
     if model_provider:
         stored["ModelProvider"] = model_provider
+    model_base_url = _get_string_value(result, "ModelBaseUrl", "model_base_url")
+    if model_base_url:
+        stored["ModelBaseUrl"] = model_base_url
+    anthropic_base_url = _get_string_value(
+        result,
+        "AnthropicBaseUrl",
+        "anthropic_base_url",
+    )
+    if anthropic_base_url:
+        stored["AnthropicBaseUrl"] = anthropic_base_url
     return stored
 
 
@@ -288,6 +319,24 @@ def find_tool_model_provider(
     )
 
 
+def find_tool_model_base_urls(
+    *,
+    tool_id: Optional[str],
+    tool_type: str | SandboxToolType | None,
+) -> tuple[str | None, str | None]:
+    result = find_tool_result(normalize_tool_type(tool_type))
+    if not result:
+        return None, None
+
+    cached_tool_id = _get_string_value(result, "ToolId", "tool_id")
+    if tool_id and cached_tool_id != tool_id:
+        return None, None
+    return (
+        _get_string_value(result, "ModelBaseUrl", "model_base_url"),
+        _get_string_value(result, "AnthropicBaseUrl", "anthropic_base_url"),
+    )
+
+
 def get_remote_tool_model_provider(
     client: AgentkitToolsClient,
     tool_id: str,
@@ -302,6 +351,23 @@ def get_remote_tool_model_provider(
             _get_string_value(record, "ModelProvider", "model_provider")
         )
     return None
+
+
+def get_remote_tool_model_base_urls(
+    client: AgentkitToolsClient,
+    tool_id: str,
+    *,
+    tool_type: str | SandboxToolType | None,
+) -> tuple[str | None, str | None]:
+    response = client.get_tool(tools_types.GetToolRequest(tool_id=tool_id))
+    record = _build_tool_record(response, normalize_tool_type(tool_type))
+    if record:
+        save_tool_result(normalize_tool_type(tool_type), record)
+        return (
+            _get_string_value(record, "ModelBaseUrl", "model_base_url"),
+            _get_string_value(record, "AnthropicBaseUrl", "anthropic_base_url"),
+        )
+    return None, None
 
 
 def _get_cached_tool_id(tool_type: str) -> str | None:

--- a/agentkit/toolkit/cli/sandbox/tos_config.py
+++ b/agentkit/toolkit/cli/sandbox/tos_config.py
@@ -27,7 +27,8 @@ from agentkit.toolkit.volcengine.services.tos_service import (
 )
 
 DEFAULT_TOS_BUCKET_PATH = "/sandbox-session/default/default"
-DEFAULT_TOS_LOCAL_PATH = "/home/gem"
+DEFAULT_TOS_LOCAL_PATH = "/home/gem/workspace"
+DEFAULT_SANDBOX_WORKSPACE = "/home/gem"
 
 
 def resolve_tos_bucket(tos_bucket: Optional[str]) -> str:

--- a/tests/toolkit/cli/test_cli_create_tool.py
+++ b/tests/toolkit/cli/test_cli_create_tool.py
@@ -308,13 +308,11 @@ def test_create_command_uses_tos_service_when_bucket_is_set(monkeypatch):
     assert len(_FakeTOSService.instances) == 1
     assert _FakeTOSService.instances[0].config.bucket == "my-bucket"
     assert _FakeTOSService.instances[0].config.region == "cn-beijing"
+    assert _FakeTOSService.instances[0].local_mount_path == "/home/gem/workspace"
     tos_config = _FakeToolsClient.last_request.tos_mount_config
     assert tos_config is not None
     assert tos_config.mount_points[0].bucket_name == "my-bucket"
-    assert (
-        tos_config.mount_points[0].bucket_path
-        == "/sandbox-session/default/default"
-    )
+    assert tos_config.mount_points[0].bucket_path == "/sandbox-session/default/default"
 
 
 def test_create_command_uses_tos_mount_option(monkeypatch):
@@ -450,6 +448,7 @@ def test_create_command_help_omits_model_base_url_option():
 
     assert result.exit_code == 0
     assert "--tos-mount" in result.output
+    assert "/home/gem/workspace" in result.output
     assert "--model-provider" in result.output
     assert "--model-base-url" not in result.output
 
@@ -518,7 +517,7 @@ def test_build_create_tool_request_adds_tos_mount(monkeypatch):
     assert mount_point.bucket_name == "my-bucket"
     assert mount_point.bucket_path == "/sandbox-session/default/default"
     assert mount_point.endpoint == "http://tos-cn-beijing.ivolces.com"
-    assert mount_point.local_mount_path == "/home/gem"
+    assert mount_point.local_mount_path == "/home/gem/workspace"
     assert mount_point.read_only is False
     assert fake_service.created_directories == [
         "sandbox-session/",
@@ -651,10 +650,7 @@ def test_build_create_tool_request_adds_code_env_config_envs(monkeypatch):
     assert 'model = "deepseek-v4-pro-260425"' in config_toml
     assert 'review_model = "deepseek-v4-pro-260425"' in config_toml
     assert 'model = "deepseek-v4-flash-260425"' not in config_toml
-    assert (
-        'model_catalog_json = "/home/gem/.codex/model-catalog.json"'
-        in config_toml
-    )
+    assert 'model_catalog_json = "/home/gem/.codex/model-catalog.json"' in config_toml
     assert "model_availability_nux" not in config_toml
     assert "gpt-5.5" not in config_toml
     assert 'web_search = "disabled"' in config_toml
@@ -687,10 +683,7 @@ def test_build_create_tool_request_adds_code_env_config_envs(monkeypatch):
     assert "deepseek-v4-flash-260425" in [model["slug"] for model in models]
     models_by_slug = {model["slug"]: model for model in models}
     assert "doubao-seed-2-0-pro-260215" in models_by_slug
-    assert (
-        models_by_slug["doubao-seed-2-0-pro-260215"]["max_context_window"]
-        == 200000
-    )
+    assert models_by_slug["doubao-seed-2-0-pro-260215"]["max_context_window"] == 200000
     assert models[0]["truncation_policy"] == {"mode": "tokens", "limit": 10000}
 
 
@@ -715,12 +708,8 @@ def test_build_create_tool_request_uses_model_provider(monkeypatch):
     assert envs["OPENCODE_BASE_URL"] == (
         "https://ark.cn-beijing.volces.com/api/coding/v3"
     )
-    assert envs["CODEX_BASE_URL"] == (
-        "https://ark.cn-beijing.volces.com/api/coding/v3"
-    )
-    assert envs["MODEL_BASE_URL"] == (
-        "https://ark.cn-beijing.volces.com/api/coding/v3"
-    )
+    assert envs["CODEX_BASE_URL"] == ("https://ark.cn-beijing.volces.com/api/coding/v3")
+    assert envs["MODEL_BASE_URL"] == ("https://ark.cn-beijing.volces.com/api/coding/v3")
     assert envs["ANTHROPIC_BASE_URL"] == (
         "https://ark.cn-beijing.volces.com/api/coding"
     )
@@ -779,14 +768,9 @@ def test_build_codex_model_catalog_infers_custom_model_context_window():
     }
 
     for model_name, expected_context_window in expected_context_windows.items():
-        catalog = json.loads(
-            build_codex_model_catalog_json(model_name, "model_square")
-        )
+        catalog = json.loads(build_codex_model_catalog_json(model_name, "model_square"))
         assert catalog["models"][0]["slug"] == model_name
-        assert (
-            catalog["models"][0]["max_context_window"]
-            == expected_context_window
-        )
+        assert catalog["models"][0]["max_context_window"] == expected_context_window
 
 
 def test_build_create_tool_request_uses_model_api_key_env(monkeypatch):

--- a/tests/toolkit/cli/test_cli_create_tool.py
+++ b/tests/toolkit/cli/test_cli_create_tool.py
@@ -441,7 +441,7 @@ def test_create_command_rejects_region_option(monkeypatch):
     assert _FakeTOSService.instances == []
 
 
-def test_create_command_help_omits_model_base_url_option():
+def test_create_command_help_includes_model_base_url_option():
     from agentkit.toolkit.cli.cli import app
 
     result = runner.invoke(app, ["sandbox", "create", "--help"])
@@ -450,7 +450,7 @@ def test_create_command_help_omits_model_base_url_option():
     assert "--tos-mount" in result.output
     assert "/home/gem/workspace" in result.output
     assert "--model-provider" in result.output
-    assert "--model-base-url" not in result.output
+    assert "--model-base-url" in result.output
 
 
 def test_create_command_waits_until_tool_ready(monkeypatch):
@@ -725,6 +725,87 @@ def test_build_create_tool_request_uses_model_provider(monkeypatch):
     assert "glm-5.2" not in models
 
 
+def test_build_create_tool_request_uses_model_base_url_over_provider(monkeypatch):
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    request = cli_create._build_create_tool_request(
+        tool_type="CodeEnv",
+        name="demo-tool",
+        tos_bucket="my-bucket",
+        tos_region="cn-beijing",
+        model_provider="agent_plan",
+        model_name="custom-model",
+        model_base_url="https://models.example.com/v1",
+    )
+
+    envs = {item.key: item.value for item in request.envs}
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "agent_plan"
+    assert envs["OPENCODE_MODEL"] == "custom-model"
+    assert envs["CODEX_MODEL"] == "custom-model"
+    assert envs["ANTHROPIC_MODEL"] == "custom-model"
+    assert envs["OPENCODE_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["CODEX_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["MODEL_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["ANTHROPIC_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
+    assert envs["HOME"] == "/home/gem"
+    assert envs["CODEX_HOME"] == "/home/gem/.codex"
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
+
+
+def test_build_create_tool_request_allows_arbitrary_model_provider_with_base_url(
+    monkeypatch,
+):
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    request = cli_create._build_create_tool_request(
+        tool_type="CodeEnv",
+        name="demo-tool",
+        tos_bucket="my-bucket",
+        tos_region="cn-beijing",
+        model_provider="model-square-experimental",
+        model_name="custom-model",
+        model_base_url="https://models.example.com/v1",
+    )
+
+    envs = {item.key: item.value for item in request.envs}
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "model-square-experimental"
+    assert envs["CODEX_MODEL"] == "custom-model"
+    assert envs["CODEX_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["ANTHROPIC_BASE_URL"] == "https://models.example.com/v1"
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
+
+
+def test_build_create_tool_request_rejects_arbitrary_model_provider_without_base_url(
+    monkeypatch,
+):
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    with pytest.raises(
+        ValueError,
+        match="--model-provider requires --model-base-url for custom providers",
+    ):
+        cli_create._build_create_tool_request(
+            tool_type="CodeEnv",
+            name="demo-tool",
+            tos_bucket="my-bucket",
+            tos_region="cn-beijing",
+            model_provider="model-square-experimental",
+            model_name="custom-model",
+        )
+
+
 def test_build_create_tool_request_allows_custom_model_name(monkeypatch):
     from agentkit.toolkit.cli.sandbox import cli_create
 
@@ -823,7 +904,7 @@ def test_build_create_tool_request_model_api_key_option_overrides_env(
     ]
 
 
-def test_create_command_rejects_model_base_url_option(monkeypatch):
+def test_create_command_accepts_model_base_url_without_model_name(monkeypatch):
     from agentkit.toolkit.cli.cli import app
     from agentkit.toolkit.cli.sandbox import cli_create
 
@@ -836,15 +917,104 @@ def test_create_command_rejects_model_base_url_option(monkeypatch):
         [
             "sandbox",
             "create",
+            "--model-provider",
+            "custom_provider",
             "--model-base-url",
             "https://models.example.com",
         ],
     )
 
+    assert result.exit_code == 0
+    envs = {item.key: item.value for item in _FakeToolsClient.last_request.envs}
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "custom_provider"
+    assert envs["CODEX_BASE_URL"] == "https://models.example.com"
+    assert "CODEX_MODEL" not in envs
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
+
+
+def test_build_create_tool_request_infers_provider_from_builtin_model_base_url(
+    monkeypatch,
+):
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    request = cli_create._build_create_tool_request(
+        tool_type="CodeEnv",
+        name="demo-tool",
+        tos_bucket="my-bucket",
+        tos_region="cn-beijing",
+        model_base_url="https://ark.cn-beijing.volces.com/api/plan/v3",
+    )
+
+    envs = {item.key: item.value for item in request.envs}
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "agent_plan"
+    assert envs["CODEX_MODEL"] == "deepseek-v4-flash"
+    assert envs["CODEX_BASE_URL"] == "https://ark.cn-beijing.volces.com/api/plan/v3"
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
+
+
+def test_create_command_rejects_non_ark_model_base_url_without_model_provider(
+    monkeypatch,
+):
+    from agentkit.toolkit.cli.cli import app
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "--tool-name",
+            "demo-tool",
+            "--model-name",
+            "custom-model",
+            "--model-base-url",
+            "https://models.example.com/v1",
+        ],
+    )
+
     assert result.exit_code != 0
-    assert "No such option: --model-base-url" in result.output
+    assert "--model-base-url requires --model-provider for non-Ark base URLs" in result.output
     assert _FakeToolsClient.instances == []
-    assert _FakeTOSService.instances == []
+
+
+def test_create_command_accepts_model_base_url_with_model_name_and_provider(monkeypatch):
+    from agentkit.toolkit.cli.cli import app
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "--tool-name",
+            "demo-tool",
+            "--model-name",
+            "custom-model",
+            "--model-provider",
+            "custom_provider",
+            "--model-base-url",
+            "https://models.example.com/v1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envs = {item.key: item.value for item in _FakeToolsClient.last_request.envs}
+    assert envs["CODEX_BASE_URL"] == "https://models.example.com/v1"
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
 
 
 def test_build_create_tool_request_adds_default_model_base_url(monkeypatch):

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -736,6 +736,101 @@ def test_build_model_envs_option_overrides_model_api_key_env(monkeypatch) -> Non
     ]
 
 
+def test_build_model_envs_uses_model_base_url_and_skips_codex_config() -> None:
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
+
+    envs = session_create.build_model_envs(
+        model_name="custom-model",
+        model_provider="agent_plan",
+        model_base_url="https://models.example.com/v1",
+        include_codex_config=True,
+    )
+
+    assert [(item.key, item.value) for item in envs] == [
+        ("AGENTKIT_SANDBOX_MODEL_PROVIDER", "agent_plan"),
+        ("OPENCODE_MODEL", "custom-model"),
+        ("CODEX_MODEL", "custom-model"),
+        ("ANTHROPIC_MODEL", "custom-model"),
+        ("OPENCODE_BASE_URL", "https://models.example.com/v1"),
+        ("CODEX_BASE_URL", "https://models.example.com/v1"),
+        ("MODEL_BASE_URL", "https://models.example.com/v1"),
+        ("ANTHROPIC_BASE_URL", "https://models.example.com/v1"),
+    ]
+
+
+def test_build_model_envs_allows_arbitrary_model_provider_with_base_url() -> None:
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
+
+    envs = session_create.build_model_envs(
+        model_name="custom-model",
+        model_provider="agent_plan_experimental",
+        model_base_url="https://models.example.com/v1",
+        include_codex_config=True,
+    )
+
+    assert [(item.key, item.value) for item in envs] == [
+        ("AGENTKIT_SANDBOX_MODEL_PROVIDER", "agent_plan_experimental"),
+        ("OPENCODE_MODEL", "custom-model"),
+        ("CODEX_MODEL", "custom-model"),
+        ("ANTHROPIC_MODEL", "custom-model"),
+        ("OPENCODE_BASE_URL", "https://models.example.com/v1"),
+        ("CODEX_BASE_URL", "https://models.example.com/v1"),
+        ("MODEL_BASE_URL", "https://models.example.com/v1"),
+        ("ANTHROPIC_BASE_URL", "https://models.example.com/v1"),
+    ]
+
+
+def test_build_model_envs_requires_base_url_with_arbitrary_model_provider() -> None:
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
+
+    with pytest.raises(
+        ValueError,
+        match="--model-provider requires --model-base-url for custom providers",
+    ):
+        session_create.build_model_envs(
+            model_name="custom-model",
+            model_provider="agent_plan_experimental",
+        )
+
+
+def test_build_model_envs_allows_model_base_url_without_model_name() -> None:
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
+
+    envs = session_create.build_model_envs(
+        model_provider="custom_provider",
+        model_base_url="https://models.example.com/v1",
+        include_codex_config=True,
+    )
+
+    assert [(item.key, item.value) for item in envs] == [
+        ("AGENTKIT_SANDBOX_MODEL_PROVIDER", "custom_provider"),
+        ("OPENCODE_BASE_URL", "https://models.example.com/v1"),
+        ("CODEX_BASE_URL", "https://models.example.com/v1"),
+        ("MODEL_BASE_URL", "https://models.example.com/v1"),
+        ("ANTHROPIC_BASE_URL", "https://models.example.com/v1"),
+    ]
+
+
+def test_build_model_envs_infers_provider_from_builtin_model_base_url() -> None:
+    import agentkit.toolkit.cli.sandbox.session_create as session_create
+
+    envs = session_create.build_model_envs(
+        model_base_url="https://ark.cn-beijing.volces.com/api/coding/v3",
+        include_codex_config=True,
+    )
+
+    assert [(item.key, item.value) for item in envs] == [
+        ("AGENTKIT_SANDBOX_MODEL_PROVIDER", "coding_plan"),
+        ("OPENCODE_MODEL", "deepseek-v4-flash"),
+        ("CODEX_MODEL", "deepseek-v4-flash"),
+        ("ANTHROPIC_MODEL", "deepseek-v4-flash"),
+        ("OPENCODE_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+        ("CODEX_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+        ("MODEL_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+        ("ANTHROPIC_BASE_URL", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+    ]
+
+
 def test_ensure_sandbox_session_skips_tos_mount_when_tool_has_none(
     monkeypatch,
     tmp_path,
@@ -3562,6 +3657,55 @@ exec:
     assert "agentkit sandbox exec --session-id user-right" in pane_2
 
 
+def test_cli_sandbox_run_executes_single_entry_inline_on_non_macos(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_run as cli_run
+
+    config_path = tmp_path / "sandbox-run.yaml"
+    config_path.write_text(
+        """
+exec:
+  - session_id: run-model-base-url
+    model_name: run-model
+    model_base_url: https://run.example.com/v1
+    command: "printenv CODEX_MODEL; exit"
+""",
+        encoding="utf-8",
+    )
+    captured = {}
+
+    def fake_run(args, check):
+        captured["args"] = args
+        captured["check"] = check
+
+    monkeypatch.setattr(cli_run.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(cli_run.subprocess, "run", fake_run)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "run",
+            "--config",
+            str(config_path),
+            "--terminal",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["check"] is True
+    assert captured["args"][:2] == ["/bin/sh", "-c"]
+    command = captured["args"][2]
+    assert "agentkit sandbox exec" in command
+    assert "--session-id run-model-base-url" in command
+    assert "--model-name run-model" in command
+    assert "--model-base-url https://run.example.com/v1" in command
+
+
 def test_cli_exec_git_config_file_does_not_reuse_shell_exec_id_for_ws(
     monkeypatch,
     tmp_path,
@@ -4168,6 +4312,146 @@ def test_cli_exec_model_name_uses_cached_tool_model_provider(
     )
 
 
+def test_cli_exec_model_name_inherits_cached_custom_model_base_url(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
+
+    monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    store_path = _patch_store_path(monkeypatch, tmp_path)
+    tool_store_path = _patch_tool_store_path(monkeypatch, tmp_path)
+    tool_store_path.parent.mkdir(parents=True, exist_ok=True)
+    tool_store_path.write_text(
+        json.dumps(
+            {
+                "CodeEnv": {
+                    "ToolId": "tool-1",
+                    "ToolType": "CodeEnv",
+                    "Name": "custom-url-tool",
+                    "Status": "Ready",
+                    "ModelProvider": "model_square",
+                    "ModelBaseUrl": "https://models.example.com/v1",
+                    "AnthropicBaseUrl": "https://models.example.com/v1",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com/?token=abc",
+    }
+    store_path.write_text(
+        json.dumps({"user-1": stored_session}),
+        encoding="utf-8",
+    )
+    captured_session = {}
+    _patch_exec_session(
+        monkeypatch,
+        cli_exec,
+        stored_session,
+        capture=captured_session,
+    )
+    monkeypatch.setattr(
+        cli_exec,
+        "_connect_terminal",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--tool-id",
+            "tool-1",
+            "--session-id",
+            "user-1",
+            "--model-name",
+            "custom-model",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envs = {item.key: item.value for item in captured_session["envs"]}
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "model_square"
+    assert envs["CODEX_MODEL"] == "custom-model"
+    assert envs["CODEX_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["ANTHROPIC_BASE_URL"] == "https://models.example.com/v1"
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
+
+
+def test_cli_exec_model_name_inherits_default_cached_custom_model_base_url(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
+
+    monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    _patch_store_path(monkeypatch, tmp_path)
+    tool_store_path = _patch_tool_store_path(monkeypatch, tmp_path)
+    tool_store_path.parent.mkdir(parents=True, exist_ok=True)
+    tool_store_path.write_text(
+        json.dumps(
+            {
+                "CodeEnv": {
+                    "ToolId": "tool-1",
+                    "ToolType": "CodeEnv",
+                    "Name": "custom-url-tool",
+                    "Status": "Ready",
+                    "ModelProvider": "model_square",
+                    "ModelBaseUrl": "https://models.example.com/v1",
+                    "AnthropicBaseUrl": "https://models.example.com/v1",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured_session = {}
+    _patch_exec_session(
+        monkeypatch,
+        cli_exec,
+        {
+            "session_id": "generated-1",
+            "tool_id": "tool-1",
+            "instance_id": "session-1",
+            "endpoint": "https://sandbox.example.com/?token=abc",
+        },
+        capture=captured_session,
+    )
+    monkeypatch.setattr(
+        cli_exec,
+        "_connect_terminal",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--model-name",
+            "custom-model",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envs = {item.key: item.value for item in captured_session["envs"]}
+    assert captured_session["tool_id"] is None
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "model_square"
+    assert envs["CODEX_MODEL"] == "custom-model"
+    assert envs["CODEX_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["ANTHROPIC_BASE_URL"] == "https://models.example.com/v1"
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
+
+
 def test_cli_exec_model_provider_sets_default_model_and_codex_config(
     monkeypatch,
     tmp_path,
@@ -4232,7 +4516,7 @@ def test_cli_exec_model_provider_sets_default_model_and_codex_config(
     assert "glm-5.2" not in models
 
 
-def test_cli_exec_rejects_model_base_url_option() -> None:
+def test_cli_exec_rejects_model_base_url_without_model_provider() -> None:
     from agentkit.toolkit.cli.cli import app
 
     result = runner.invoke(
@@ -4246,7 +4530,109 @@ def test_cli_exec_rejects_model_base_url_option() -> None:
     )
 
     assert result.exit_code != 0
-    assert "No such option" in result.output
+    assert "--model-base-url requires --model-provider for non-Ark base URLs" in result.output
+
+
+def test_cli_exec_rejects_non_ark_model_base_url_without_model_provider() -> None:
+    from agentkit.toolkit.cli.cli import app
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--model-name",
+            "custom-model",
+            "--model-base-url",
+            "https://models.example.com/v1",
+            "--command",
+            "echo should-not-run; exit",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--model-base-url requires --model-provider for non-Ark base URLs" in result.output
+
+
+def test_cli_exec_rejects_arbitrary_model_provider_without_base_url() -> None:
+    from agentkit.toolkit.cli.cli import app
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--model-provider",
+            "custom_provider",
+            "--model-name",
+            "custom-model",
+            "--command",
+            "echo should-not-run; exit",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--model-provider requires --model-base-url for custom providers" in result.output
+
+
+def test_cli_exec_model_base_url_overrides_provider_and_skips_codex_config(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
+
+    monkeypatch.delenv("MODEL_API_KEY", raising=False)
+    store_path = _patch_store_path(monkeypatch, tmp_path)
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com/?token=abc",
+    }
+    store_path.write_text(
+        json.dumps({"user-1": stored_session}),
+        encoding="utf-8",
+    )
+    captured_session = {}
+    _patch_exec_session(
+        monkeypatch,
+        cli_exec,
+        stored_session,
+        capture=captured_session,
+    )
+    monkeypatch.setattr(
+        cli_exec,
+        "_connect_terminal",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "exec",
+            "--session-id",
+            "user-1",
+            "--model-provider",
+            "agent_plan",
+            "--model-name",
+            "custom-model",
+            "--model-base-url",
+            "https://models.example.com/v1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envs = {item.key: item.value for item in captured_session["envs"]}
+    assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "agent_plan"
+    assert envs["CODEX_MODEL"] == "custom-model"
+    assert envs["OPENCODE_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["CODEX_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["MODEL_BASE_URL"] == "https://models.example.com/v1"
+    assert envs["ANTHROPIC_BASE_URL"] == "https://models.example.com/v1"
+    assert "CODEX_CONFIG_TOML" not in envs
+    assert "CODEX_MODEL_CATALOG_JSON" not in envs
 
 
 def test_cli_exec_supports_empty_command(

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 import json
 import os
+import tarfile
 
 import pytest
 from typer.testing import CliRunner
@@ -726,9 +727,7 @@ def test_build_model_envs_option_overrides_model_api_key_env(monkeypatch) -> Non
 
     monkeypatch.setenv("MODEL_API_KEY", "env-model-value")
 
-    envs = session_create.build_model_envs(
-        **{"model_" + "api_key": "cli-model-value"}
-    )
+    envs = session_create.build_model_envs(**{"model_" + "api_key": "cli-model-value"})
 
     assert [(item.key, item.value) for item in envs] == [
         ("OPENCODE_API_KEY", "cli-model-value"),
@@ -848,9 +847,7 @@ def test_ensure_sandbox_session_confirms_create_start_fail_by_user_session_id(
         "instance_id": "confirmed-instance",
         "endpoint": "https://confirmed.example.com",
     }
-    assert json.loads(store_path.read_text(encoding="utf-8")) == {
-        "user-cli": result
-    }
+    assert json.loads(store_path.read_text(encoding="utf-8")) == {"user-cli": result}
 
 
 def test_ensure_sandbox_session_waits_for_ready_after_create_start_fail(
@@ -939,7 +936,7 @@ def test_ensure_sandbox_session_requires_endpoint_after_create_start_fail(
                     status="Ready",
                 )
             ]
-        )
+        ),
     ]
 
     with pytest.raises(Exception, match="ErrCreateSessionFail"):
@@ -1168,9 +1165,7 @@ def test_cli_mount_uses_stored_session_tool_and_opens_tosbrowser(
         "&clientId=5cf70436-5191-42d0-8260-b888ee1d0fe3"
     )
     assert result.exit_code == 0
-    assert captured["url"] == (
-        "https://example.com/oauth/.well-known/agentkit-cli"
-    )
+    assert captured["url"] == ("https://example.com/oauth/.well-known/agentkit-cli")
     assert _FakeToolsClient.last_get_tool_request.tool_id == "tool-from-session"
     assert captured["command"] == expected_command
     assert json.loads(discovery_path.read_text(encoding="utf-8")) == discovery
@@ -1298,12 +1293,10 @@ def test_cli_mount_uses_latest_auth_session_when_oauth_url_omitted(
     auth_sessions_dir = tmp_path / "auth" / "sessions"
     auth_sessions_dir.mkdir(parents=True)
     old_session = (
-        auth_sessions_dir
-        / "agentkit-cli-1111111111.tos-cn-beijing.volces.com.json"
+        auth_sessions_dir / "agentkit-cli-1111111111.tos-cn-beijing.volces.com.json"
     )
     latest_session = (
-        auth_sessions_dir
-        / "agentkit-cli-2107625663.tos-cn-beijing.volces.com.json"
+        auth_sessions_dir / "agentkit-cli-2107625663.tos-cn-beijing.volces.com.json"
     )
     old_session.write_text("{}", encoding="utf-8")
     latest_session.write_text("{}", encoding="utf-8")
@@ -1375,8 +1368,7 @@ def test_cli_mount_errors_when_latest_auth_session_name_is_invalid(
     auth_sessions_dir = tmp_path / "auth" / "sessions"
     auth_sessions_dir.mkdir(parents=True)
     valid_session = (
-        auth_sessions_dir
-        / "agentkit-cli-1111111111.tos-cn-beijing.volces.com.json"
+        auth_sessions_dir / "agentkit-cli-1111111111.tos-cn-beijing.volces.com.json"
     )
     invalid_session = auth_sessions_dir / "default.json"
     valid_session.write_text("{}", encoding="utf-8")
@@ -1451,9 +1443,7 @@ def test_cli_mount_errors_when_tool_has_no_tos_mount(
             }
         },
     )
-    _FakeToolsClient.get_tool_response = _FakeGetToolResponse(
-        tos_mount_config=None
-    )
+    _FakeToolsClient.get_tool_response = _FakeGetToolResponse(tos_mount_config=None)
     monkeypatch.setattr(
         cli_mount,
         "AgentkitToolsClient",
@@ -1705,7 +1695,7 @@ def test_open_tosbrowser_detects_missing_tosbrowser_from_open_error(
     original_error = (
         "No application knows how to open URL tosbrowser://open?path=tos://"
         "sandbox-bucket-cn-beijing/sandbox-session/tool-t-example/session-test/"
-        '&type=oAuthLogin (Error Domain=NSOSStatusErrorDomain Code=-10814 '
+        "&type=oAuthLogin (Error Domain=NSOSStatusErrorDomain Code=-10814 "
         '"kLSApplicationNotFoundErr")'
     )
 
@@ -1870,9 +1860,7 @@ def test_ensure_sandbox_session_syncs_missing_local_session_before_create(
         "instance_id": "remote-instance",
         "endpoint": "https://remote.example.com",
     }
-    assert json.loads(store_path.read_text(encoding="utf-8")) == {
-        "remote-user": result
-    }
+    assert json.loads(store_path.read_text(encoding="utf-8")) == {"remote-user": result}
 
 
 def test_ensure_sandbox_session_recreates_when_remote_session_missing(
@@ -2851,6 +2839,96 @@ def test_cli_shell_uploads_sources_before_command(monkeypatch, tmp_path) -> None
     assert payload["data"]["shell_id"] == "shell-1"
 
 
+def test_cli_shell_uploads_directory_as_directory_before_command(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from agentkit.toolkit.cli.cli import app
+    import agentkit.toolkit.cli.sandbox.cli_exec as cli_exec
+    import agentkit.toolkit.cli.sandbox.cli_shell as cli_shell
+
+    source_dir = tmp_path / "shell_dir"
+    source_dir.mkdir()
+    (source_dir / "hello.txt").write_text("hello", encoding="utf-8")
+    stored_session = {
+        "session_id": "user-1",
+        "tool_id": "tool-1",
+        "instance_id": "session-1",
+        "endpoint": "https://sandbox.example.com",
+    }
+    _patch_shell_session(monkeypatch, cli_shell, stored_session)
+    monkeypatch.setattr(
+        cli_exec,
+        "_new_remote_archive_path",
+        lambda _prefix: "/tmp/agentkit-upload.tar",
+    )
+    captured = {}
+
+    def fake_upload_remote_file(_session, *, local_path, remote_path):
+        assert remote_path == "/tmp/agentkit-upload.tar"
+        with tarfile.open(local_path, mode="r") as tar:
+            captured["archive_names"] = sorted(
+                member.name for member in tar.getmembers()
+            )
+
+    def fake_exec_shell_command(_session, command):
+        captured["extract_command"] = command
+        return {"success": True}
+
+    class FakeResponse:
+        text = '{"success": true}'
+
+        def json(self):
+            return {
+                "success": True,
+                "data": {
+                    "session_id": "shell-1",
+                    "status": "completed",
+                    "output": "done",
+                    "exit_code": 0,
+                },
+            }
+
+    def fake_post(url, json, timeout):
+        captured["post"] = (url, json, timeout)
+        return FakeResponse()
+
+    monkeypatch.setattr(cli_exec, "_upload_remote_file", fake_upload_remote_file)
+    monkeypatch.setattr(cli_exec, "_exec_shell_command", fake_exec_shell_command)
+    monkeypatch.setattr(cli_shell.requests, "post", fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "shell",
+            "--session-id",
+            "user-1",
+            "--command",
+            "echo done",
+            "--src-dir",
+            str(source_dir),
+            "--workspace",
+            "/workspace",
+            "--dst-dir",
+            "tmp",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["archive_names"] == ["shell_dir", "shell_dir/hello.txt"]
+    assert captured["extract_command"] == (
+        "mkdir -p /workspace/tmp && tar -xf /tmp/agentkit-upload.tar "
+        "-C /workspace/tmp; status=$?; rm -f /tmp/agentkit-upload.tar; "
+        "[ $status -eq 0 ]"
+    )
+    assert captured["post"] == (
+        "https://sandbox.example.com/v1/shell/exec",
+        {"id": "", "exec_dir": "", "command": "echo done"},
+        cli_shell.SANDBOX_EXEC_TIMEOUT_SECONDS,
+    )
+
+
 def test_cli_shell_git_config_file_does_not_reuse_shell_exec_id(
     monkeypatch,
     tmp_path,
@@ -3472,7 +3550,7 @@ exec:
     assert f"/bin/zsh {scripts_dir / 'run.zsh'}" in script
 
     launcher = (scripts_dir / "run.zsh").read_text(encoding="utf-8")
-    assert 'TMUX_BIN=/opt/homebrew/bin/tmux' in launcher
+    assert "TMUX_BIN=/opt/homebrew/bin/tmux" in launcher
     assert "new-session -d -s" in launcher
     assert launcher.count("split-window") == 1
     assert "select-layout" in launcher
@@ -3581,6 +3659,10 @@ def test_cli_exec_uploads_directory_before_connecting(
         assert local_path.exists()
         assert remote_path == "/tmp/agentkit-upload.tar"
         events.append(("upload", remote_path))
+        with tarfile.open(local_path, mode="r") as tar:
+            events.append(
+                ("archive", sorted(member.name for member in tar.getmembers()))
+            )
 
     def fake_exec_shell_command(session, command):
         assert session == stored_session
@@ -3611,6 +3693,7 @@ def test_cli_exec_uploads_directory_before_connecting(
     assert result.exit_code == 0
     assert events == [
         ("upload", "/tmp/agentkit-upload.tar"),
+        ("archive", ["upload-src", "upload-src/hello.txt"]),
         (
             "extract",
             "mkdir -p /home/gem && tar -xf /tmp/agentkit-upload.tar "
@@ -4006,7 +4089,7 @@ def test_cli_exec_model_name_without_provider_syncs_codex_config(
     assert envs["CODEX_MODEL"] == "glm-5.2"
     assert envs["ANTHROPIC_MODEL"] == "glm-5.2"
     assert 'model_provider = "model_square"' in envs["CODEX_CONFIG_TOML"]
-    assert '[model_providers.model_square]' in envs["CODEX_CONFIG_TOML"]
+    assert "[model_providers.model_square]" in envs["CODEX_CONFIG_TOML"]
     catalog = json.loads(envs["CODEX_MODEL_CATALOG_JSON"])
     assert catalog["models"][0]["slug"] == "glm-5.2"
 
@@ -4077,13 +4160,8 @@ def test_cli_exec_model_name_uses_cached_tool_model_provider(
     envs = {item.key: item.value for item in captured_session["envs"]}
     assert envs["AGENTKIT_SANDBOX_MODEL_PROVIDER"] == "agent_plan"
     assert envs["CODEX_MODEL"] == "glm-5.2"
-    assert envs["CODEX_BASE_URL"] == (
-        "https://ark.cn-beijing.volces.com/api/plan/v3"
-    )
-    assert (
-        'model_provider = "agent_plan"'
-        in envs["CODEX_CONFIG_TOML"]
-    )
+    assert envs["CODEX_BASE_URL"] == ("https://ark.cn-beijing.volces.com/api/plan/v3")
+    assert 'model_provider = "agent_plan"' in envs["CODEX_CONFIG_TOML"]
     assert (
         'base_url = "https://ark.cn-beijing.volces.com/api/plan/v3"'
         in envs["CODEX_CONFIG_TOML"]
@@ -4142,9 +4220,7 @@ def test_cli_exec_model_provider_sets_default_model_and_codex_config(
     assert envs["OPENCODE_BASE_URL"] == (
         "https://ark.cn-beijing.volces.com/api/plan/v3"
     )
-    assert envs["ANTHROPIC_BASE_URL"] == (
-        "https://ark.cn-beijing.volces.com/api/plan"
-    )
+    assert envs["ANTHROPIC_BASE_URL"] == ("https://ark.cn-beijing.volces.com/api/plan")
     assert (
         'base_url = "https://ark.cn-beijing.volces.com/api/plan/v3"'
         in envs["CODEX_CONFIG_TOML"]
@@ -4213,10 +4289,7 @@ def test_cli_exec_supports_empty_command(
     )
 
     assert result.exit_code == 0
-    assert (
-        captured["ws_url"]
-        == "ws://sandbox.example.com/base/v1/shell/ws?token=abc"
-    )
+    assert captured["ws_url"] == "ws://sandbox.example.com/base/v1/shell/ws?token=abc"
     assert captured["initial_command"] == ""
 
 


### PR DESCRIPTION
This MR enhances `agentkit sandbox` model and WebSearch configuration:

  - Adds `--model-base-url` support to `sandbox create/exec` for custom model endpoints and custom `--model-provider`
  values.
  - Injects custom model base URLs into `OPENCODE_BASE_URL`, `CODEX_BASE_URL`, `MODEL_BASE_URL`, and `ANTHROPIC_BASE_URL`,
  while skipping built-in Codex model config/catalog generation.
  - Adds WebSearch setup for `sandbox create`:
    - `--skill-role-name` to create or reuse an IAM Role.
    - `--websearch-apikey` to inject `WEB_SEARCH_API_KEY`.
  - Lets `sandbox exec` inherit custom model base URLs from the tool and disable API-key based WebSearch per session via
  `--disable-websearch-apikey`.
  - Updates the default TOS mount to `/home/gem/workspace` and preserves the top-level source directory during uploads.
  - Updates sandbox docs and CLI test coverage.