### PR TITLE
refactor(agentkit): engineering-standards uplift (logging / exceptions / timeouts)

### DIFF
--- a/agentkit/apps/simple_app/simple_app.py
+++ b/agentkit/apps/simple_app/simple_app.py
@@ -52,9 +52,10 @@ class AgentkitSimpleApp(BaseAgentkitApp, Starlette):
         return func
 
     def ping(self, func: Callable) -> Callable:
-        assert len(list(inspect.signature(func).parameters.keys())) == 0, (
-            f"Health check function `{func.__name__}` should not receive any arguments."
-        )
+        if len(inspect.signature(func).parameters) != 0:
+            raise TypeError(
+                f"Health check function `{func.__name__}` should not receive any arguments."
+            )
 
         self.ping_handler.func = func
         return func

--- a/agentkit/auth/errors.py
+++ b/agentkit/auth/errors.py
@@ -16,8 +16,10 @@
 
 from __future__ import annotations
 
+from agentkit.errors import AgentKitError
 
-class AuthError(Exception):
+
+class AuthError(AgentKitError):
     """Base class for all authentication failures.
 
     Carries an optional ``hint`` with an actionable next step that CLIs can

--- a/agentkit/auth/session.py
+++ b/agentkit/auth/session.py
@@ -207,7 +207,8 @@ class AuthSession:
                             self._refresh_token = sibling._refresh_token or self._refresh_token
                             return self._sts
                 self._renew_locked()
-            assert self._sts is not None
+            if self._sts is None:
+                raise AuthError("internal: STS credentials not populated after renew")
             return self._sts
 
     # -- data-plane JWT (id_token) --------------------------------------------
@@ -238,7 +239,8 @@ class AuthSession:
                         self._access_token = sibling._access_token or self._access_token
                         return self._id_token
                 self._refresh_id_token_locked()
-            assert self._id_token is not None
+            if self._id_token is None:
+                raise AuthError("internal: id_token not populated after renew")
             return self._id_token
 
     def _refresh_id_token_locked(self) -> None:

--- a/agentkit/client/base_agentkit_client.py
+++ b/agentkit/client/base_agentkit_client.py
@@ -70,8 +70,13 @@ class BaseAgentkitClient(BaseServiceClient):
 
     def _get(self, api_action: str, params: Dict[str, Any] = None) -> str:
         """Legacy method for GET requests."""
+        # Imported lazily: ``agentkit.toolkit`` pulls in ``sdk`` which imports
+        # back into ``agentkit.client``, so a module-level import would cycle
+        # (mirrors ``BaseServiceClient._invoke_api``).
+        from agentkit.toolkit.errors import ApiError
+
         try:
             resp = self.get(api_action, params)
             return resp
         except Exception as e:
-            raise Exception(f"Failed to {api_action}: {str(e)}")
+            raise ApiError(f"Failed to {api_action}: {e}") from e

--- a/agentkit/client/base_service_client.py
+++ b/agentkit/client/base_service_client.py
@@ -18,10 +18,10 @@ This is the top-level base class for all service clients.
 """
 
 import json
-import os
 from typing import Any, Dict, Type, TypeVar, Union, Optional
 from dataclasses import dataclass
 
+import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from volcengine.ApiInfo import ApiInfo
@@ -29,6 +29,7 @@ from volcengine.base.Service import Service
 from volcengine.Credentials import Credentials as VolcCredentials
 from volcengine.ServiceInfo import ServiceInfo
 
+from agentkit.auth.errors import NetworkError
 from agentkit.platform import (
     VolcConfiguration,
     resolve_credentials,
@@ -36,7 +37,11 @@ from agentkit.platform import (
 )
 from agentkit.platform.configuration import Credentials as PlatformCredentials
 from agentkit.platform.provider import CloudProvider
+from agentkit.utils.http_defaults import http_retries, http_timeout
+from agentkit.utils.logging_config import get_logger
 from agentkit.utils.ve_sign import ensure_x_custom_source_header
+
+logger = get_logger(__name__)
 
 T = TypeVar("T")
 _CREDENTIAL_ERROR_TOKENS = frozenset(
@@ -161,8 +166,8 @@ class BaseServiceClient(Service):
                 region=self.region,
                 session_token=self.session_token or "",
             ),
-            connection_timeout=30,
-            socket_timeout=30,
+            connection_timeout=int(http_timeout()),
+            socket_timeout=int(http_timeout()),
             scheme=self.scheme,
         )
 
@@ -188,10 +193,7 @@ class BaseServiceClient(Service):
         timeouts are not retried (``read=0``) and only 429/503 are status-
         retried. Honors ``Retry-After``. Disabled with AGENTKIT_HTTP_RETRIES=0.
         """
-        try:
-            retries = max(0, int(os.getenv("AGENTKIT_HTTP_RETRIES", "2")))
-        except ValueError:
-            retries = 2
+        retries = http_retries()
         if retries <= 0:
             return
         session = getattr(self, "session", None)
@@ -251,7 +253,14 @@ class BaseServiceClient(Service):
         creds = self._platform_config.get_vefaas_iam_credentials(force=force)
         if not creds:
             return False
-        return self._apply_credentials(creds)
+        applied = self._apply_credentials(creds)
+        if applied:
+            logger.info(
+                "Refreshed vefaas credentials (force=%s) for service %s",
+                force,
+                self.service,
+            )
+        return applied
 
     def _is_probable_credential_error_code(self, code: str) -> bool:
         c = (code or "").lower()
@@ -319,12 +328,18 @@ class BaseServiceClient(Service):
             Typed response object
 
         Raises:
-            Exception: If API call fails or returns an error
+            ApiError: If the API call fails or returns an error response.
+            NetworkError: If a transport-level failure occurs.
         """
+        # Imported lazily: ``agentkit.toolkit`` pulls in ``sdk`` which imports
+        # back into ``agentkit.client``, so a module-level import would cycle.
+        from agentkit.toolkit.errors import ApiError
+
         self._refresh_credentials_if_needed()
         last_error: Optional[BaseException] = None
 
         for attempt in (0, 1):
+            logger.debug("Invoking API %s (attempt %d)", api_action, attempt)
             if attempt == 1:
                 self._refresh_credentials_if_needed(force=True)
 
@@ -336,16 +351,34 @@ class BaseServiceClient(Service):
                         request.model_dump(by_alias=True, exclude_none=True)
                     ),
                 )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                requests.exceptions.HTTPError,
+                requests.exceptions.RequestException,
+            ) as e:
+                # Transport-level failure: not a credential issue, surface as
+                # a typed network error so callers can distinguish it.
+                raise NetworkError(f"Failed to {api_action}: network error") from e
             except Exception as e:
                 last_error = e
                 if attempt == 0 and self._is_probable_credential_error_text(str(e)):
+                    logger.debug(
+                        "Retrying %s after probable credential error", api_action
+                    )
                     continue
-                raise Exception(f"Failed to {api_action}: {str(e)}") from e
+                raise ApiError(f"Failed to {api_action}: {str(e)}") from e
 
             if not res:
-                raise Exception(f"Empty response from {api_action} request.")
+                raise ApiError(f"Empty response from {api_action} request.")
 
-            response_data = json.loads(res)
+            try:
+                response_data = json.loads(res)
+            except (ValueError, TypeError) as e:
+                raise ApiError(
+                    f"Failed to {api_action}: malformed response body"
+                ) from e
+
             metadata = response_data.get("ResponseMetadata", {})
             if metadata.get("Error"):
                 err = metadata.get("Error", {}) or {}
@@ -355,13 +388,21 @@ class BaseServiceClient(Service):
                     self._is_probable_credential_error_code(error_code)
                     or self._is_probable_credential_error_text(error_msg)
                 ):
+                    logger.debug(
+                        "Retrying %s after credential error code %s",
+                        api_action,
+                        error_code or "<none>",
+                    )
                     continue
-                raise Exception(f"Failed to {api_action}: {error_msg}")
+                raise ApiError(
+                    f"Failed to {api_action}: {error_msg}",
+                    error_code=error_code or None,
+                )
 
             return response_type(**response_data.get("Result", {}))
 
         if last_error is not None:
-            raise Exception(
+            raise ApiError(
                 f"Failed to {api_action}: {str(last_error)}"
             ) from last_error
-        raise Exception(f"Failed to {api_action}: Unknown error")
+        raise ApiError(f"Failed to {api_action}: Unknown error")

--- a/agentkit/errors.py
+++ b/agentkit/errors.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Backward-compatible shim.
+"""Top-level exception root for AgentKit.
 
-The redaction helpers now live in :mod:`agentkit.utils.redact`; this module
-re-exports them so existing importers keep working.
+This module is a stdlib-only leaf: it has no intra-package imports so that any
+subpackage (``agentkit.auth``, ``agentkit.toolkit``, ...) can subclass the
+single root without creating dependency cycles.
 """
 
-from __future__ import annotations
 
-from agentkit.utils.redact import mask, redact
+class AgentKitError(Exception):
+    """The single root of the AgentKit exception hierarchy.
 
-__all__ = ["redact", "mask"]
+    Every domain-specific AgentKit exception (auth, toolkit, API, ...) ultimately
+    inherits from this class so callers can ``except AgentKitError`` to catch any
+    AgentKit-originated failure.
+    """
+
+
+__all__ = ["AgentKitError"]

--- a/agentkit/platform/configuration.py
+++ b/agentkit/platform/configuration.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import threading
 import time
@@ -42,8 +41,9 @@ from agentkit.utils.global_config_io import (
     get_global_config_value,
     read_global_config_dict,
 )
+from agentkit.utils.logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 VEFAAS_IAM_CREDENTIAL_PATH = "/var/run/secrets/iam/credential"
 VEFAAS_IAM_CREDENTIAL_FALLBACK_TTL_SECONDS = 60

--- a/agentkit/sdk/account/client.py
+++ b/agentkit/sdk/account/client.py
@@ -66,9 +66,7 @@ class AgentkitAccountClient(BaseAgentkitClient):
         Returns:
             The status string ('Enabled' or 'Disabled'), or None if service not found.
         """
-        print(1)
         response = self.list_account_linked_services(ListAccountLinkedServicesRequest())
-        print(2)
         if not response.service_statuses:
             return None
         for svc in response.service_statuses:

--- a/agentkit/sdk/identity/auth.py
+++ b/agentkit/sdk/identity/auth.py
@@ -21,6 +21,7 @@ from agentkit.platform import (
     resolve_credentials,
     resolve_endpoint,
 )
+from agentkit.toolkit.errors import ApiError
 
 
 def requires_api_key(*, provider_name: str, into: str = "api_key"):
@@ -59,8 +60,8 @@ def requires_api_key(*, provider_name: str, into: str = "api_key"):
 
             try:
                 return response["Result"]["ApiKey"]
-            except Exception as _:
-                raise RuntimeError(f"Get api key failed: {response}")
+            except Exception as e:
+                raise ApiError("GetResourceApiKey did not return an ApiKey") from e
 
         @wraps(func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/agentkit/toolkit/cli/sandbox/cli_mount.py
+++ b/agentkit/toolkit/cli/sandbox/cli_mount.py
@@ -27,6 +27,7 @@ from urllib.request import urlopen
 import typer
 
 from agentkit.sdk.tools.client import AgentkitToolsClient
+from agentkit.utils.http_defaults import http_timeout
 from agentkit.sdk.tools import types as tools_types
 from agentkit.toolkit.cli.sandbox.session_create import SANDBOX_TOOL_ID_ENV
 from agentkit.toolkit.cli.sandbox.session_sync import sync_remote_sessions
@@ -212,7 +213,7 @@ def _download_discovery(oauth_url: str) -> dict[str, object]:
     path = _get_discovery_store_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    with urlopen(discovery_url) as response:
+    with urlopen(discovery_url, timeout=http_timeout()) as response:
         content = response.read()
     path.write_bytes(content)
 

--- a/agentkit/toolkit/errors.py
+++ b/agentkit/toolkit/errors.py
@@ -22,6 +22,8 @@ handling, monitoring, and internationalization.
 
 from enum import Enum
 
+from agentkit.errors import AgentKitError as _RootAgentKitError
+
 
 class ErrorCode(str, Enum):
     """
@@ -78,7 +80,7 @@ class ErrorCode(str, Enum):
     UNKNOWN_ERROR = "UNKNOWN_ERROR"
 
 
-class AgentKitError(Exception):
+class AgentKitError(_RootAgentKitError):
     """
     Base exception class for all AgentKit errors.
 
@@ -134,6 +136,18 @@ class InvokeError(AgentKitError):
         super().__init__(message, ErrorCode.INVOKE_FAILED)
 
 
+class ApiError(AgentKitError):
+    """Raised when a backend API call fails.
+
+    Carries an optional ``error_code`` extracted from the API response metadata
+    (distinct from the :class:`ErrorCode` enum used by the other domain errors).
+    """
+
+    def __init__(self, message: str, *, error_code: str | None = None):
+        super().__init__(message)
+        self.error_code = error_code
+
+
 __all__ = [
     "ErrorCode",
     "AgentKitError",
@@ -142,4 +156,5 @@ __all__ = [
     "BuildError",
     "DeployError",
     "InvokeError",
+    "ApiError",
 ]

--- a/agentkit/toolkit/volcengine/cr.py
+++ b/agentkit/toolkit/volcengine/cr.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import time
 
 from agentkit.platform import resolve_endpoint, VolcConfiguration
+from agentkit.utils.logging_config import get_logger
 from agentkit.utils.ve_sign import ve_request
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DEFAULT_CR_INSTANCE_NAME = "agentkit-platform-instance"
 DEFAULT_CR_NAMESPACE_NAME = "agenkit-platform-namespace"
@@ -268,7 +268,7 @@ class VeCR:
             host=self.host,
             scheme=self.scheme,
         )
-        logger.debug(f"get cr authorization token: {response}")
+        logger.debug("got cr authorization token")
 
         if "Error" in response["ResponseMetadata"]:
             error_code = response["ResponseMetadata"]["Error"]["Code"]

--- a/agentkit/toolkit/volcengine/iam.py
+++ b/agentkit/toolkit/volcengine/iam.py
@@ -232,7 +232,7 @@ class VeIAM(BaseIAMClient):
             # If role not found, return None
             if "RoleNotExist" in str(e) or "NotFound" in str(e) or "404" in str(e):
                 return None
-            raise e
+            raise
 
     def create_role(
         self, role_name: str, trust_policy_document: str

--- a/agentkit/utils/http_defaults.py
+++ b/agentkit/utils/http_defaults.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single source of truth for HTTP timeout/retry defaults.
+
+Defaults and their controlling environment variables live here so the
+HTTP/credential/SDK paths share one consistent, env-tunable configuration.
+``AGENTKIT_HTTP_RETRIES=0`` disables retries.
+"""
+
+import os
+
+ENV_HTTP_TIMEOUT = "AGENTKIT_HTTP_TIMEOUT"
+ENV_HTTP_RETRIES = "AGENTKIT_HTTP_RETRIES"
+ENV_STREAM_TIMEOUT = "AGENTKIT_STREAM_TIMEOUT"
+
+DEFAULT_HTTP_TIMEOUT = 30.0
+DEFAULT_HTTP_RETRIES = 2
+DEFAULT_STREAM_TIMEOUT = 300.0
+
+
+def http_timeout() -> float:
+    """Return the per-request HTTP timeout in seconds (clamped to >= 1.0)."""
+    try:
+        return max(1.0, float(os.getenv(ENV_HTTP_TIMEOUT, "30")))
+    except ValueError:
+        return DEFAULT_HTTP_TIMEOUT
+
+
+def http_retries() -> int:
+    """Return the number of HTTP retries (clamped to >= 0; 0 disables retries)."""
+    try:
+        return max(0, int(os.getenv(ENV_HTTP_RETRIES, "2")))
+    except ValueError:
+        return DEFAULT_HTTP_RETRIES
+
+
+def stream_timeout() -> float:
+    """Return the streaming-response timeout in seconds (clamped to >= 1.0)."""
+    try:
+        return max(1.0, float(os.getenv(ENV_STREAM_TIMEOUT, "300")))
+    except ValueError:
+        return DEFAULT_STREAM_TIMEOUT

--- a/agentkit/utils/logging_config.py
+++ b/agentkit/utils/logging_config.py
@@ -23,6 +23,8 @@ from datetime import datetime
 from pathlib import Path
 import contextvars
 
+from agentkit.utils.redact import redact
+
 # Context for request/session/user tracing
 request_id_var = contextvars.ContextVar("request_id", default=None)
 session_id_var = contextvars.ContextVar("session_id", default=None)
@@ -64,6 +66,16 @@ class ContextFilter(logging.Filter):
         record.request_id = request_id_var.get()
         record.session_id = session_id_var.get()
         record.user_id = user_id_var.get()
+        return True
+
+
+class RedactionFilter(logging.Filter):
+    """Scrub credential-looking substrings from records before they are emitted."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Replace the record's rendered message with a redacted copy."""
+        record.msg = redact(record.getMessage())
+        record.args = ()
         return True
 
 
@@ -195,12 +207,16 @@ def setup_logging(
     # Context filter
     context_filter = ContextFilter()
 
+    # Redaction filter
+    redaction_filter = RedactionFilter()
+
     # Console handler
     if console_out:
         console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setLevel(numeric_level)
         console_handler.setFormatter(formatter)
         console_handler.addFilter(context_filter)
+        console_handler.addFilter(redaction_filter)
         root_logger.addHandler(console_handler)
 
     # File handler
@@ -214,6 +230,7 @@ def setup_logging(
             file_handler.setLevel(numeric_level)
             file_handler.setFormatter(formatter)
             file_handler.addFilter(context_filter)
+            file_handler.addFilter(redaction_filter)
             root_logger.addHandler(file_handler)
         except Exception as e:
             print(f"Warning: Failed to create log file handler: {e}", file=sys.stderr)
@@ -308,6 +325,9 @@ def _setup_dual_level_logging(
     # Context filter
     context_filter = ContextFilter()
 
+    # Redaction filter
+    redaction_filter = RedactionFilter()
+
     # Console handler
     if console_enabled:
         console_handler = logging.StreamHandler(sys.stderr)
@@ -321,6 +341,7 @@ def _setup_dual_level_logging(
         console_handler.setLevel(console_numeric_level)
         console_handler.setFormatter(formatter)
         console_handler.addFilter(context_filter)
+        console_handler.addFilter(redaction_filter)
         root_logger.addHandler(console_handler)
 
     # File handler
@@ -341,6 +362,7 @@ def _setup_dual_level_logging(
             file_handler.setLevel(file_numeric_level)
             file_handler.setFormatter(formatter)
             file_handler.addFilter(context_filter)
+            file_handler.addFilter(redaction_filter)
             root_logger.addHandler(file_handler)
         except Exception as e:
             print(f"Warning: Failed to create log file handler: {e}", file=sys.stderr)

--- a/agentkit/utils/redact.py
+++ b/agentkit/utils/redact.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Secret redaction for log/error output.
+
+Auth flows shuttle tokens and STS secrets around; any of them can end up in an
+exception body or a debug print. :func:`redact` scrubs the high-entropy strings
+(JWTs, bearer/STS tokens, ``ak/sk`` style secrets) before they are surfaced.
+"""
+
+from __future__ import annotations
+
+import re
+
+# JWTs: three base64url segments separated by dots.
+_JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")
+# Volcengine STS / access tokens and long opaque secrets (>= 16 url-safe chars).
+_OPAQUE = re.compile(r"\b[A-Za-z0-9/+_-]{16,}={0,2}\b")
+# Explicit secret-bearing query/JSON/header fields.
+_FIELD = re.compile(
+    r"(?i)(\"?(?:access_token|refresh_token|id_token|client_secret|secret_access_key"
+    r"|secretkey|accesskeyid|accesskey|sessiontoken|session_token|authorization"
+    r"|apikey|api_key|token|password)\"?\s*[:=]\s*\"?(?:bearer\s+)?)"
+    r"([^\"&\s,}]+)"
+)
+
+
+def redact(text: str) -> str:
+    """Return ``text`` with credential-looking substrings replaced by ``***``."""
+    if not text:
+        return text
+    text = _FIELD.sub(lambda m: m.group(1) + "***", text)
+    text = _JWT.sub("***", text)
+    text = _OPAQUE.sub("***", text)
+    return text
+
+
+def mask(secret: str | None, *, keep: int = 4) -> str:
+    """Mask a secret, keeping only the last ``keep`` characters for recognition."""
+    if not secret:
+        return "<none>"
+    if len(secret) <= keep:
+        return "*" * len(secret)
+    return "*" * (len(secret) - keep) + secret[-keep:]

--- a/agentkit/utils/request.py
+++ b/agentkit/utils/request.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
+from agentkit.utils.logging_config import get_logger
 from agentkit.utils.ve_sign import ve_request
 
-logger = logging.getLogger("agentkit." + __name__)
+logger = get_logger(__name__)
 
 
 def request(
@@ -56,4 +55,5 @@ def request(
                 response = getattr(response, key, None)
         return response
     except Exception as e:
-        logger.error(f"Request {name} failed {e}. Response from volcengine: {response}")
+        logger.error("Request %s failed: %s", name, e, exc_info=True)
+        raise

--- a/agentkit/utils/ve_sign.py
+++ b/agentkit/utils/ve_sign.py
@@ -35,6 +35,11 @@ import time
 import requests
 from urllib.parse import quote
 
+from agentkit.utils.http_defaults import http_timeout, http_retries
+from agentkit.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
 
 Service = ""
 Version = ""
@@ -53,20 +58,6 @@ MAX_X_CUSTOM_SOURCE_LENGTH = 256
 # call outright with no retry. Both are now bounded and conservatively retried.
 # Tunable via env; AGENTKIT_HTTP_RETRIES=0 disables retries.
 _RETRYABLE_STATUS = frozenset({429, 503})
-
-
-def _http_timeout() -> float:
-    try:
-        return max(1.0, float(os.getenv("AGENTKIT_HTTP_TIMEOUT", "30")))
-    except ValueError:
-        return 30.0
-
-
-def _http_retries() -> int:
-    try:
-        return max(0, int(os.getenv("AGENTKIT_HTTP_RETRIES", "2")))
-    except ValueError:
-        return 2
 
 
 def _backoff_seconds(attempt: int) -> float:
@@ -92,8 +83,10 @@ def _signed_request(method, url, headers, params, data) -> requests.Response:
     so non-idempotent ``Create*`` actions are never double-executed. Read
     timeouts and other 5xx are surfaced, not retried. Honors ``Retry-After``.
     """
-    retries = _http_retries()
-    timeout = _http_timeout()
+    from agentkit.auth.errors import NetworkError
+
+    retries = http_retries()
+    timeout = http_timeout()
     resp: requests.Response | None = None
     for attempt in range(retries + 1):
         try:
@@ -105,15 +98,40 @@ def _signed_request(method, url, headers, params, data) -> requests.Response:
                 data=data,
                 timeout=timeout,
             )
-        except requests.ConnectionError:
+        except requests.ConnectionError as e:
             # Not delivered (connection failed/reset before completion), so a
             # retry cannot double-execute the request.
             if attempt < retries:
-                time.sleep(_backoff_seconds(attempt))
+                sleep = _backoff_seconds(attempt)
+                logger.debug(
+                    "signed request connection error on attempt %d/%d; "
+                    "retrying in %.2fs",
+                    attempt + 1,
+                    retries + 1,
+                    sleep,
+                )
+                time.sleep(sleep)
                 continue
-            raise
+            raise NetworkError(
+                "signed request failed: connection error after "
+                f"{retries + 1} attempt(s)"
+            ) from e
+        except (requests.Timeout, requests.HTTPError, requests.RequestException) as e:
+            # Read timeouts and other transport errors are not retried (a
+            # non-idempotent action may already have been processed); surface
+            # them as a domain error with the original cause chained.
+            raise NetworkError(f"signed request failed: {type(e).__name__}") from e
         if resp.status_code in _RETRYABLE_STATUS and attempt < retries:
-            time.sleep(_retry_after_seconds(resp) or _backoff_seconds(attempt))
+            sleep = _retry_after_seconds(resp) or _backoff_seconds(attempt)
+            logger.debug(
+                "signed request got retryable status %d on attempt %d/%d; "
+                "retrying in %.2fs",
+                resp.status_code,
+                attempt + 1,
+                retries + 1,
+                sleep,
+            )
+            time.sleep(sleep)
             continue
         return resp
     assert resp is not None  # loop always returns or raises before here
@@ -343,14 +361,11 @@ def ve_request(
     # response_body = request("GET", now, {"Limit": "2"}, {}, AK, SK, "ListUsers", None)
     import json
 
-    try:
-        response_body = request(
-            "POST", now, {}, header or {}, AK, SK, action, json.dumps(request_body)
-        )
-        check_error(response_body)
-        return response_body
-    except Exception as e:
-        raise e
+    response_body = request(
+        "POST", now, {}, header or {}, AK, SK, action, json.dumps(request_body)
+    )
+    check_error(response_body)
+    return response_body
 
 
 def check_error(response: dict) -> None:
@@ -361,5 +376,5 @@ def check_error(response: dict) -> None:
         error_message = response["ResponseMetadata"]["Error"]["Message"]
         action = response["ResponseMetadata"]["Action"]
         raise ValueError(
-            f"Error when ve_request {action}: {error_code} {error_message}, res: {response}"
+            f"Error when ve_request {action}: {error_code} {error_message}"
         )

--- a/tests/apps/test_a2a_app.py
+++ b/tests/apps/test_a2a_app.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit guards for ``AgentkitA2aApp``.
+
+These tests exercise the decorator guards (``agent_executor`` / ``task_store`` /
+``ping``), the pure ``_format_ping_status`` helper, the async ``ping_endpoint``
+handler (driven via ``asyncio.run``), and the ``/env`` runtime-detection route
+(driven via ``starlette.testclient.TestClient``) -- all without building the
+real A2A server or ever calling ``run()`` (which binds sockets via uvicorn).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.tasks.task_store import TaskStore
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from agentkit.apps.a2a_app.a2a_app import AgentkitA2aApp
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete a2a subclasses used as decorator targets.
+# a2a's AgentExecutor requires execute/cancel; TaskStore requires get/save/delete.
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgentExecutor(AgentExecutor):
+    async def execute(self, context, event_queue):  # pragma: no cover - never invoked
+        return None
+
+    async def cancel(self, context, event_queue):  # pragma: no cover - never invoked
+        return None
+
+
+class _FakeTaskStore(TaskStore):
+    async def get(self, task_id):  # pragma: no cover - never invoked
+        return None
+
+    async def save(self, task):  # pragma: no cover - never invoked
+        return None
+
+    async def delete(self, task_id):  # pragma: no cover - never invoked
+        return None
+
+
+class _NotAnExecutor:
+    """A plain class that is deliberately NOT a subclass of AgentExecutor."""
+
+
+class _NotATaskStore:
+    """A plain class that is deliberately NOT a subclass of TaskStore."""
+
+
+class _DummyRequest:
+    """Placeholder request object; ping_endpoint never reads the request."""
+
+
+# ---------------------------------------------------------------------------
+# _format_ping_status (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_format_ping_status_wraps_string_result_under_status_key():
+    app = AgentkitA2aApp()
+    assert app._format_ping_status("ok") == {"status": "ok"}
+
+
+def test_format_ping_status_wraps_dict_result_under_status_key():
+    app = AgentkitA2aApp()
+    payload = {"healthy": True, "detail": "fine"}
+    assert app._format_ping_status(payload) == {"status": payload}
+
+
+def test_format_ping_status_returns_error_dict_for_non_str_non_dict_result():
+    app = AgentkitA2aApp()
+    assert app._format_ping_status(12345) == {
+        "status": "error",
+        "message": "Invalid response type.",
+    }
+
+
+def test_format_ping_status_treats_bool_as_invalid_response_type():
+    # NOTE: bool is not str/dict, so it falls through to the error branch.
+    app = AgentkitA2aApp()
+    assert app._format_ping_status(True) == {
+        "status": "error",
+        "message": "Invalid response type.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# ping() decorator guard
+# ---------------------------------------------------------------------------
+
+
+def test_ping_decorator_rejects_function_with_parameters():
+    app = AgentkitA2aApp()
+
+    def health(request):
+        return "ok"
+
+    with pytest.raises(AssertionError):
+        app.ping(health)
+    assert app._ping_func is None
+
+
+def test_ping_decorator_registers_zero_argument_function_and_returns_it():
+    app = AgentkitA2aApp()
+
+    def health():
+        return "ok"
+
+    returned = app.ping(health)
+    assert returned is health
+    assert app._ping_func is health
+
+
+# ---------------------------------------------------------------------------
+# ping_endpoint (async, driven via asyncio.run)
+# ---------------------------------------------------------------------------
+
+
+def test_ping_endpoint_returns_404_when_no_ping_func_registered():
+    app = AgentkitA2aApp()
+    response = asyncio.run(app.ping_endpoint(_DummyRequest()))
+    assert response.status_code == 404
+
+
+def test_ping_endpoint_wraps_sync_ping_func_result_under_status():
+    app = AgentkitA2aApp()
+    app._ping_func = lambda: "alive"
+
+    response = asyncio.run(app.ping_endpoint(_DummyRequest()))
+
+    assert response.status_code == 200
+    assert json.loads(bytes(response.body)) == {"status": "alive"}
+
+
+def test_ping_endpoint_awaits_coroutine_ping_func_result():
+    app = AgentkitA2aApp()
+
+    async def health():
+        return {"db": "up"}
+
+    app._ping_func = health
+
+    response = asyncio.run(app.ping_endpoint(_DummyRequest()))
+
+    assert response.status_code == 200
+    assert json.loads(bytes(response.body)) == {"status": {"db": "up"}}
+
+
+def test_ping_endpoint_returns_500_error_payload_when_ping_func_raises():
+    app = AgentkitA2aApp()
+
+    def boom():
+        raise ValueError("kaboom")
+
+    app._ping_func = boom
+
+    response = asyncio.run(app.ping_endpoint(_DummyRequest()))
+
+    assert response.status_code == 500
+    assert json.loads(bytes(response.body)) == {
+        "status": "error",
+        "message": "kaboom",
+    }
+
+
+def test_ping_endpoint_returns_error_payload_when_ping_func_returns_invalid_type():
+    app = AgentkitA2aApp()
+    app._ping_func = lambda: 42
+
+    response = asyncio.run(app.ping_endpoint(_DummyRequest()))
+
+    assert response.status_code == 200
+    assert json.loads(bytes(response.body)) == {
+        "status": "error",
+        "message": "Invalid response type.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# agent_executor() decorator guard
+# ---------------------------------------------------------------------------
+
+
+def test_agent_executor_rejects_class_not_subclassing_a2a_agent_executor():
+    app = AgentkitA2aApp()
+
+    with pytest.raises(TypeError):
+        app.agent_executor()(_NotAnExecutor)
+    assert app._agent_executor is None
+
+
+def test_agent_executor_binds_valid_executor_and_returns_the_class():
+    app = AgentkitA2aApp()
+
+    class _MyExecutor(_FakeAgentExecutor):
+        pass
+
+    returned = app.agent_executor()(_MyExecutor)
+
+    assert returned is _MyExecutor
+    assert isinstance(app._agent_executor, _MyExecutor)
+
+
+def test_agent_executor_raises_runtime_error_when_binding_a_second_executor():
+    app = AgentkitA2aApp()
+
+    class _First(_FakeAgentExecutor):
+        pass
+
+    class _Second(_FakeAgentExecutor):
+        pass
+
+    app.agent_executor()(_First)
+    with pytest.raises(RuntimeError):
+        app.agent_executor()(_Second)
+
+
+# ---------------------------------------------------------------------------
+# task_store() decorator guard
+# ---------------------------------------------------------------------------
+
+
+def test_task_store_rejects_class_not_subclassing_a2a_task_store():
+    app = AgentkitA2aApp()
+
+    with pytest.raises(TypeError):
+        app.task_store()(_NotATaskStore)
+    assert app._task_store is None
+
+
+def test_task_store_binds_valid_store_and_returns_the_class():
+    app = AgentkitA2aApp()
+
+    class _MyStore(_FakeTaskStore):
+        pass
+
+    returned = app.task_store()(_MyStore)
+
+    assert returned is _MyStore
+    assert isinstance(app._task_store, _MyStore)
+
+
+def test_task_store_raises_runtime_error_when_binding_a_second_store():
+    app = AgentkitA2aApp()
+
+    class _First(_FakeTaskStore):
+        pass
+
+    class _Second(_FakeTaskStore):
+        pass
+
+    app.task_store()(_First)
+    with pytest.raises(RuntimeError):
+        app.task_store()(_Second)
+
+
+# ---------------------------------------------------------------------------
+# add_env_detect_route() -> GET /env
+# ---------------------------------------------------------------------------
+
+
+def test_env_route_reports_agentkit_when_runtime_iam_role_trn_is_set(monkeypatch):
+    monkeypatch.setenv("RUNTIME_IAM_ROLE_TRN", "x")
+
+    bare_app = Starlette()
+    AgentkitA2aApp().add_env_detect_route(bare_app)
+
+    with TestClient(bare_app) as client:
+        response = client.get("/env")
+
+    assert response.status_code == 200
+    assert response.json() == {"env": "agentkit"}
+
+
+def test_env_route_reports_veadk_when_runtime_iam_role_trn_is_absent(monkeypatch):
+    monkeypatch.delenv("RUNTIME_IAM_ROLE_TRN", raising=False)
+
+    bare_app = Starlette()
+    AgentkitA2aApp().add_env_detect_route(bare_app)
+
+    with TestClient(bare_app) as client:
+        response = client.get("/env")
+
+    assert response.status_code == 200
+    assert response.json() == {"env": "veadk"}

--- a/tests/apps/test_agent_server_invoke.py
+++ b/tests/apps/test_agent_server_invoke.py
@@ -1,0 +1,679 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline behaviour guards for the ``/invoke`` compatibility serving path.
+
+Target: ``AgentkitAgentServerApp.__init__``'s ``_invoke_compat`` closure
+(``agentkit/apps/agent_server_app/agent_server_app.py``). The endpoint is the
+AgentKit-CLI-compatible request-serving transport and is otherwise 0% covered.
+
+``_invoke_compat`` is a *closure* defined inside ``__init__`` -- there is no
+class-level method to bind, and constructing the app normally builds heavy ADK
+objects (AdkWebServer, to_a2a, a full FastAPI app). So we rebuild the *real*
+function object from its compiled code object -- the closure captures exactly
+one free variable (``self``) -- and rebind it against a hand-rolled fake
+``self``. This runs the genuine bytecode of ``_invoke_compat`` (real branch
+logic, real module globals: ``trace``, ``telemetry``, ``HTTPException``,
+``json``, ``types``, ``RunConfig``, ``StreamingMode``, ``Aclosing``,
+``StreamingResponse``) with a controllable collaborator surface -- no sockets,
+no ADK runtime, no network.
+
+The fakes match the real collaborator surface the closure reaches for:
+``self.server.agent_loader.list_agents()``, the async
+``self.server.session_service.get_session/create_session(...)``, and the async
+``self.server.get_runner_async(app_name)`` yielding a runner whose
+``run_async(...)`` returns an async generator of events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import types as pytypes
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from google.adk.agents.run_config import StreamingMode
+from google.genai import types as genai_types
+
+import agentkit.apps.agent_server_app.agent_server_app as mod
+
+
+# ---------------------------------------------------------------------------
+# Extract the real _invoke_compat code object from __init__ and rebuild it.
+# ---------------------------------------------------------------------------
+
+
+def _find_code(code, name):
+    for const in code.co_consts:
+        if isinstance(const, pytypes.CodeType):
+            if const.co_name == name:
+                return const
+            found = _find_code(const, name)
+            if found is not None:
+                return found
+    return None
+
+
+_INVOKE_COMPAT_CODE = _find_code(
+    mod.AgentkitAgentServerApp.__init__.__code__, "_invoke_compat"
+)
+assert _INVOKE_COMPAT_CODE is not None, "could not locate _invoke_compat code object"
+# Guard the seam assumption: the closure captures exactly `self`. If a future
+# refactor adds free variables, this test's rebind would silently drift.
+assert _INVOKE_COMPAT_CODE.co_freevars == ("self",), (
+    f"unexpected freevars: {_INVOKE_COMPAT_CODE.co_freevars}"
+)
+
+
+def _make_cell(value):
+    # Build a closure cell holding `value`.
+    return (lambda: value).__closure__[0]
+
+
+def _bind_invoke_compat(fake_self):
+    """Rebuild the real ``_invoke_compat`` bound to ``fake_self``.
+
+    Uses the module's real ``__dict__`` as globals so every name the closure
+    references resolves to the production symbol.
+    """
+    return pytypes.FunctionType(
+        _INVOKE_COMPAT_CODE,
+        mod.__dict__,
+        "_invoke_compat",
+        None,
+        (_make_cell(fake_self),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fakes matching the real collaborator surface.
+# ---------------------------------------------------------------------------
+
+
+class _FakeHeaders:
+    """Mapping-like stand-in for starlette Headers.
+
+    ``_invoke_compat`` reaches for ``dict(headers)`` (needs keys/__getitem__)
+    and ``headers.get(...)``.
+    """
+
+    def __init__(self, data: dict) -> None:
+        self._d = dict(data)
+
+    def keys(self):
+        return self._d.keys()
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+
+class _FakeRequest:
+    """Minimal starlette Request substitute for the invoke path.
+
+    ``json_payload`` is returned by the async ``json()``; when
+    ``raise_on_json`` is set, ``json()`` raises to drive the fallback branch.
+    ``body_bytes`` backs the async ``body()`` fallback.
+    """
+
+    def __init__(
+        self,
+        headers: dict | None = None,
+        json_payload=None,
+        raise_on_json: bool = False,
+        body_bytes: bytes = b"",
+    ) -> None:
+        self.headers = _FakeHeaders(headers or {})
+        self._json_payload = json_payload
+        self._raise_on_json = raise_on_json
+        self._body_bytes = body_bytes
+        self.json_calls = 0
+        self.body_calls = 0
+
+    async def json(self):
+        self.json_calls += 1
+        if self._raise_on_json:
+            raise ValueError("not json")
+        return self._json_payload
+
+    async def body(self):
+        self.body_calls += 1
+        return self._body_bytes
+
+
+class _FakeEvent:
+    """Event stand-in with the real ``model_dump_json`` signature."""
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.dump_kwargs = None
+
+    def model_dump_json(self, exclude_none=False, by_alias=False):
+        self.dump_kwargs = {"exclude_none": exclude_none, "by_alias": by_alias}
+        return json.dumps(self._payload)
+
+
+class _FakeRunner:
+    """Records the run_async kwargs and yields the configured events.
+
+    ``run_async`` returns a *real* async generator so ``Aclosing`` can call
+    ``aclose()`` on it, exactly as the production code expects.
+    """
+
+    def __init__(self, events, raise_exc: Exception | None = None) -> None:
+        self._events = events
+        self._raise_exc = raise_exc
+        self.run_async_calls: list[dict] = []
+
+    def run_async(self, **kwargs):
+        self.run_async_calls.append(kwargs)
+        events = self._events
+        raise_exc = self._raise_exc
+
+        async def _agen():
+            if raise_exc is not None:
+                raise raise_exc
+            for ev in events:
+                yield ev
+
+        return _agen()
+
+
+class _FakeSessionService:
+    """Async session service.
+
+    ``existing_session`` (any truthy sentinel) is returned by ``get_session``;
+    when it is falsy, the closure must call ``create_session``. All calls are
+    recorded with their kwargs.
+    """
+
+    def __init__(self, existing_session=None) -> None:
+        self._existing = existing_session
+        self.get_calls: list[dict] = []
+        self.create_calls: list[dict] = []
+
+    async def get_session(self, **kwargs):
+        self.get_calls.append(kwargs)
+        return self._existing
+
+    async def create_session(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return object()
+
+
+class _FakeAgentLoader:
+    def __init__(self, agents) -> None:
+        self._agents = list(agents)
+        self.list_calls = 0
+
+    def list_agents(self):
+        self.list_calls += 1
+        return list(self._agents)
+
+
+class _FakeServer:
+    def __init__(self, agent_loader, session_service, runner) -> None:
+        self.agent_loader = agent_loader
+        self.session_service = session_service
+        self._runner = runner
+        self.get_runner_calls: list = []
+
+    async def get_runner_async(self, app_name):
+        self.get_runner_calls.append(app_name)
+        return self._runner
+
+
+class _FakeSelf:
+    """The ``self`` the closure captures: only ``server`` is ever touched."""
+
+    def __init__(self, server) -> None:
+        self.server = server
+
+
+# Records of telemetry calls so tests can assert wiring without touching a
+# real OTEL span (whose set_attribute/end side-effects we don't want here).
+_TELEMETRY_CALLS: dict = {"server": [], "finish": []}
+
+
+class _FakeSpan:
+    def __init__(self) -> None:
+        self.recording = True
+
+    def is_recording(self):
+        return self.recording
+
+
+@pytest.fixture(autouse=True)
+def _isolate_telemetry_and_span(monkeypatch):
+    """Neutralise telemetry side-effects and record its calls.
+
+    ``_invoke_compat`` calls ``trace.get_current_span()`` then
+    ``telemetry.trace_agent_server(...)`` at entry, and
+    ``telemetry.trace_agent_server_finish(...)`` on the 404 branch and inside
+    the streaming generator's error path. We patch the module singleton's
+    bound methods to no-op recorders and pin the current span so nothing
+    touches a live tracer.
+    """
+    _TELEMETRY_CALLS["server"].clear()
+    _TELEMETRY_CALLS["finish"].clear()
+
+    def _fake_trace_agent_server(*, func_name, span, headers, text):
+        _TELEMETRY_CALLS["server"].append(
+            {"func_name": func_name, "headers": headers, "text": text}
+        )
+
+    def _fake_trace_finish(*, path, func_result, exception):
+        _TELEMETRY_CALLS["finish"].append(
+            {"path": path, "func_result": func_result, "exception": exception}
+        )
+
+    monkeypatch.setattr(
+        mod.telemetry, "trace_agent_server", _fake_trace_agent_server
+    )
+    monkeypatch.setattr(
+        mod.telemetry, "trace_agent_server_finish", _fake_trace_finish
+    )
+    monkeypatch.setattr(mod.trace, "get_current_span", lambda: _FakeSpan())
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build(
+    *,
+    agents=("my_app",),
+    existing_session=None,
+    events=None,
+    run_exc: Exception | None = None,
+):
+    runner = _FakeRunner(events if events is not None else [], raise_exc=run_exc)
+    session_service = _FakeSessionService(existing_session=existing_session)
+    agent_loader = _FakeAgentLoader(agents)
+    server = _FakeServer(agent_loader, session_service, runner)
+    fake_self = _FakeSelf(server)
+    invoke = _bind_invoke_compat(fake_self)
+    return invoke, fake_self, server, session_service, runner
+
+
+async def _drain(response: StreamingResponse) -> list[str]:
+    return [chunk async for chunk in response.body_iterator]
+
+
+# ===========================================================================
+# 404 branch: no agents configured
+# ===========================================================================
+
+
+def test_invoke_raises_404_when_no_agents_configured():
+    invoke, _self, server, session_service, _runner = _build(agents=())
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(invoke(request))
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail == "No agents configured"
+    # The loader was consulted, but nothing downstream ran.
+    assert server.agent_loader.list_calls == 1
+    assert session_service.get_calls == []
+    assert session_service.create_calls == []
+
+
+def test_invoke_404_reports_finish_telemetry_for_invoke_path_with_the_exception():
+    invoke, _self, _server, _ss, _runner = _build(agents=())
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(invoke(request))
+
+    # The 404 branch traces a finish event on the /invoke path carrying the
+    # raised HTTPException before re-raising.
+    assert len(_TELEMETRY_CALLS["finish"]) == 1
+    finish = _TELEMETRY_CALLS["finish"][0]
+    assert finish["path"] == "/invoke"
+    assert finish["exception"] is excinfo.value
+
+
+# ===========================================================================
+# Entry telemetry + header redaction
+# ===========================================================================
+
+
+def test_invoke_entry_traces_request_with_authorization_and_token_redacted():
+    invoke, _self, _server, _ss, _runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    request = _FakeRequest(
+        headers={
+            "Authorization": "Bearer secret",
+            "Token": "abc",
+            "user_id": "u1",
+            "content-type": "application/json",
+        },
+        json_payload={"prompt": "hi"},
+    )
+
+    asyncio.run(invoke(request))
+
+    assert len(_TELEMETRY_CALLS["server"]) == 1
+    entry = _TELEMETRY_CALLS["server"][0]
+    assert entry["func_name"] == "_invoke_compat"
+    # Authorization/token (case-insensitively) are stripped from telemetry.
+    assert "Authorization" not in entry["headers"]
+    assert "Token" not in entry["headers"]
+    assert entry["headers"]["user_id"] == "u1"
+    assert entry["headers"]["content-type"] == "application/json"
+
+
+# ===========================================================================
+# user_id / session_id header handling
+# ===========================================================================
+
+
+def test_invoke_defaults_user_id_and_empty_session_when_headers_absent():
+    invoke, _self, _server, session_service, _runner = _build(
+        agents=("my_app",), existing_session=None
+    )
+    request = _FakeRequest(headers={}, json_payload={"prompt": "hi"})
+
+    asyncio.run(invoke(request))
+
+    # get_session is called with the defaulted identity before the stream.
+    assert session_service.get_calls == [
+        {
+            "app_name": "my_app",
+            "user_id": "agentkit_user",
+            "session_id": "",
+        }
+    ]
+
+
+def test_invoke_uses_user_and_session_id_from_headers():
+    invoke, _self, _server, session_service, _runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    request = _FakeRequest(
+        headers={"user_id": "alice", "session_id": "sess-9"},
+        json_payload={"prompt": "hi"},
+    )
+
+    asyncio.run(invoke(request))
+
+    assert session_service.get_calls == [
+        {"app_name": "my_app", "user_id": "alice", "session_id": "sess-9"}
+    ]
+
+
+# ===========================================================================
+# app_name selection: first agent from the loader
+# ===========================================================================
+
+
+def test_invoke_selects_first_agent_as_app_name():
+    invoke, _self, server, session_service, runner = _build(
+        agents=("first_app", "second_app"), existing_session=object()
+    )
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    assert session_service.get_calls[0]["app_name"] == "first_app"
+    assert server.get_runner_calls == ["first_app"]
+    assert runner.run_async_calls[0]["session_id"] == ""
+
+
+# ===========================================================================
+# Prompt extraction branches
+# ===========================================================================
+
+
+def test_invoke_uses_prompt_field_verbatim_as_content_text():
+    invoke, _self, _server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    request = _FakeRequest(json_payload={"prompt": "hello world", "other": 1})
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    content = runner.run_async_calls[0]["new_message"]
+    assert isinstance(content, genai_types.UserContent)
+    assert content.parts[0].text == "hello world"
+
+
+def test_invoke_falls_back_to_json_dumps_of_dict_payload_without_prompt():
+    invoke, _self, _server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    payload = {"foo": "bar", "n": 2}
+    request = _FakeRequest(json_payload=payload)
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    content = runner.run_async_calls[0]["new_message"]
+    # No "prompt" key -> the whole dict is json.dumps'd (ensure_ascii=False).
+    assert content.parts[0].text == json.dumps(payload, ensure_ascii=False)
+
+
+def test_invoke_json_dumps_fallback_preserves_non_ascii():
+    invoke, _self, _server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    payload = {"msg": "你好"}
+    request = _FakeRequest(json_payload=payload)
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    content = runner.run_async_calls[0]["new_message"]
+    # ensure_ascii=False keeps the raw characters rather than \uXXXX escapes.
+    assert content.parts[0].text == json.dumps(payload, ensure_ascii=False)
+    assert "你好" in content.parts[0].text
+
+
+def test_invoke_reads_raw_body_when_json_parsing_fails():
+    invoke, _self, _server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    request = _FakeRequest(raise_on_json=True, body_bytes=b"raw text body")
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    # json() raised -> payload is None -> not a dict -> raw body decoded.
+    assert request.json_calls == 1
+    assert request.body_calls == 1
+    content = runner.run_async_calls[0]["new_message"]
+    assert content.parts[0].text == "raw text body"
+
+
+def test_invoke_non_dict_json_payload_is_json_dumped_not_read_from_body():
+    # json() succeeds but returns a list (not a dict): text is None, and since
+    # payload is not None the raw-body branch is skipped -- json.dumps(payload)
+    # runs instead. Pin that: a list payload is serialised, NOT the raw body.
+    invoke, _self, _server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    payload = ["a", "b"]
+    request = _FakeRequest(json_payload=payload, body_bytes=b"unused")
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    # payload is not None -> json.dumps(payload) path (body() NOT read).
+    assert request.body_calls == 0
+    content = runner.run_async_calls[0]["new_message"]
+    assert content.parts[0].text == json.dumps(payload, ensure_ascii=False)
+
+
+# ===========================================================================
+# Session creation branch
+# ===========================================================================
+
+
+def test_invoke_creates_session_when_missing():
+    invoke, _self, _server, session_service, _runner = _build(
+        agents=("my_app",), existing_session=None
+    )
+    request = _FakeRequest(
+        headers={"user_id": "u2", "session_id": "s2"},
+        json_payload={"prompt": "hi"},
+    )
+
+    asyncio.run(invoke(request))
+
+    # get_session returned falsy -> create_session invoked with same identity.
+    assert session_service.create_calls == [
+        {"app_name": "my_app", "user_id": "u2", "session_id": "s2"}
+    ]
+
+
+def test_invoke_does_not_create_session_when_it_already_exists():
+    invoke, _self, _server, session_service, _runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    asyncio.run(invoke(request))
+
+    assert session_service.get_calls != []
+    assert session_service.create_calls == []
+
+
+# ===========================================================================
+# StreamingResponse shape + SSE headers
+# ===========================================================================
+
+
+def test_invoke_returns_sse_streaming_response_with_cache_headers():
+    invoke, _self, _server, _ss, _runner = _build(
+        agents=("my_app",), existing_session=object()
+    )
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    response = asyncio.run(invoke(request))
+
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "text/event-stream"
+    assert response.headers.get("Cache-Control") == "no-cache"
+    assert response.headers.get("Connection") == "keep-alive"
+    assert response.headers.get("X-Accel-Buffering") == "no"
+
+
+# ===========================================================================
+# Event streaming body: happy path
+# ===========================================================================
+
+
+def test_invoke_stream_emits_sse_data_frames_per_event():
+    ev1 = _FakeEvent({"id": 1, "text": "a"})
+    ev2 = _FakeEvent({"id": 2, "text": "b"})
+    invoke, _self, server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object(), events=[ev1, ev2]
+    )
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    response = asyncio.run(invoke(request))
+    chunks = asyncio.run(_drain(response))
+
+    # The runner is fetched lazily inside the generator, only on drain.
+    assert server.get_runner_calls == ["my_app"]
+    assert chunks == [
+        "data: " + json.dumps({"id": 1, "text": "a"}) + "\n\n",
+        "data: " + json.dumps({"id": 2, "text": "b"}) + "\n\n",
+    ]
+    # Each event is dumped with the ADK-web serialization flags.
+    assert ev1.dump_kwargs == {"exclude_none": True, "by_alias": True}
+    assert ev2.dump_kwargs == {"exclude_none": True, "by_alias": True}
+
+
+def test_invoke_stream_runs_agent_with_sse_run_config_and_identity():
+    ev = _FakeEvent({"ok": True})
+    invoke, _self, _server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object(), events=[ev]
+    )
+    request = _FakeRequest(
+        headers={"user_id": "bob", "session_id": "sid-5"},
+        json_payload={"prompt": "yo"},
+    )
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    call = runner.run_async_calls[0]
+    assert call["user_id"] == "bob"
+    assert call["session_id"] == "sid-5"
+    assert isinstance(call["new_message"], genai_types.UserContent)
+    assert call["new_message"].parts[0].text == "yo"
+    assert call["run_config"].streaming_mode == StreamingMode.SSE
+
+
+def test_invoke_stream_is_lazy_no_runner_fetch_before_drain():
+    ev = _FakeEvent({"ok": True})
+    invoke, _self, server, _ss, runner = _build(
+        agents=("my_app",), existing_session=object(), events=[ev]
+    )
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    asyncio.run(invoke(request))  # build the response but do NOT drain
+
+    # get_runner_async / run_async live inside the body generator; without
+    # draining they must not have run.
+    assert server.get_runner_calls == []
+    assert runner.run_async_calls == []
+
+
+# ===========================================================================
+# Event streaming body: error path inside the generator
+# ===========================================================================
+
+
+def test_invoke_stream_emits_error_frame_when_runner_raises():
+    boom = RuntimeError("runner exploded")
+    invoke, _self, _server, _ss, _runner = _build(
+        agents=("my_app",), existing_session=object(), run_exc=boom
+    )
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    response = asyncio.run(invoke(request))
+    chunks = asyncio.run(_drain(response))
+
+    # The generator catches the exception and yields a single error SSE frame.
+    assert chunks == ['data: {"error": "runner exploded"}\n\n']
+
+
+def test_invoke_stream_error_path_traces_finish_with_the_exception():
+    boom = RuntimeError("kaboom")
+    invoke, _self, _server, _ss, _runner = _build(
+        agents=("my_app",), existing_session=object(), run_exc=boom
+    )
+    request = _FakeRequest(json_payload={"prompt": "hi"})
+
+    response = asyncio.run(invoke(request))
+    asyncio.run(_drain(response))
+
+    # The except branch traces a finish event for /invoke carrying the error.
+    assert len(_TELEMETRY_CALLS["finish"]) == 1
+    finish = _TELEMETRY_CALLS["finish"][0]
+    assert finish["path"] == "/invoke"
+    assert finish["exception"] is boom

--- a/tests/apps/test_agent_server_loader.py
+++ b/tests/apps/test_agent_server_loader.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit guards for ``agent_server_app`` light logic.
+
+These cover only the cheap, side-effect-free surface of
+``agentkit.apps.agent_server_app.agent_server_app``:
+
+* ``AgentKitAgentLoader`` -- the tiny loader that wraps a single agent/app and
+  answers ``load_agent`` / ``list_agents`` / ``list_agents_detailed``.
+* ``AgentkitAgentServerApp.__init__`` argument-validation guards that raise
+  *before* any heavy ADK ``AdkWebServer`` / A2A construction happens.
+
+Nothing here constructs a real web server, binds a socket, or calls ``.run()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.apps.app import App
+
+from agentkit.apps.agent_server_app.agent_server_app import (
+    AgentKitAgentLoader,
+    AgentkitAgentServerApp,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fakes
+# ---------------------------------------------------------------------------
+class _FakeAgent:
+    """Minimal stand-in for a ``BaseAgent``.
+
+    A plain object is deliberately *not* an ``App`` instance, so passing it to
+    ``AgentKitAgentLoader`` exercises the ``else`` (BaseAgent) branch of the
+    ``isinstance(agent_or_app, App)`` check without dragging in real ADK
+    machinery.
+    """
+
+    def __init__(self, name: str, description: str | None = None) -> None:
+        self.name = name
+        self.description = description
+
+
+def _make_real_app(app_name: str, root_name: str, root_desc: str) -> App:
+    """Build a genuine ``App`` wrapping a genuine (empty) ``BaseAgent``.
+
+    ``App`` validates that ``root_agent`` is a real ``BaseAgent``/``BaseNode``
+    and that its ``name`` is a valid identifier, so we cannot cheaply fake this
+    branch -- a real (but otherwise inert) ``BaseAgent`` is the minimal object
+    that passes ``isinstance(agent_or_app, App)``.
+    """
+    root = BaseAgent(name=root_name, description=root_desc)
+    return App(name=app_name, root_agent=root)
+
+
+# ===========================================================================
+# AgentKitAgentLoader -- BaseAgent branch (agent_server_app.py:73-75)
+# ===========================================================================
+def test_loader_with_bare_agent_uses_agent_as_root_and_app_name():
+    agent = _FakeAgent(name="my_agent", description="a fake agent")
+    loader = AgentKitAgentLoader(agent)
+
+    # else-branch: root_agent is the agent itself; app_name is agent.name.
+    assert loader.root_agent is agent
+    assert loader.app_name == "my_agent"
+    assert loader.agent_or_app is agent
+
+
+def test_loader_load_agent_returns_wrapped_entry_on_name_match():
+    agent = _FakeAgent(name="my_agent")
+    loader = AgentKitAgentLoader(agent)
+
+    assert loader.load_agent("my_agent") is agent
+
+
+def test_loader_load_agent_raises_value_error_on_unknown_name():
+    agent = _FakeAgent(name="my_agent")
+    loader = AgentKitAgentLoader(agent)
+
+    with pytest.raises(ValueError) as exc_info:
+        loader.load_agent("someone_else")
+
+    # Message names both the unknown request and the one known agent.
+    message = str(exc_info.value)
+    assert "someone_else" in message
+    assert "my_agent" in message
+
+
+def test_loader_list_agents_returns_single_app_name():
+    agent = _FakeAgent(name="my_agent")
+    loader = AgentKitAgentLoader(agent)
+
+    assert loader.list_agents() == ["my_agent"]
+
+
+def test_loader_list_agents_detailed_returns_python_metadata_dict():
+    agent = _FakeAgent(name="my_agent", description="a fake agent")
+    loader = AgentKitAgentLoader(agent)
+
+    assert loader.list_agents_detailed() == [
+        {
+            "name": "my_agent",
+            "root_agent_name": "my_agent",
+            "description": "a fake agent",
+            "language": "python",
+        }
+    ]
+
+
+def test_loader_list_agents_detailed_coerces_missing_description_to_empty_string():
+    # description=None -> the ``or ""`` guard normalizes to the empty string.
+    agent = _FakeAgent(name="my_agent", description=None)
+    loader = AgentKitAgentLoader(agent)
+
+    detailed = loader.list_agents_detailed()
+    assert detailed[0]["description"] == ""
+
+
+def test_loader_list_agents_detailed_coerces_absent_description_attr_to_empty_string():
+    # getattr(..., "description", "") fallback when the attribute is missing.
+    class _NoDescriptionAgent:
+        name = "bare"
+
+    loader = AgentKitAgentLoader(_NoDescriptionAgent())
+
+    detailed = loader.list_agents_detailed()
+    assert detailed[0]["description"] == ""
+    assert detailed[0]["root_agent_name"] == "bare"
+
+
+# ===========================================================================
+# AgentKitAgentLoader -- App branch (agent_server_app.py:70-72)
+# ===========================================================================
+def test_loader_with_app_uses_app_root_agent_and_app_name():
+    app = _make_real_app(
+        app_name="my_app", root_name="root_agent_x", root_desc="root description"
+    )
+    loader = AgentKitAgentLoader(app)
+
+    # App-branch: root_agent comes from app.root_agent; app_name from app.name.
+    assert loader.root_agent is app.root_agent
+    assert loader.root_agent.name == "root_agent_x"
+    assert loader.app_name == "my_app"
+
+
+def test_loader_with_app_load_agent_matches_on_app_name():
+    app = _make_real_app(
+        app_name="my_app", root_name="root_agent_x", root_desc="root description"
+    )
+    loader = AgentKitAgentLoader(app)
+
+    assert loader.load_agent("my_app") is app
+    with pytest.raises(ValueError):
+        # The root agent's name is NOT a valid load key -- only the app name is.
+        loader.load_agent("root_agent_x")
+
+
+def test_loader_with_app_list_agents_detailed_reports_app_and_root_names():
+    app = _make_real_app(
+        app_name="my_app", root_name="root_agent_x", root_desc="root description"
+    )
+    loader = AgentKitAgentLoader(app)
+
+    assert loader.list_agents() == ["my_app"]
+    assert loader.list_agents_detailed() == [
+        {
+            "name": "my_app",
+            "root_agent_name": "root_agent_x",
+            "description": "root description",
+            "language": "python",
+        }
+    ]
+
+
+# NOTE: The ``agent_or_app.name or self.root_agent.name`` fallback on
+# agent_server_app.py:72 (App with a falsy name -> use root_agent.name) is not
+# reachable as a pure unit test: ``App`` construction is rejected by pydantic
+# validation for any empty/falsy name ("must start with a letter ..."), so a
+# falsy-named App instance cannot be built to feed the loader. Branch skipped.
+
+
+# ===========================================================================
+# AgentkitAgentServerApp.__init__ -- early-return validation guards
+# (agent_server_app.py:115-123). Each guard raises before any AdkWebServer /
+# A2A construction, so plain truthy sentinels are enough to trip them.
+# ===========================================================================
+def test_server_app_ctor_raises_type_error_when_short_term_memory_is_none():
+    with pytest.raises(TypeError) as exc_info:
+        AgentkitAgentServerApp(agent=object(), short_term_memory=None)
+
+    assert "short_term_memory is required" in str(exc_info.value)
+
+
+def test_server_app_ctor_raises_type_error_when_both_agent_and_app_provided():
+    # Mutual-exclusion guard fires before any heavy build; sentinels suffice.
+    with pytest.raises(TypeError) as exc_info:
+        AgentkitAgentServerApp(
+            agent=object(),
+            short_term_memory=object(),
+            app=object(),
+        )
+
+    assert "Only one of 'agent' or 'app'" in str(exc_info.value)
+
+
+def test_server_app_ctor_raises_type_error_when_neither_agent_nor_app_provided():
+    # Neither-provided guard fires before any heavy build; sentinel STM only.
+    with pytest.raises(TypeError) as exc_info:
+        AgentkitAgentServerApp(
+            agent=None,
+            short_term_memory=object(),
+            app=None,
+        )
+
+    assert "Either 'agent' or 'app'" in str(exc_info.value)

--- a/tests/apps/test_agent_server_middleware.py
+++ b/tests/apps/test_agent_server_middleware.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit guards for ``AgentkitTelemetryHTTPMiddleware``.
+
+The middleware is a pure ASGI callable: it wraps another ASGI app, opens a
+telemetry span for HTTP requests, strips sensitive headers before handing them
+to the telemetry singleton, and closes the span exactly once when the response
+body finishes (or when the wrapped app raises). These tests drive ``__call__``
+directly with hand-rolled ``scope``/``receive``/``send`` coroutines and spy on
+the module-level ``telemetry`` singleton, so no real OTEL exporter, socket, or
+uvicorn server is involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentkit.apps.agent_server_app import middleware as middleware_mod
+from agentkit.apps.agent_server_app.middleware import AgentkitTelemetryHTTPMiddleware
+
+
+@pytest.fixture
+def fake_telemetry(monkeypatch):
+    """Replace the module-level telemetry singleton with a MagicMock.
+
+    ``tracer.start_span`` must return a usable span object because the real
+    middleware feeds it into ``trace.set_span_in_context``; a MagicMock span is
+    accepted there without touching a real exporter.
+    """
+
+    fake = MagicMock(name="telemetry")
+    monkeypatch.setattr(middleware_mod, "telemetry", fake)
+    return fake
+
+
+async def _noop_receive():  # pragma: no cover - never awaited in these tests
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _make_send_recorder():
+    """Return (send_coro, sent_messages) capturing everything sent downstream."""
+
+    sent = []
+
+    async def _send(message):
+        sent.append(message)
+
+    return _send, sent
+
+
+def test_non_http_scope_is_passed_through_without_touching_telemetry(fake_telemetry):
+    seen = {}
+
+    async def _app(scope, receive, send):
+        seen["scope"] = scope
+        seen["receive"] = receive
+        seen["send"] = send
+        return "app-return-value"
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {"type": "lifespan"}
+    send, _sent = _make_send_recorder()
+
+    result = asyncio.run(mw(scope, _noop_receive, send))
+
+    # The wrapped app is called with the exact same objects, unchanged.
+    assert seen["scope"] is scope
+    assert seen["receive"] is _noop_receive
+    assert seen["send"] is send
+    assert result == "app-return-value"
+
+    # No telemetry interaction at all for non-http scopes.
+    assert fake_telemetry.mock_calls == []
+
+
+def test_http_scope_starts_span_and_calls_trace_agent_server(fake_telemetry):
+    async def _app(scope, receive, send):
+        return None
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/hello",
+        "headers": [(b"content-type", b"application/json")],
+    }
+    send, _sent = _make_send_recorder()
+
+    asyncio.run(mw(scope, _noop_receive, send))
+
+    fake_telemetry.tracer.start_span.assert_called_once_with(name="agent_server_request")
+    fake_telemetry.trace_agent_server.assert_called_once()
+    kwargs = fake_telemetry.trace_agent_server.call_args.kwargs
+    assert kwargs["func_name"] == "GET /hello"
+    assert kwargs["text"] == ""
+    assert kwargs["span"] is fake_telemetry.tracer.start_span.return_value
+    assert kwargs["headers"] == {"content-type": "application/json"}
+
+
+def test_sensitive_headers_are_excluded_before_reaching_telemetry(fake_telemetry):
+    async def _app(scope, receive, send):
+        return None
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/chat",
+        "headers": [
+            (b"authorization", b"Bearer secret-token"),
+            (b"token", b"another-secret"),
+            (b"content-type", b"text/plain"),
+        ],
+    }
+    send, _sent = _make_send_recorder()
+
+    asyncio.run(mw(scope, _noop_receive, send))
+
+    kwargs = fake_telemetry.trace_agent_server.call_args.kwargs
+    headers = kwargs["headers"]
+    assert "authorization" not in headers
+    assert "token" not in headers
+    # The non-sensitive header survives with its decoded value.
+    assert headers == {"content-type": "text/plain"}
+
+
+def test_header_exclusion_is_case_insensitive(fake_telemetry):
+    async def _app(scope, receive, send):
+        return None
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [
+            (b"Authorization", b"Bearer x"),
+            (b"TOKEN", b"y"),
+            (b"X-Custom", b"keep"),
+        ],
+    }
+    send, _sent = _make_send_recorder()
+
+    asyncio.run(mw(scope, _noop_receive, send))
+
+    headers = fake_telemetry.trace_agent_server.call_args.kwargs["headers"]
+    # Keys are preserved verbatim; only the lowercased comparison decides exclusion.
+    assert "Authorization" not in headers
+    assert "TOKEN" not in headers
+    assert headers == {"X-Custom": "keep"}
+
+
+def test_finish_is_called_only_on_final_body_message_not_on_response_start(fake_telemetry):
+    async def _app(scope, receive, send):
+        # A realistic send sequence: start, then a final body chunk.
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        # After the start message, finish must NOT yet have been called.
+        assert fake_telemetry.trace_agent_server_finish.call_count == 0
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {"type": "http", "method": "GET", "path": "/done", "headers": []}
+    send, sent = _make_send_recorder()
+
+    asyncio.run(mw(scope, _noop_receive, send))
+
+    # Exactly one finish, triggered by the final body message.
+    fake_telemetry.trace_agent_server_finish.assert_called_once_with(
+        path="/done", func_result="", exception=None
+    )
+    # Both messages were forwarded downstream in order.
+    assert [m["type"] for m in sent] == [
+        "http.response.start",
+        "http.response.body",
+    ]
+
+
+def test_finish_is_not_called_while_more_body_is_true(fake_telemetry):
+    async def _app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"chunk", "more_body": True})
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {"type": "http", "method": "GET", "path": "/stream", "headers": []}
+    send, sent = _make_send_recorder()
+
+    asyncio.run(mw(scope, _noop_receive, send))
+
+    # more_body=True means the response is not finished, so no finish call.
+    assert fake_telemetry.trace_agent_server_finish.call_count == 0
+    # The chunk is still forwarded downstream.
+    assert [m["type"] for m in sent] == [
+        "http.response.start",
+        "http.response.body",
+    ]
+
+
+def test_body_message_without_more_body_key_defaults_to_finished(fake_telemetry):
+    async def _app(scope, receive, send):
+        # Omitting "more_body" entirely: the middleware defaults it to False,
+        # so the response is treated as finished.
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {"type": "http", "method": "GET", "path": "/nofield", "headers": []}
+    send, _sent = _make_send_recorder()
+
+    asyncio.run(mw(scope, _noop_receive, send))
+
+    fake_telemetry.trace_agent_server_finish.assert_called_once_with(
+        path="/nofield", func_result="", exception=None
+    )
+
+
+def test_wrapped_app_exception_records_finish_with_exception_and_reraises(fake_telemetry):
+    boom = RuntimeError("downstream failure")
+
+    async def _app(scope, receive, send):
+        raise boom
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {"type": "http", "method": "GET", "path": "/boom", "headers": []}
+    send, _sent = _make_send_recorder()
+
+    with pytest.raises(RuntimeError, match="downstream failure") as exc_info:
+        asyncio.run(mw(scope, _noop_receive, send))
+
+    # The very same exception instance is re-raised.
+    assert exc_info.value is boom
+    # finish is called once, on the error path, carrying the exception.
+    fake_telemetry.trace_agent_server_finish.assert_called_once_with(
+        path="/boom", func_result="", exception=boom
+    )
+
+
+def test_context_is_detached_in_finally_even_on_success(monkeypatch, fake_telemetry):
+    # Spy on context attach/detach to prove the finally block runs and pairs up.
+    attached_token = object()
+    detached = []
+
+    monkeypatch.setattr(
+        middleware_mod.context_api, "attach", lambda ctx: attached_token
+    )
+    monkeypatch.setattr(
+        middleware_mod.context_api, "detach", lambda token: detached.append(token)
+    )
+
+    async def _app(scope, receive, send):
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {"type": "http", "method": "GET", "path": "/ok", "headers": []}
+    send, _sent = _make_send_recorder()
+
+    asyncio.run(mw(scope, _noop_receive, send))
+
+    assert detached == [attached_token]
+
+
+def test_context_is_detached_in_finally_even_on_exception(monkeypatch, fake_telemetry):
+    attached_token = object()
+    detached = []
+
+    monkeypatch.setattr(
+        middleware_mod.context_api, "attach", lambda ctx: attached_token
+    )
+    monkeypatch.setattr(
+        middleware_mod.context_api, "detach", lambda token: detached.append(token)
+    )
+
+    async def _app(scope, receive, send):
+        raise ValueError("nope")
+
+    mw = AgentkitTelemetryHTTPMiddleware(_app)
+    scope = {"type": "http", "method": "GET", "path": "/err", "headers": []}
+    send, _sent = _make_send_recorder()
+
+    with pytest.raises(ValueError, match="nope"):
+        asyncio.run(mw(scope, _noop_receive, send))
+
+    # detach still ran despite the exception (finally block), no crash.
+    assert detached == [attached_token]

--- a/tests/apps/test_apps_telemetry.py
+++ b/tests/apps/test_apps_telemetry.py
@@ -1,0 +1,491 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit guards for the per-app telemetry helpers.
+
+These pin the observable behaviour of the ``Telemetry`` helpers that live in
+each ``agentkit.apps.*.telemetry`` module:
+
+* ``simple_app.telemetry`` -- the ``dont_throw`` decorator, ``trace_agent``,
+  ``trace_agent_finish`` (latency recording + exception handling), and
+  ``handle_exception``.
+* ``agent_server_app.telemetry`` -- ``trace_agent_server_finish`` error_type
+  formatting and the ``_INVOKE_PATH`` gate on latency recording.
+* ``mcp_app.telemetry`` -- ``trace_tool`` attribute wiring.
+* ``a2a_app.telemetry`` -- ``handle_exception`` and ``trace_a2a_agent``.
+
+Everything is driven with hand-rolled fakes (no OTEL SDK exporters, no real
+histograms). The trace_* methods are called directly; the ``dont_throw``
+assertions exercise the decorator in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import agentkit.apps.simple_app.telemetry as simple_tel
+import agentkit.apps.agent_server_app.telemetry as server_tel
+import agentkit.apps.mcp_app.telemetry as mcp_tel
+import agentkit.apps.a2a_app.telemetry as a2a_tel
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpanContext:
+    def __init__(self, trace_id: int = 1, span_id: int = 2) -> None:
+        self.trace_id = trace_id
+        self.span_id = span_id
+
+
+class _FakeSpan:
+    """Minimal stand-in for an OTEL Span.
+
+    ``set_attribute`` records into ``.attributes``; the various lifecycle
+    hooks record into flat lists so tests can assert on them.
+    """
+
+    def __init__(self, recording: bool = True, start_time: int = 0) -> None:
+        self.attributes: dict = {}
+        self._recording = recording
+        self._context = _FakeSpanContext()
+        self.statuses: list = []
+        self.recorded_exceptions: list = []
+        self.events: list = []
+        self.ended = False
+        # start_time is read via hasattr(span, "start_time") to gate latency
+        # recording; keep it a real attribute so the branch executes.
+        self.start_time = start_time
+
+    def set_attribute(self, key, value) -> None:
+        self.attributes[key] = value
+
+    def is_recording(self) -> bool:
+        return self._recording
+
+    def get_span_context(self) -> _FakeSpanContext:
+        return self._context
+
+    def set_status(self, status) -> None:
+        self.statuses.append(status)
+
+    def record_exception(self, exception) -> None:
+        self.recorded_exceptions.append(exception)
+
+    def add_event(self, name, attributes=None) -> None:
+        self.events.append((name, attributes))
+
+    def end(self) -> None:
+        self.ended = True
+
+
+class _FakeHistogram:
+    """Records every .record(value, attributes) call."""
+
+    def __init__(self) -> None:
+        self.records: list = []
+
+    def record(self, value, attributes=None) -> None:
+        self.records.append((value, attributes))
+
+
+def _make_func(name: str = "my_agent"):
+    def f():  # pragma: no cover - only __name__ is read
+        return None
+
+    f.__name__ = name
+    return f
+
+
+def _unwrap_dont_throw(wrapper):
+    """Recover the original function wrapped by ``dont_throw``.
+
+    The ``dont_throw`` decorator does not use ``functools.wraps``, so there is
+    no ``__wrapped__``; the original callable lives in the wrapper's closure
+    under the ``func`` free variable. Reaching for it lets us invoke the
+    traced logic directly, bypassing the exception-swallowing wrapper so any
+    error surfaces in the test.
+    """
+    idx = wrapper.__code__.co_freevars.index("func")
+    return wrapper.__closure__[idx].cell_contents
+
+
+# The undecorated trace_agent (invoked directly, per the test brief).
+_simple_trace_agent = _unwrap_dont_throw(simple_tel.Telemetry.trace_agent)
+
+
+# ===========================================================================
+# simple_app.telemetry
+# ===========================================================================
+
+
+def test_dont_throw_swallows_exception_and_returns_none_without_propagating():
+    @simple_tel.dont_throw
+    def boom():
+        raise RuntimeError("kaboom")
+
+    # The wrapper must not propagate; it returns None on failure.
+    assert boom() is None
+
+
+def test_dont_throw_returns_wrapped_value_when_function_succeeds():
+    @simple_tel.dont_throw
+    def ok(a, b):
+        return a + b
+
+    assert ok(2, 3) == 5
+
+
+def test_simple_trace_agent_sets_core_span_attributes():
+    span = _FakeSpan()
+    func = _make_func("handle_run")
+    payload = {"prompt": "hi"}
+    headers = {"content-type": "application/json"}
+
+    # Call the underlying function directly, bypassing dont_throw, so any
+    # error surfaces instead of being swallowed.
+    _simple_trace_agent(simple_tel.telemetry, func, span, payload, headers)
+
+    attrs = span.attributes
+    assert attrs["gen_ai.system"] == "agentkit"
+    assert attrs["gen_ai.func_name"] == "handle_run"
+    assert attrs["gen_ai.span.kind"] == "workflow"
+    assert attrs["gen_ai.operation.name"] == "invoke_agent"
+    assert attrs["gen_ai.operation.type"] == "agent"
+    assert attrs["gen_ai.request.headers"] == json.dumps(headers, ensure_ascii=False)
+    assert attrs["gen_ai.input"] == json.dumps(payload, ensure_ascii=False)
+
+
+def test_simple_trace_agent_sets_session_and_user_ids_only_when_in_headers():
+    span_with = _FakeSpan()
+    _simple_trace_agent(
+        simple_tel.telemetry,
+        _make_func(),
+        span_with,
+        {},
+        {"session_id": "sess-1", "user_id": "user-1"},
+    )
+    assert span_with.attributes["gen_ai.session.id"] == "sess-1"
+    assert span_with.attributes["gen_ai.user.id"] == "user-1"
+
+    span_without = _FakeSpan()
+    _simple_trace_agent(simple_tel.telemetry, _make_func(), span_without, {}, {})
+    assert "gen_ai.session.id" not in span_without.attributes
+    assert "gen_ai.user.id" not in span_without.attributes
+
+
+def test_simple_trace_agent_finish_sets_output_and_records_latency(monkeypatch):
+    fake_hist = _FakeHistogram()
+    span = _FakeSpan(recording=True, start_time=0)
+
+    monkeypatch.setattr(simple_tel.telemetry, "latency_histogram", fake_hist)
+    monkeypatch.setattr(simple_tel.trace, "get_current_span", lambda: span)
+
+    simple_tel.telemetry.trace_agent_finish("the-output", None)
+
+    assert span.attributes["gen_ai.output"] == "the-output"
+    assert span.ended is True
+    # No exception -> exactly one latency record with the base attributes only.
+    assert len(fake_hist.records) == 1
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["gen_ai_operation_name"] == "invoke_agent"
+    assert attributes["gen_ai_operation_type"] == "agent"
+    assert "error_type" not in attributes
+
+
+def test_simple_trace_agent_finish_on_exception_sets_error_type_and_handles(
+    monkeypatch,
+):
+    fake_hist = _FakeHistogram()
+    span = _FakeSpan(recording=True, start_time=0)
+    monkeypatch.setattr(simple_tel.telemetry, "latency_histogram", fake_hist)
+    monkeypatch.setattr(simple_tel.trace, "get_current_span", lambda: span)
+
+    exc = ValueError("bad input")
+    simple_tel.telemetry.trace_agent_finish("out", exc)
+
+    # handle_exception must have run: ERROR status set + exception recorded.
+    assert span.recorded_exceptions == [exc]
+    assert len(span.statuses) == 1
+    assert span.statuses[0].status_code == simple_tel.trace.StatusCode.ERROR
+    # error_type carried into the latency attributes.
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["error_type"] == "ValueError"
+
+
+def test_simple_trace_agent_finish_is_noop_when_span_not_recording(monkeypatch):
+    fake_hist = _FakeHistogram()
+    span = _FakeSpan(recording=False, start_time=0)
+    monkeypatch.setattr(simple_tel.telemetry, "latency_histogram", fake_hist)
+    monkeypatch.setattr(simple_tel.trace, "get_current_span", lambda: span)
+
+    simple_tel.telemetry.trace_agent_finish("out", None)
+
+    assert "gen_ai.output" not in span.attributes
+    assert span.ended is False
+    assert fake_hist.records == []
+
+
+def test_simple_handle_exception_sets_error_status_and_records_exception():
+    span = _FakeSpan()
+    exc = KeyError("missing")
+
+    simple_tel.Telemetry.handle_exception(span, exc)
+
+    assert span.recorded_exceptions == [exc]
+    assert len(span.statuses) == 1
+    status = span.statuses[0]
+    assert status.status_code == simple_tel.trace.StatusCode.ERROR
+    assert "KeyError" in status.description
+
+
+# ===========================================================================
+# agent_server_app.telemetry
+# ===========================================================================
+
+
+class _StatusCodeExc(Exception):
+    """Exception carrying a truthy status_code attribute."""
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def test_server_trace_agent_server_finish_error_type_includes_status_code(monkeypatch):
+    fake_hist = _FakeHistogram()
+    span = _FakeSpan(recording=True, start_time=0)
+    monkeypatch.setattr(server_tel.telemetry, "latency_histogram", fake_hist)
+    monkeypatch.setattr(server_tel.trace, "get_current_span", lambda: span)
+
+    exc = _StatusCodeExc("nope", 503)
+    server_tel.telemetry.trace_agent_server_finish("/run", "result", exc)
+
+    assert len(fake_hist.records) == 1
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["error_type"] == "_StatusCodeExc_503"
+    # handle_exception still ran.
+    assert span.recorded_exceptions == [exc]
+
+
+def test_server_trace_agent_server_finish_error_type_is_plain_class_without_status(
+    monkeypatch,
+):
+    fake_hist = _FakeHistogram()
+    span = _FakeSpan(recording=True, start_time=0)
+    monkeypatch.setattr(server_tel.telemetry, "latency_histogram", fake_hist)
+    monkeypatch.setattr(server_tel.trace, "get_current_span", lambda: span)
+
+    exc = ValueError("plain")
+    server_tel.telemetry.trace_agent_server_finish("/invoke", "result", exc)
+
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["error_type"] == "ValueError"
+
+
+def test_server_latency_recorded_only_for_invoke_paths(monkeypatch):
+    # Matching path -> record fires.
+    for path in ("/run_sse", "/run", "/invoke"):
+        fake_hist = _FakeHistogram()
+        span = _FakeSpan(recording=True, start_time=0)
+        monkeypatch.setattr(server_tel.telemetry, "latency_histogram", fake_hist)
+        monkeypatch.setattr(server_tel.trace, "get_current_span", lambda: span)
+
+        server_tel.telemetry.trace_agent_server_finish(path, "result", None)
+
+        assert len(fake_hist.records) == 1, f"expected a record for path {path}"
+        assert span.ended is True
+
+
+def test_server_latency_not_recorded_for_non_invoke_path(monkeypatch):
+    fake_hist = _FakeHistogram()
+    span = _FakeSpan(recording=True, start_time=0)
+    monkeypatch.setattr(server_tel.telemetry, "latency_histogram", fake_hist)
+    monkeypatch.setattr(server_tel.trace, "get_current_span", lambda: span)
+
+    server_tel.telemetry.trace_agent_server_finish("/healthz", "result", None)
+
+    # Path is not in _INVOKE_PATH -> no latency recorded, but span still ends.
+    assert fake_hist.records == []
+    assert span.ended is True
+
+
+def test_server_status_code_falsy_falls_back_to_plain_class_name(monkeypatch):
+    # status_code present but falsy (0) -> getattr(..., None) is falsy -> plain name.
+    fake_hist = _FakeHistogram()
+    span = _FakeSpan(recording=True, start_time=0)
+    monkeypatch.setattr(server_tel.telemetry, "latency_histogram", fake_hist)
+    monkeypatch.setattr(server_tel.trace, "get_current_span", lambda: span)
+
+    exc = _StatusCodeExc("zero", 0)
+    server_tel.telemetry.trace_agent_server_finish("/run", "result", exc)
+
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["error_type"] == "_StatusCodeExc"
+
+
+# ===========================================================================
+# mcp_app.telemetry
+# ===========================================================================
+
+
+def test_mcp_trace_tool_sets_operation_type_and_io_attributes():
+    span = _FakeSpan(recording=True, start_time=0)
+    fake_hist = _FakeHistogram()
+    mcp_tel.telemetry.latency_histogram = fake_hist  # reset below in fixture
+
+    func = _make_func("multiply")
+    args = {"a": 2, "b": 3}
+    result = {"value": 6}
+
+    mcp_tel.telemetry.trace_tool(
+        func, span, args, result, operation_type="my_op", exception=None
+    )
+
+    attrs = span.attributes
+    assert attrs["gen_ai.operation.type"] == "my_op"
+    assert attrs["gen_ai.system"] == "agentkit"
+    assert attrs["gen_ai.func_name"] == "multiply"
+    assert attrs["gen_ai.span.kind"] == "tool"
+    assert attrs["gen_ai.operation.name"] == "tool"
+    assert attrs["gen_ai.input"] == json.dumps(args, ensure_ascii=False)
+    assert attrs["gen_ai.output"] == json.dumps(result, ensure_ascii=False)
+    # latency recorded once with base attributes (no exception).
+    assert len(fake_hist.records) == 1
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["gen_ai_operation_type"] == "my_op"
+    assert "error_type" not in attributes
+
+
+@pytest.fixture(autouse=True)
+def _restore_mcp_histogram():
+    # test_mcp_trace_tool_* replaces the module singleton's histogram; restore.
+    original = mcp_tel.telemetry.latency_histogram
+    yield
+    mcp_tel.telemetry.latency_histogram = original
+
+
+def test_mcp_trace_tool_records_error_type_on_exception(monkeypatch):
+    span = _FakeSpan(recording=True, start_time=0)
+    fake_hist = _FakeHistogram()
+    monkeypatch.setattr(mcp_tel.telemetry, "latency_histogram", fake_hist)
+
+    exc = RuntimeError("tool failed")
+    mcp_tel.telemetry.trace_tool(
+        _make_func("t"),
+        span,
+        {"x": 1},
+        None,
+        operation_type="op",
+        exception=exc,
+    )
+
+    assert span.recorded_exceptions == [exc]
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["error_type"] == "RuntimeError"
+
+
+# ===========================================================================
+# a2a_app.telemetry
+# ===========================================================================
+
+
+def test_a2a_handle_exception_sets_error_status_and_records_exception():
+    span = _FakeSpan()
+    exc = ValueError("a2a boom")
+
+    a2a_tel.Telemetry.handle_exception(span, exc)
+
+    assert span.recorded_exceptions == [exc]
+    assert len(span.statuses) == 1
+    status = span.statuses[0]
+    assert status.status_code == a2a_tel.trace.StatusCode.ERROR
+    assert "ValueError" in status.description
+
+
+class _FakePart:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeMessage:
+    def __init__(self, parts) -> None:
+        self.parts = parts
+
+
+class _FakeRequestContext:
+    """RequestContext-like object satisfying trace_a2a_agent + _get_user_id.
+
+    ``_get_user_id`` reads ``call_context`` (None here -> fall back path) and
+    ``context_id``; ``trace_a2a_agent`` reads ``context_id`` and
+    ``message.parts``.
+    """
+
+    def __init__(self, context_id: str, parts) -> None:
+        self.context_id = context_id
+        self.message = _FakeMessage(parts)
+        self.call_context = None
+
+
+def test_a2a_trace_a2a_agent_sets_attributes_and_derives_user_from_context_id():
+    span = _FakeSpan(recording=True, start_time=0)
+    fake_hist = _FakeHistogram()
+    a2a_tel.telemetry.latency_histogram = fake_hist  # restored by fixture below
+
+    request = _FakeRequestContext("ctx-42", [_FakePart("hello")])
+
+    a2a_tel.telemetry.trace_a2a_agent(
+        _make_func("a2a_handler"), span, request, result=None, exception=None
+    )
+
+    attrs = span.attributes
+    assert attrs["gen_ai.system"] == "agentkit"
+    assert attrs["gen_ai.func_name"] == "a2a_handler"
+    assert attrs["gen_ai.span.kind"] == "a2a_agent"
+    assert attrs["gen_ai.operation.type"] == "a2a_agent"
+    assert attrs["gen_ai.session.id"] == "ctx-42"
+    # _get_user_id falls back to A2A_USER_<context_id> when no call_context user.
+    assert attrs["gen_ai.user.id"] == "A2A_USER_ctx-42"
+    assert attrs["gen_ai.input"] == a2a_tel.safe_serialize_to_json_string(
+        request.message.parts
+    )
+    assert len(fake_hist.records) == 1
+
+
+@pytest.fixture(autouse=True)
+def _restore_a2a_histogram():
+    original = a2a_tel.telemetry.latency_histogram
+    yield
+    a2a_tel.telemetry.latency_histogram = original
+
+
+def test_a2a_trace_a2a_agent_records_error_type_on_exception(monkeypatch):
+    span = _FakeSpan(recording=True, start_time=0)
+    fake_hist = _FakeHistogram()
+    monkeypatch.setattr(a2a_tel.telemetry, "latency_histogram", fake_hist)
+
+    request = _FakeRequestContext("ctx-1", [_FakePart("hi")])
+    exc = RuntimeError("a2a failed")
+
+    a2a_tel.telemetry.trace_a2a_agent(
+        _make_func(), span, request, result=None, exception=exc
+    )
+
+    assert span.recorded_exceptions == [exc]
+    _duration, attributes = fake_hist.records[0]
+    assert attributes["error_type"] == "RuntimeError"

--- a/tests/apps/test_mcp_app.py
+++ b/tests/apps/test_mcp_app.py
@@ -1,0 +1,443 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit guards for ``agentkit.apps.mcp_app.mcp_app.AgentkitMCPApp``.
+
+These tests exercise the decorator/registration surface of the MCP app without
+ever calling ``run()`` (which would bind a socket via uvicorn). We spy on the
+``FastMCP`` server's ``tool`` method to capture the wrapper that gets registered,
+and we replace the module-level ``telemetry`` singleton with a hand-rolled fake
+so we can assert how ``trace_tool`` is invoked (operation type, argument shape)
+for both the sync and the coroutine code paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentkit.apps.mcp_app import mcp_app as mcp_app_module
+from agentkit.apps.mcp_app.mcp_app import AgentkitMCPApp
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpan:
+    """Minimal span honouring the ``start_as_current_span`` context manager."""
+
+    def __init__(self) -> None:
+        self.attributes: dict = {}
+        self.ended = False
+
+    def set_attribute(self, key=None, value=None, **_kw) -> None:
+        self.attributes[key] = value
+
+    def is_recording(self) -> bool:
+        return True
+
+    def get_span_context(self):
+        return object()
+
+    def set_status(self, *_a, **_kw) -> None:
+        pass
+
+    def record_exception(self, *_a, **_kw) -> None:
+        pass
+
+    def add_event(self, *_a, **_kw) -> None:
+        pass
+
+    def end(self, *_a, **_kw) -> None:
+        self.ended = True
+
+
+class _FakeSpanCM:
+    """Context manager returned by ``tracer.start_as_current_span``."""
+
+    def __init__(self, span: _FakeSpan) -> None:
+        self._span = span
+
+    def __enter__(self) -> _FakeSpan:
+        return self._span
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+class _FakeTracer:
+    def __init__(self) -> None:
+        self.span = _FakeSpan()
+
+    def start_as_current_span(self, name=None, **_kw) -> _FakeSpanCM:
+        return _FakeSpanCM(self.span)
+
+
+class _FakeTelemetry:
+    """Spy standing in for the module-level ``telemetry`` singleton."""
+
+    def __init__(self) -> None:
+        self.tracer = _FakeTracer()
+        self.calls: list[dict] = []
+
+    def trace_tool(
+        self,
+        func=None,
+        span=None,
+        args=None,
+        func_result=None,
+        operation_type=None,
+        exception=None,
+    ) -> None:
+        self.calls.append(
+            {
+                "func": func,
+                "span": span,
+                "args": args,
+                "func_result": func_result,
+                "operation_type": operation_type,
+                "exception": exception,
+            }
+        )
+
+
+class _FakeMCPServer:
+    """Captures every callable registered via ``.tool``."""
+
+    def __init__(self) -> None:
+        self.registered: list = []
+
+    def tool(self, func):
+        self.registered.append(func)
+        return func
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (local to this file)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_telemetry(monkeypatch) -> _FakeTelemetry:
+    fake = _FakeTelemetry()
+    monkeypatch.setattr(mcp_app_module, "telemetry", fake)
+    return fake
+
+
+@pytest.fixture
+def app(monkeypatch, fake_telemetry) -> AgentkitMCPApp:
+    """An app whose real ``FastMCP`` server is swapped for a capturing fake.
+
+    We build the app first (letting the ctor construct the real FastMCP, which
+    performs no I/O) and then replace ``_mcp_server`` so registrations are
+    captured without hitting the actual server.
+    """
+    instance = AgentkitMCPApp()
+    instance._mcp_server = _FakeMCPServer()
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_builds_a_fastmcp_server_without_binding_sockets():
+    from fastmcp import FastMCP
+
+    instance = AgentkitMCPApp()
+
+    assert isinstance(instance._mcp_server, FastMCP)
+
+
+# ---------------------------------------------------------------------------
+# tool() decorator
+# ---------------------------------------------------------------------------
+
+
+def test_tool_decorator_returns_the_same_func_object_for_sync_func(app):
+    def my_sync_tool(x):
+        return x + 1
+
+    returned = app.tool(my_sync_tool)
+
+    assert returned is my_sync_tool
+
+
+def test_tool_decorator_returns_the_same_func_object_for_async_func(app):
+    async def my_async_tool(x):
+        return x + 1
+
+    returned = app.tool(my_async_tool)
+
+    assert returned is my_async_tool
+
+
+def test_tool_decorator_registers_a_wrapper_not_the_original_sync_func(app):
+    def my_sync_tool(x):
+        return x + 1
+
+    app.tool(my_sync_tool)
+
+    assert len(app._mcp_server.registered) == 1
+    registered = app._mcp_server.registered[0]
+    # A wraps() wrapper preserves __name__ but is a distinct object.
+    assert registered is not my_sync_tool
+    assert registered.__name__ == "my_sync_tool"
+
+
+def test_tool_decorator_registers_a_wrapper_not_the_original_async_func(app):
+    async def my_async_tool(x):
+        return x + 1
+
+    app.tool(my_async_tool)
+
+    assert len(app._mcp_server.registered) == 1
+    registered = app._mcp_server.registered[0]
+    assert registered is not my_async_tool
+    assert registered.__name__ == "my_async_tool"
+
+
+def test_invoking_sync_tool_wrapper_returns_result_and_traces_as_mcp_tool(
+    app, fake_telemetry
+):
+    def my_sync_tool(x):
+        return x * 10
+
+    app.tool(my_sync_tool)
+    wrapper = app._mcp_server.registered[0]
+
+    result = wrapper(5)
+
+    assert result == 50
+    assert len(fake_telemetry.calls) == 1
+    call = fake_telemetry.calls[0]
+    assert call["func"] is my_sync_tool
+    assert call["operation_type"] == "mcp_tool"
+    assert call["func_result"] == 50
+    assert call["exception"] is None
+    # The sync branch forwards the positional args tuple.
+    assert call["args"] == (5,)
+    assert call["span"] is fake_telemetry.tracer.span
+
+
+def test_invoking_async_tool_wrapper_returns_result_and_traces_as_mcp_tool(
+    app, fake_telemetry
+):
+    async def my_async_tool(x):
+        return x * 10
+
+    app.tool(my_async_tool)
+    wrapper = app._mcp_server.registered[0]
+
+    result = asyncio.run(wrapper(5))
+
+    assert result == 50
+    assert len(fake_telemetry.calls) == 1
+    call = fake_telemetry.calls[0]
+    assert call["func"] is my_async_tool
+    assert call["operation_type"] == "mcp_tool"
+    assert call["func_result"] == 50
+    assert call["exception"] is None
+    assert call["args"] == (5,)
+
+
+def test_invoking_sync_tool_wrapper_raises_unbound_local_error_when_func_fails(
+    app, fake_telemetry
+):
+    boom = ValueError("kaboom")
+
+    def failing_tool():
+        raise boom
+
+    app.tool(failing_tool)
+    wrapper = app._mcp_server.registered[0]
+
+    # NOTE: latent bug -- when the wrapped func raises, ``result`` is never
+    # assigned, so the ``finally`` block's ``telemetry.trace_tool(..., func_result=result, ...)``
+    # dereferences an unbound local. That UnboundLocalError is raised out of the
+    # ``finally`` and MASKS the original ValueError, so trace_tool is never
+    # invoked. We pin the actual current behavior: an UnboundLocalError, not the
+    # original ValueError, escapes and no telemetry call is recorded.
+    with pytest.raises(UnboundLocalError):
+        wrapper()
+
+    assert fake_telemetry.calls == []
+
+
+def test_invoking_async_tool_wrapper_raises_unbound_local_error_when_func_fails(
+    app, fake_telemetry
+):
+    boom = ValueError("kaboom")
+
+    async def failing_tool():
+        raise boom
+
+    app.tool(failing_tool)
+    wrapper = app._mcp_server.registered[0]
+
+    # NOTE: latent bug -- see sync counterpart. The async wrapper's ``finally``
+    # references the unbound ``result``, raising UnboundLocalError that masks the
+    # original ValueError; trace_tool is never reached.
+    with pytest.raises(UnboundLocalError):
+        asyncio.run(wrapper())
+
+    assert fake_telemetry.calls == []
+
+
+# ---------------------------------------------------------------------------
+# agent_as_a_tool()
+# ---------------------------------------------------------------------------
+
+
+def test_agent_as_a_tool_returns_the_same_func_object_for_sync_func(app):
+    def my_agent(x):
+        return x
+
+    returned = app.agent_as_a_tool(my_agent)
+
+    assert returned is my_agent
+
+
+def test_agent_as_a_tool_returns_the_same_func_object_for_async_func(app):
+    async def my_agent(x):
+        return x
+
+    returned = app.agent_as_a_tool(my_agent)
+
+    assert returned is my_agent
+
+
+def test_agent_as_a_tool_registers_a_wrapper_not_the_original_sync_func(app):
+    def my_agent(x):
+        return x
+
+    app.agent_as_a_tool(my_agent)
+
+    assert len(app._mcp_server.registered) == 1
+    assert app._mcp_server.registered[0] is not my_agent
+    assert app._mcp_server.registered[0].__name__ == "my_agent"
+
+
+def test_invoking_sync_agent_tool_wrapper_traces_as_agent_mcp_tool_with_positional_args(
+    app, fake_telemetry
+):
+    def my_agent(a, b):
+        return a + b
+
+    app.agent_as_a_tool(my_agent)
+    wrapper = app._mcp_server.registered[0]
+
+    result = wrapper(2, 3)
+
+    assert result == 5
+    assert len(fake_telemetry.calls) == 1
+    call = fake_telemetry.calls[0]
+    assert call["operation_type"] == "agent_mcp_tool"
+    assert call["func"] is my_agent
+    assert call["func_result"] == 5
+    # Sync branch (source :135) forwards the positional args tuple to
+    # trace_tool's third positional parameter.
+    assert call["args"] == (2, 3)
+
+
+def test_invoking_async_agent_tool_wrapper_traces_as_agent_mcp_tool_with_args_as_keyword(
+    app, fake_telemetry
+):
+    async def my_agent(a, b):
+        return a + b
+
+    app.agent_as_a_tool(my_agent)
+    wrapper = app._mcp_server.registered[0]
+
+    result = asyncio.run(wrapper(2, 3))
+
+    assert result == 5
+    assert len(fake_telemetry.calls) == 1
+    call = fake_telemetry.calls[0]
+    assert call["operation_type"] == "agent_mcp_tool"
+    assert call["func"] is my_agent
+    assert call["func_result"] == 5
+    # NOTE: the async branch (source :112) passes ``args=args`` as a keyword,
+    # while the sync branch (source :135) passes it positionally. Because
+    # Telemetry.trace_tool declares ``args`` as its third parameter, both bind
+    # to the same slot -- the observable payload is identical: the positional
+    # args tuple. This pins that current behavior.
+    assert call["args"] == (2, 3)
+
+
+def test_invoking_async_agent_tool_wrapper_raises_unbound_local_error_when_func_fails(
+    app, fake_telemetry
+):
+    boom = RuntimeError("agent boom")
+
+    async def failing_agent():
+        raise boom
+
+    app.agent_as_a_tool(failing_agent)
+    wrapper = app._mcp_server.registered[0]
+
+    # NOTE: latent bug -- same unbound-``result`` defect as the tool() wrappers.
+    # The ``finally`` block raises UnboundLocalError, masking the original
+    # RuntimeError, and trace_tool is never called.
+    with pytest.raises(UnboundLocalError):
+        asyncio.run(wrapper())
+
+    assert fake_telemetry.calls == []
+
+
+# ---------------------------------------------------------------------------
+# add_env_detect_tool()
+# ---------------------------------------------------------------------------
+
+
+def test_add_env_detect_tool_registers_a_single_get_env_callable(app):
+    app.add_env_detect_tool()
+
+    assert len(app._mcp_server.registered) == 1
+    get_env = app._mcp_server.registered[0]
+    assert get_env.__name__ == "get_env"
+
+
+def test_env_detect_tool_reports_agentkit_when_iam_role_trn_is_set(app, monkeypatch):
+    app.add_env_detect_tool()
+    get_env = app._mcp_server.registered[0]
+
+    monkeypatch.setenv("RUNTIME_IAM_ROLE_TRN", "trn:some:role")
+
+    assert get_env() == {"env": "agentkit"}
+
+
+def test_env_detect_tool_reports_veadk_when_iam_role_trn_is_absent(app, monkeypatch):
+    app.add_env_detect_tool()
+    get_env = app._mcp_server.registered[0]
+
+    monkeypatch.delenv("RUNTIME_IAM_ROLE_TRN", raising=False)
+
+    assert get_env() == {"env": "veadk"}
+
+
+def test_env_detect_tool_reports_veadk_when_iam_role_trn_is_empty_string(
+    app, monkeypatch
+):
+    app.add_env_detect_tool()
+    get_env = app._mcp_server.registered[0]
+
+    # An empty string is falsy, so is_agentkit_runtime() returns False.
+    monkeypatch.setenv("RUNTIME_IAM_ROLE_TRN", "")
+
+    assert get_env() == {"env": "veadk"}

--- a/tests/apps/test_simple_app.py
+++ b/tests/apps/test_simple_app.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline route + wiring guards for ``AgentkitSimpleApp``.
+
+``AgentkitSimpleApp`` is a no-arg Starlette application exposing five routes
+(``/ping``, ``/health``, ``/readiness``, ``/liveness``, ``/invoke``). These
+tests drive it through ``starlette.testclient.TestClient`` (which pumps the
+async handlers synchronously) and never touch a socket -- ``.run()`` is never
+called. They pin:
+
+* the JSON shape of the three probe endpoints and their ``service`` field,
+* ``/ping`` returning 404 until a ping function is registered and
+  ``{"status": <value>}`` afterwards,
+* the zero-argument guard inside ``AgentkitSimpleApp.ping``, and
+* the ``entrypoint`` wiring onto ``invoke_handler.func``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from agentkit.apps.simple_app.simple_app import AgentkitSimpleApp
+
+
+@pytest.fixture()
+def app() -> AgentkitSimpleApp:
+    return AgentkitSimpleApp()
+
+
+@pytest.fixture()
+def client(app: AgentkitSimpleApp) -> TestClient:
+    return TestClient(app)
+
+
+def test_health_endpoint_returns_healthy_status_and_agent_service(client: TestClient):
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["service"] == "agent-service"
+    assert isinstance(body["timestamp"], (int, float))
+
+
+def test_readiness_endpoint_returns_success_status_and_agent_service(client: TestClient):
+    response = client.get("/readiness")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["service"] == "agent-service"
+    assert isinstance(body["timestamp"], (int, float))
+
+
+def test_liveness_endpoint_returns_success_status_and_agent_service(client: TestClient):
+    response = client.get("/liveness")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["service"] == "agent-service"
+    assert isinstance(body["timestamp"], (int, float))
+
+
+def test_all_probe_endpoints_report_the_same_service_identifier(client: TestClient):
+    services = {
+        client.get(path).json()["service"]
+        for path in ("/health", "/readiness", "/liveness")
+    }
+    assert services == {"agent-service"}
+
+
+def test_ping_returns_404_before_any_ping_function_is_registered(client: TestClient):
+    response = client.get("/ping")
+
+    assert response.status_code == 404
+
+
+def test_ping_returns_registered_function_result_wrapped_in_status(
+    app: AgentkitSimpleApp, client: TestClient
+):
+    app.ping(lambda: "pong")
+
+    response = client.get("/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "pong"}
+
+
+def test_ping_wraps_a_non_string_return_value_verbatim_under_status(
+    app: AgentkitSimpleApp, client: TestClient
+):
+    # PingHandler.handle wraps the raw return value in {"status": result}
+    # directly (it does not route through _format_ping_status), so a plain
+    # int survives as-is.
+    app.ping(lambda: 1)
+
+    response = client.get("/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": 1}
+
+
+def test_ping_accepts_a_zero_argument_function(app: AgentkitSimpleApp):
+    def health() -> str:
+        return "ok"
+
+    returned = app.ping(health)
+
+    # ping() returns the function unchanged (decorator style) and wires it up.
+    assert returned is health
+    assert app.ping_handler.func is health
+
+
+def test_ping_rejects_a_function_that_declares_parameters(app: AgentkitSimpleApp):
+    def health(request):  # noqa: ANN001 - shape under test
+        return "ok"
+
+    with pytest.raises(TypeError) as excinfo:
+        app.ping(health)
+
+    assert "health" in str(excinfo.value)
+    # The rejected function must not be wired onto the handler.
+    assert app.ping_handler.func is None
+
+
+def test_ping_rejects_a_lambda_that_takes_a_parameter(app: AgentkitSimpleApp):
+    with pytest.raises(TypeError):
+        app.ping(lambda x: x)
+
+    assert app.ping_handler.func is None
+
+
+def test_entrypoint_wires_the_function_onto_invoke_handler_and_returns_it(
+    app: AgentkitSimpleApp,
+):
+    def agent(payload):  # noqa: ANN001 - shape under test
+        return payload
+
+    returned = app.entrypoint(agent)
+
+    assert returned is agent
+    assert app.invoke_handler.func is agent
+
+
+def test_fresh_app_has_no_entrypoint_or_ping_function_registered(
+    app: AgentkitSimpleApp,
+):
+    assert app.invoke_handler.func is None
+    assert app.ping_handler.func is None

--- a/tests/apps/test_simple_app_handlers.py
+++ b/tests/apps/test_simple_app_handlers.py
@@ -1,0 +1,540 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the simple_app request handlers.
+
+Covers the pure helpers (`_build_error_content`, `_convert_to_sse`,
+`_format_ping_status`), the entrypoint-dispatch logic of
+`InvokeHandler._process_invoke`, the full HTTP response matrix of
+`InvokeHandler.handle` (driven through a Starlette TestClient), and the
+in-memory bookkeeping of `AsyncTaskHandler`.
+
+The telemetry singleton attached to the ``handle`` path binds real OTEL
+tracer/meter objects, so tests that exercise ``handle`` swap the module-level
+``telemetry`` for a hand-rolled fake. This keeps the tests deterministic and
+free of any real exporter, while still driving the async handlers synchronously
+via the TestClient / ``asyncio.run``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from starlette.exceptions import HTTPException
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.testclient import TestClient
+
+import agentkit.apps.simple_app.simple_app_handlers as handlers_mod
+from agentkit.apps.simple_app.simple_app import AgentkitSimpleApp
+from agentkit.apps.simple_app.simple_app_handlers import (
+    AsyncTaskHandler,
+    InvalidJSONPayloadError,
+    InvokeHandler,
+    PingHandler,
+    _build_error_content,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpanContext:
+    def __init__(self) -> None:
+        self.trace_id = 0
+        self.span_id = 0
+
+
+class _FakeSpan:
+    def __init__(self) -> None:
+        self.attributes: dict = {}
+        self.ended = False
+        self.status = None
+        self.recorded_exceptions: list = []
+        self.events: list = []
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def is_recording(self):
+        return True
+
+    def get_span_context(self):
+        return _FakeSpanContext()
+
+    def set_status(self, status):
+        self.status = status
+
+    def record_exception(self, exc):
+        self.recorded_exceptions.append(exc)
+
+    def add_event(self, *args, **kwargs):
+        self.events.append((args, kwargs))
+
+    def end(self):
+        self.ended = True
+
+
+class _FakeTracer:
+    def __init__(self) -> None:
+        self.spans: list = []
+
+    def start_span(self, name=None, **kwargs):
+        span = _FakeSpan()
+        self.spans.append(span)
+        return span
+
+
+class _FakeTelemetry:
+    """Records calls instead of touching real OTEL exporters."""
+
+    def __init__(self) -> None:
+        self.tracer = _FakeTracer()
+        self.trace_agent_calls: list = []
+        self.finish_calls: list = []
+
+    def trace_agent(self, func, span, payload, headers):
+        self.trace_agent_calls.append((func, span, payload, headers))
+
+    def trace_agent_finish(self, func_result, exception):
+        self.finish_calls.append((func_result, exception))
+
+
+class _FakeHeaders:
+    """Minimal mapping stand-in that survives dict(...) conversion."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = dict(data)
+
+    def keys(self):
+        return self._data.keys()
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
+class _FakeRequest:
+    """Async request stand-in for exercising `_process_invoke` directly."""
+
+    def __init__(self, payload=None, headers=None, raise_json=False) -> None:
+        self._payload = {} if payload is None else payload
+        self.headers = _FakeHeaders(headers or {})
+        self._raise_json = raise_json
+
+    async def json(self):
+        if self._raise_json:
+            import json as _json
+
+            # Trigger the real JSONDecodeError path taken by Request.json().
+            _json.loads("not json")
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _spy_telemetry(monkeypatch):
+    """Swap the module-level telemetry singleton for a fake on every test."""
+    fake = _FakeTelemetry()
+    monkeypatch.setattr(handlers_mod, "telemetry", fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# _build_error_content
+# ---------------------------------------------------------------------------
+
+
+def test_build_error_content_returns_nested_error_dict_shape():
+    assert _build_error_content(message="boom", error_type="BadRequest") == {
+        "error": {"message": "boom", "type": "BadRequest"}
+    }
+
+
+# ---------------------------------------------------------------------------
+# Instantiability with no args
+# ---------------------------------------------------------------------------
+
+
+def test_all_handlers_are_instantiable_with_no_arguments():
+    assert InvokeHandler().func is None
+    assert PingHandler().func is None
+    async_handler = AsyncTaskHandler()
+    assert async_handler.func is None
+    assert async_handler._active_tasks == {}
+
+
+# ---------------------------------------------------------------------------
+# InvokeHandler._process_invoke dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_process_invoke_zero_param_entrypoint_is_called_with_no_args():
+    handler = InvokeHandler()
+
+    def entrypoint():
+        return {"called": "no-args"}
+
+    handler.func = entrypoint
+    request = _FakeRequest(payload={"ignored": True}, headers={"h": "v"})
+    payload, headers, result = asyncio.run(handler._process_invoke(request))
+
+    assert payload == {"ignored": True}
+    assert headers == {"h": "v"}
+    assert result == {"called": "no-args"}
+
+
+def test_process_invoke_single_param_named_request_receives_the_request():
+    handler = InvokeHandler()
+
+    def entrypoint(Request):  # case-insensitive match on "request"
+        return {"is_request": Request is captured["req"]}
+
+    captured: dict = {}
+    handler.func = entrypoint
+    request = _FakeRequest(payload={"a": 1})
+    captured["req"] = request
+    _, _, result = asyncio.run(handler._process_invoke(request))
+
+    assert result == {"is_request": True}
+
+
+def test_process_invoke_single_param_other_name_receives_the_payload_dict():
+    handler = InvokeHandler()
+
+    def entrypoint(payload):
+        return {"echo": payload}
+
+    handler.func = entrypoint
+    request = _FakeRequest(payload={"x": 42})
+    _, _, result = asyncio.run(handler._process_invoke(request))
+
+    assert result == {"echo": {"x": 42}}
+
+
+def test_process_invoke_two_param_entrypoint_receives_payload_and_headers():
+    handler = InvokeHandler()
+
+    def entrypoint(payload, headers):
+        return {"payload": payload, "headers": headers}
+
+    handler.func = entrypoint
+    request = _FakeRequest(payload={"k": "v"}, headers={"user_id": "u1"})
+    _, _, result = asyncio.run(handler._process_invoke(request))
+
+    assert result == {"payload": {"k": "v"}, "headers": {"user_id": "u1"}}
+
+
+def test_process_invoke_supports_async_coroutine_entrypoint():
+    handler = InvokeHandler()
+
+    async def entrypoint(payload):
+        return {"async_echo": payload}
+
+    handler.func = entrypoint
+    request = _FakeRequest(payload={"n": 7})
+    _, _, result = asyncio.run(handler._process_invoke(request))
+
+    assert result == {"async_echo": {"n": 7}}
+
+
+def test_process_invoke_malformed_json_body_raises_invalid_json_payload_error():
+    handler = InvokeHandler()
+
+    def entrypoint(payload):
+        return payload
+
+    handler.func = entrypoint
+    request = _FakeRequest(raise_json=True)
+
+    with pytest.raises(InvalidJSONPayloadError):
+        asyncio.run(handler._process_invoke(request))
+
+
+def test_process_invoke_without_registered_func_returns_placeholder_message():
+    handler = InvokeHandler()
+    request = _FakeRequest(payload={"any": "thing"})
+    payload, headers, result = asyncio.run(handler._process_invoke(request))
+
+    assert payload == {}
+    assert headers == {}
+    assert result == {"message": "Invoke handler function is not set."}
+
+
+# ---------------------------------------------------------------------------
+# InvokeHandler._convert_to_sse
+# ---------------------------------------------------------------------------
+
+
+def test_convert_to_sse_passes_string_through_unserialized():
+    handler = InvokeHandler()
+    assert handler._convert_to_sse("hello") == b"data: hello\n\n"
+
+
+def test_convert_to_sse_json_serializes_non_string_objects():
+    handler = InvokeHandler()
+    assert handler._convert_to_sse({"a": 1}) == b'data: {"a": 1}\n\n'
+
+
+# ---------------------------------------------------------------------------
+# InvokeHandler.handle response matrix (via TestClient)
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> tuple[AgentkitSimpleApp, TestClient]:
+    app = AgentkitSimpleApp()
+    return app, TestClient(app)
+
+
+def test_handle_without_registered_entrypoint_returns_404():
+    app, client = _make_client()
+    resp = client.post("/invoke", json={"anything": True})
+
+    assert resp.status_code == 404
+    assert resp.json() == {
+        "error": {
+            "message": (
+                "Entrypoint function is not set. Please register a function "
+                "with @app.entrypoint."
+            ),
+            "type": "NotFound",
+        }
+    }
+
+
+def test_handle_entrypoint_returning_plain_dict_yields_json_200():
+    app, client = _make_client()
+
+    @app.entrypoint
+    def entrypoint(payload):
+        return {"got": payload}
+
+    resp = client.post("/invoke", json={"q": "hi"})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.json() == {"got": {"q": "hi"}}
+
+
+def test_handle_malformed_json_request_body_returns_400():
+    app, client = _make_client()
+
+    @app.entrypoint
+    def entrypoint(payload):
+        return payload
+
+    resp = client.post(
+        "/invoke",
+        content=b"this-is-not-json",
+        headers={"content-type": "application/json"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json() == {
+        "error": {
+            "message": (
+                "Invalid JSON payload. Please provide a valid JSON object in "
+                "the request body."
+            ),
+            "type": "BadRequest",
+        }
+    }
+
+
+def test_handle_http_exception_below_500_passes_detail_through():
+    app, client = _make_client()
+
+    @app.entrypoint
+    def entrypoint(payload):
+        raise HTTPException(status_code=403, detail="forbidden zone")
+
+    resp = client.post("/invoke", json={})
+
+    assert resp.status_code == 403
+    assert resp.json() == {
+        "error": {"message": "forbidden zone", "type": "HTTPException"}
+    }
+
+
+def test_handle_http_exception_at_or_above_500_masks_detail_with_generic_message():
+    app, client = _make_client()
+
+    @app.entrypoint
+    def entrypoint(payload):
+        raise HTTPException(status_code=503, detail="leaky internal secret")
+
+    resp = client.post("/invoke", json={})
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["error"]["type"] == "HTTPException"
+    assert "leaky internal secret" not in body["error"]["message"]
+    assert "user-defined entrypoint function" in body["error"]["message"]
+
+
+def test_handle_generic_exception_returns_500_with_exception_type_name():
+    app, client = _make_client()
+
+    class _CustomBoom(Exception):
+        ...
+
+    @app.entrypoint
+    def entrypoint(payload):
+        raise _CustomBoom("kaboom")
+
+    resp = client.post("/invoke", json={})
+
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["type"] == "_CustomBoom"
+    assert "user-defined entrypoint function" in body["error"]["message"]
+
+
+def test_handle_sync_generator_entrypoint_streams_sse():
+    app, client = _make_client()
+
+    @app.entrypoint
+    def entrypoint(payload):
+        yield "chunk-1"
+        yield {"chunk": 2}
+
+    resp = client.post("/invoke", json={})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert resp.text == 'data: chunk-1\n\ndata: {"chunk": 2}\n\n'
+
+
+def test_handle_async_generator_entrypoint_streams_sse():
+    app, client = _make_client()
+
+    @app.entrypoint
+    async def entrypoint(payload):
+        yield "async-1"
+        yield {"async": 2}
+
+    resp = client.post("/invoke", json={})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert resp.text == 'data: async-1\n\ndata: {"async": 2}\n\n'
+
+
+# ---------------------------------------------------------------------------
+# AsyncTaskHandler in-memory bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_async_task_handler_add_then_complete_known_task_returns_true():
+    handler = AsyncTaskHandler()
+    task_id = handler.add_async_task("file_processing", {"file": "data.csv"})
+
+    assert task_id in handler._active_tasks
+    info = handler.get_async_task_info()
+    assert info["active_count"] == 1
+    assert info["running_jobs"][0]["name"] == "file_processing"
+
+    assert handler.complete_async_task(task_id) is True
+    assert handler._active_tasks == {}
+    assert handler.get_async_task_info()["active_count"] == 0
+
+
+def test_async_task_handler_complete_unknown_task_returns_false():
+    handler = AsyncTaskHandler()
+    assert handler.complete_async_task(1234567890) is False
+
+
+def test_async_task_handler_tracks_multiple_independent_tasks():
+    handler = AsyncTaskHandler()
+    first = handler.add_async_task("a")
+    second = handler.add_async_task("b")
+
+    assert first != second
+    assert handler.get_async_task_info()["active_count"] == 2
+
+    assert handler.complete_async_task(first) is True
+    assert handler.get_async_task_info()["active_count"] == 1
+    # Completing the same id twice: second attempt no longer found.
+    assert handler.complete_async_task(first) is False
+    assert handler.complete_async_task(second) is True
+
+
+# ---------------------------------------------------------------------------
+# PingHandler._format_ping_status
+# ---------------------------------------------------------------------------
+
+
+def test_format_ping_status_wraps_string_result_in_status_dict():
+    handler = PingHandler()
+    assert handler._format_ping_status("healthy") == {"status": "healthy"}
+
+
+def test_format_ping_status_returns_dict_result_unchanged():
+    handler = PingHandler()
+    payload = {"status": "ok", "extra": 1}
+    assert handler._format_ping_status(payload) == payload
+
+
+def test_format_ping_status_on_non_str_non_dict_raises_when_func_is_none():
+    # NOTE: latent bug -- the else branch logs f"... {self.func.__name__} ..."
+    # (simple_app_handlers.py:312). When no ping func has been registered,
+    # self.func is None, so attribute access raises AttributeError *before* the
+    # intended {"status": "error", ...} dict is returned. We pin the ACTUAL
+    # current behavior (AttributeError), not the intended error dict.
+    handler = PingHandler()
+    assert handler.func is None
+    with pytest.raises(AttributeError):
+        handler._format_ping_status(12345)
+
+
+def test_format_ping_status_on_non_str_non_dict_returns_error_dict_when_func_present():
+    # With a registered func the __name__ lookup succeeds, so the intended
+    # error dict is returned for an unexpected (non str/dict) result type.
+    handler = PingHandler()
+
+    def ping():
+        return "ok"
+
+    handler.func = ping
+    assert handler._format_ping_status(12345) == {
+        "status": "error",
+        "message": "Invalid response type.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# AsyncTaskHandler.handle signature deviation
+# ---------------------------------------------------------------------------
+
+
+def test_async_task_handler_handle_takes_no_request_argument():
+    # NOTE: latent bug -- AsyncTaskHandler.handle is declared as `handle(self)`
+    # (simple_app_handlers.py:325), violating the abstract
+    # BaseHandler.handle(self, request) contract. It therefore cannot be used as
+    # a Starlette route endpoint (which always passes a request). We pin the
+    # ACTUAL current behavior: it accepts NO request argument and returns an
+    # empty Response; passing a request raises TypeError.
+    handler = AsyncTaskHandler()
+
+    resp = asyncio.run(handler.handle())
+    assert isinstance(resp, Response)
+
+    with pytest.raises(TypeError):
+        asyncio.run(handler.handle(object()))

--- a/tests/client/test_base_service_client_errors.py
+++ b/tests/client/test_base_service_client_errors.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline error-mapping tests for ``BaseServiceClient._invoke_api``.
+
+Verifies the exception-discipline standard at the HTTP-owning layer:
+
+* a transport error raised by ``self.json`` is wrapped as ``NetworkError``
+  (typed, with the original cause chained), not surfaced raw;
+* a malformed response body becomes a domain ``ApiError`` rather than a raw
+  ``json.JSONDecodeError`` bubbling out of the SDK.
+
+No network is performed: ``self.json`` is replaced with a stub. Explicit
+credentials are supplied so the vefaas auto-refresh path is never taken.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+
+# Import the toolkit package first to fully initialise the import graph before
+# touching ``agentkit.client`` (the package wiring is order-sensitive).
+import agentkit.toolkit  # noqa: F401
+
+import pytest
+import requests
+
+from agentkit.auth.errors import NetworkError
+from agentkit.client.base_service_client import BaseServiceClient
+from agentkit.platform.configuration import VolcConfiguration
+from agentkit.toolkit.errors import ApiError
+
+
+class _Req:
+    """Minimal stand-in for a Pydantic request model."""
+
+    def model_dump(self, *, by_alias: bool = True, exclude_none: bool = True):
+        return {}
+
+
+class _Resp:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _DummyClient(BaseServiceClient):
+    API_ACTIONS = {"TestAction": "TestAction"}
+
+    def __init__(self) -> None:
+        # Explicit ak/sk => _explicit_credentials is True => no vefaas refresh,
+        # so construction needs neither a credential file nor network.
+        super().__init__(
+            service="agentkit",
+            access_key="AK_LOCAL_TEST_ONLY",
+            secret_key="SK_LOCAL_TEST_ONLY",
+            region="cn-beijing",
+            service_name="dummy",
+            platform_config=VolcConfiguration(),
+        )
+
+
+@pytest.fixture
+def client():
+    c = _DummyClient()
+    # Sanity: the explicit-credential path must avoid auto-refresh entirely.
+    assert c._explicit_credentials is True
+    assert c._should_auto_refresh_vefaas_credentials() is False
+    return c
+
+
+def _set_json(client, fn):
+    client.json = types.MethodType(fn, client)
+
+
+def test_invoke_api_connection_error_becomes_networkerror(client):
+    def _json(self, api, params, body):
+        raise requests.exceptions.ConnectionError("socket reset")
+
+    _set_json(client, _json)
+
+    with pytest.raises(NetworkError) as excinfo:
+        client._invoke_api("TestAction", _Req(), _Resp)
+
+    assert isinstance(excinfo.value.__cause__, requests.exceptions.ConnectionError)
+    # Transport detail must not leak into the domain message.
+    assert "socket reset" not in str(excinfo.value)
+
+
+def test_invoke_api_malformed_body_becomes_apierror_not_jsondecodeerror(client):
+    def _json(self, api, params, body):
+        return "this-is-not-valid-json{"
+
+    _set_json(client, _json)
+
+    with pytest.raises(ApiError) as excinfo:
+        client._invoke_api("TestAction", _Req(), _Resp)
+
+    # The raw decode error is chained but never the type that escapes the SDK.
+    assert not isinstance(excinfo.value, json.JSONDecodeError)
+    assert isinstance(excinfo.value.__cause__, (ValueError, TypeError))
+    assert "JSONDecodeError" not in str(excinfo.value)
+
+
+def test_invoke_api_error_metadata_becomes_apierror_with_code(client):
+    def _json(self, api, params, body):
+        return json.dumps(
+            {
+                "ResponseMetadata": {
+                    "Error": {"Code": "SomeBizError", "Message": "boom"}
+                }
+            }
+        )
+
+    _set_json(client, _json)
+
+    with pytest.raises(ApiError) as excinfo:
+        client._invoke_api("TestAction", _Req(), _Resp)
+
+    assert excinfo.value.error_code == "SomeBizError"

--- a/tests/test_error_hierarchy.py
+++ b/tests/test_error_hierarchy.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline regression guards for the unified exception hierarchy.
+
+The engineering-standards refactor introduced a single stdlib-only leaf root,
+``agentkit.errors.AgentKitError``. Every domain error -- auth (``AuthError`` /
+``NetworkError``) and toolkit/API (``AgentKitError`` / ``ApiError``) -- must
+descend from that single root so a caller can ``except agentkit.errors.AgentKitError``
+to catch any AgentKit-originated failure, while ``agentkit.auth`` keeps its
+dependency-free posture (importing only ``agentkit.errors``, never ``toolkit``).
+
+These tests also pin the ``agentkit.auth._redact`` -> ``agentkit.utils.redact``
+re-export shim so existing importers keep working.
+"""
+
+from __future__ import annotations
+
+import agentkit.errors as root
+from agentkit.auth.errors import AuthError, NetworkError, SsoError
+from agentkit.toolkit.errors import AgentKitError as ToolkitAgentKitError
+from agentkit.toolkit.errors import ApiError
+
+
+def test_all_domain_errors_descend_from_the_single_root():
+    # The true single root is agentkit.errors.AgentKitError.
+    assert issubclass(AuthError, root.AgentKitError)
+    assert issubclass(NetworkError, root.AgentKitError)
+    assert issubclass(SsoError, root.AgentKitError)
+    assert issubclass(ApiError, root.AgentKitError)
+    assert issubclass(ToolkitAgentKitError, root.AgentKitError)
+
+
+def test_toolkit_root_is_a_subclass_not_the_root_itself():
+    # toolkit.errors.AgentKitError specialises the leaf root (adds error_code /
+    # message), so it is a child of -- not identical to -- agentkit.errors.AgentKitError.
+    assert ToolkitAgentKitError is not root.AgentKitError
+    assert issubclass(ToolkitAgentKitError, root.AgentKitError)
+
+
+def test_auth_errors_are_siblings_of_toolkit_root_under_the_shared_root():
+    # auth errors descend from the shared root directly, NOT from the toolkit
+    # specialisation -- this is what keeps agentkit.auth free of any toolkit import.
+    assert not issubclass(AuthError, ToolkitAgentKitError)
+    assert root.AgentKitError in AuthError.__mro__
+
+
+def test_catching_the_root_catches_every_domain_error():
+    for exc in (
+        AuthError("a"),
+        NetworkError("b"),
+        ApiError("c"),
+        ToolkitAgentKitError("d"),
+    ):
+        try:
+            raise exc
+        except root.AgentKitError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"{type(exc).__name__} not caught by root")
+
+
+def test_api_error_carries_optional_error_code():
+    assert ApiError("boom").error_code is None
+    assert ApiError("boom", error_code="SomeBizError").error_code == "SomeBizError"
+
+
+def test_redact_shim_re_exports_canonical_implementation():
+    from agentkit.auth._redact import mask as shim_mask
+    from agentkit.auth._redact import redact as shim_redact
+    from agentkit.utils.redact import mask as canon_mask
+    from agentkit.utils.redact import redact as canon_redact
+
+    assert shim_redact is canon_redact
+    assert shim_mask is canon_mask

--- a/tests/toolkit/builders/test_local_docker_build.py
+++ b/tests/toolkit/builders/test_local_docker_build.py
@@ -1,0 +1,435 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral coverage for ``LocalDockerBuilder.build``.
+
+This module exercises the real Docker image build *orchestration* branch by
+branch, replacing only the Docker daemon boundary (``DockerManager``) with a
+hand-rolled fake. The Jinja2 render, cloud-provider resolution, base-image
+defaults, template hashing, ``DockerfileManager`` decision/write, and
+``.dockerignore`` creation all run for real against ``tmp_path`` and the
+packaged templates -- so the assertions below prove the actual control flow,
+error-code mapping, and result shapes, not merely that the function imports.
+
+The seam: the constructor does ``self.docker_manager = DockerManager()`` (with
+``DockerManager`` lazily imported from ``agentkit.toolkit.docker.container``).
+We patch that name at its source module *before* construction so the ctor
+never touches ``docker.from_env()``; the sibling ``DockerfileRenderer`` import
+in ``build`` stays real.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import pytest
+
+import agentkit.toolkit.docker.container as container_mod
+from agentkit.toolkit.builders.local_docker import (
+    LocalDockerBuilder,
+    LocalDockerBuilderConfig,
+)
+from agentkit.toolkit.config import CommonConfig, DockerBuildConfig
+from agentkit.toolkit.errors import ErrorCode
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeDockerManager:
+    """Stand-in for ``agentkit.toolkit.docker.container.DockerManager``.
+
+    Matches the real method names and return shapes:
+      - ``is_docker_available() -> Tuple[bool, str]``
+      - ``build_image(**kwargs) -> Tuple[bool, str, Optional[str]]``
+    Class-level attributes configure per-test behavior and record calls; they
+    are reset by the autouse fixture below so tests never leak into each other.
+    """
+
+    # --- configurable behavior (class-level) ---
+    available: Tuple[bool, str] = (True, "Docker is available (Version: test)")
+    build_return: Tuple[bool, str, Optional[str]] = (
+        True,
+        "Step 1/5 : FROM base\nSuccessfully built abc123",
+        "sha256:deadbeefimageid",
+    )
+
+    # --- recorded calls (class-level) ---
+    build_calls: List[dict] = []
+    availability_checks: int = 0
+
+    def __init__(self, *args, **kwargs):
+        # The real ctor calls docker.from_env(); we intentionally do nothing.
+        pass
+
+    def is_docker_available(self) -> Tuple[bool, str]:
+        type(self).availability_checks += 1
+        return type(self).available
+
+    def build_image(self, **kwargs) -> Tuple[bool, str, Optional[str]]:
+        type(self).build_calls.append(dict(kwargs))
+        return type(self).build_return
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_state(monkeypatch):
+    """Reset mutable fake state and pin env for deterministic provider resolution."""
+    _FakeDockerManager.available = (True, "Docker is available (Version: test)")
+    _FakeDockerManager.build_return = (
+        True,
+        "Step 1/5 : FROM base\nSuccessfully built abc123",
+        "sha256:deadbeefimageid",
+    )
+    _FakeDockerManager.build_calls = []
+    _FakeDockerManager.availability_checks = 0
+
+    # read_cloud_provider_from_env reads these; keep them absent so provider
+    # resolution is driven by config only (deterministic -> volcengine).
+    monkeypatch.delenv("AGENTKIT_CLOUD_PROVIDER", raising=False)
+    monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+
+    # Swap the DockerManager name at its source module so the ctor builds the
+    # fake instead of connecting to a Docker daemon.
+    monkeypatch.setattr(container_mod, "DockerManager", _FakeDockerManager)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_builder(project_dir: Path) -> LocalDockerBuilder:
+    """Construct the builder; ctor picks up the patched fake DockerManager."""
+    builder = LocalDockerBuilder(project_dir=project_dir)
+    assert isinstance(builder.docker_manager, _FakeDockerManager)
+    return builder
+
+
+def _python_common(**overrides) -> CommonConfig:
+    base = dict(
+        agent_name="myagent",
+        entry_point="agent.py",
+        language="Python",
+        language_version="3.12",
+        dependencies_file="requirements.txt",
+    )
+    base.update(overrides)
+    return CommonConfig(**base)
+
+
+def _golang_common(entry_point: str, **overrides) -> CommonConfig:
+    base = dict(
+        agent_name="mygoagent",
+        entry_point=entry_point,
+        language="Golang",
+        language_version="1.24",
+    )
+    base.update(overrides)
+    return CommonConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# Happy path (Python)
+# ---------------------------------------------------------------------------
+
+
+def test_python_happy_path_returns_image_info_and_calls_build_image(tmp_path):
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(
+        common_config=_python_common(),
+        image_name="my-repo",
+        image_tag="v1.2",
+    )
+
+    result = builder.build(config)
+
+    assert result.success is True
+    assert result.error is None
+    assert result.error_code is None
+    # ImageInfo is assembled from image_name/image_tag and the image_id digest.
+    assert result.image is not None
+    assert result.image.repository == "my-repo"
+    assert result.image.tag == "v1.2"
+    assert result.image.digest == "sha256:deadbeefimageid"
+    assert result.image.full_name == "my-repo:v1.2"
+    # build_logs echoes the raw string returned by build_image (see note below).
+    assert "Successfully built abc123" in result.build_logs
+    assert result.build_timestamp is not None
+
+    # A real Dockerfile was rendered + written to the workdir, and .dockerignore too.
+    assert (tmp_path / "Dockerfile").exists()
+    dockerfile_text = (tmp_path / "Dockerfile").read_text()
+    assert "CMD [\"python\", \"-m\", \"agent\"]" in dockerfile_text
+    assert (tmp_path / ".dockerignore").exists()
+
+    # build_image was invoked exactly once with the resolved name/tag/context dir.
+    assert len(_FakeDockerManager.build_calls) == 1
+    call = _FakeDockerManager.build_calls[0]
+    assert call["image_name"] == "my-repo"
+    assert call["image_tag"] == "v1.2"
+    assert call["dockerfile_path"] == str(tmp_path)
+    assert call["build_args"] == {}
+    # platform not supplied -> not forwarded
+    assert "platform" not in call
+
+
+def test_python_default_image_name_and_tag_when_blank(tmp_path):
+    builder = _make_builder(tmp_path)
+    # image_name blank, image_tag blank -> defaults agentkit-app / latest
+    config = LocalDockerBuilderConfig(
+        common_config=_python_common(),
+        image_name="",
+        image_tag="",
+    )
+
+    result = builder.build(config)
+
+    assert result.success is True
+    assert result.image.repository == "agentkit-app"
+    assert result.image.tag == "latest"
+    call = _FakeDockerManager.build_calls[0]
+    assert call["image_name"] == "agentkit-app"
+    assert call["image_tag"] == "latest"
+
+
+def test_python_missing_dependencies_file_is_created_empty(tmp_path):
+    # dependencies_file is referenced in context; if absent it is written empty.
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(common_config=_python_common())
+
+    assert not (tmp_path / "requirements.txt").exists()
+    result = builder.build(config)
+
+    assert result.success is True
+    dep_file = tmp_path / "requirements.txt"
+    assert dep_file.exists()
+    assert dep_file.read_text() == ""
+
+
+def test_platform_forwarded_when_specified_and_not_auto(tmp_path):
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(
+        common_config=_python_common(),
+        docker_build_config=DockerBuildConfig(platform="linux/arm64"),
+    )
+
+    result = builder.build(config)
+
+    assert result.success is True
+    call = _FakeDockerManager.build_calls[0]
+    assert call["platform"] == "linux/arm64"
+
+
+def test_platform_auto_is_not_forwarded(tmp_path):
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(
+        common_config=_python_common(),
+        docker_build_config=DockerBuildConfig(platform="auto"),
+    )
+
+    result = builder.build(config)
+
+    assert result.success is True
+    call = _FakeDockerManager.build_calls[0]
+    assert "platform" not in call
+
+
+def test_python_custom_base_image_is_rendered_into_dockerfile(tmp_path):
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(
+        common_config=_python_common(),
+        docker_build_config=DockerBuildConfig(base_image="python:3.12-slim"),
+    )
+
+    result = builder.build(config)
+
+    assert result.success is True
+    dockerfile_text = (tmp_path / "Dockerfile").read_text()
+    # base_image override wins over the provider default template line.
+    assert "FROM python:3.12-slim" in dockerfile_text
+
+
+# ---------------------------------------------------------------------------
+# Early error branches
+# ---------------------------------------------------------------------------
+
+
+def test_missing_common_config_returns_config_missing(tmp_path):
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(common_config=None)
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_MISSING
+    assert result.error == "Missing common configuration"
+    assert result.build_logs == ["Missing common configuration"]
+    # Short-circuits before ever checking docker availability or building.
+    assert _FakeDockerManager.availability_checks == 0
+    assert _FakeDockerManager.build_calls == []
+
+
+def test_docker_unavailable_returns_docker_not_available_with_split_logs(tmp_path):
+    _FakeDockerManager.available = (False, "Docker is not available: boom\nline two")
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(common_config=_python_common())
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.DOCKER_NOT_AVAILABLE
+    assert result.error == "Docker is not available: boom\nline two"
+    # The message is split on newlines into build_logs lines.
+    assert result.build_logs == ["Docker is not available: boom", "line two"]
+    # Never proceeds to build_image.
+    assert _FakeDockerManager.build_calls == []
+
+
+def test_unsupported_language_returns_config_invalid(tmp_path):
+    builder = _make_builder(tmp_path)
+    # Rust is not a supported language -> CONFIG_INVALID before template selection.
+    common = _python_common()
+    common.language = "Rust"
+    config = LocalDockerBuilderConfig(common_config=common)
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert result.error == "Unsupported language: Rust"
+    assert result.build_logs == ["Unsupported language: Rust"]
+    assert _FakeDockerManager.build_calls == []
+
+
+# ---------------------------------------------------------------------------
+# build_image failure branch
+# ---------------------------------------------------------------------------
+
+
+def test_build_image_failure_returns_build_failed_with_logs(tmp_path):
+    _FakeDockerManager.build_return = (
+        False,
+        "Step 3/5 : RUN bad\nERROR: build step failed",
+        None,
+    )
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(common_config=_python_common())
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.BUILD_FAILED
+    assert result.error == "Docker build failed"
+    assert result.image is None
+    # The failing build logs are surfaced on the result.
+    assert "ERROR: build step failed" in result.build_logs
+    assert result.build_timestamp is not None
+    # build_image was actually reached and invoked once.
+    assert len(_FakeDockerManager.build_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Golang entry-point resolution branches
+# ---------------------------------------------------------------------------
+
+
+def test_golang_build_script_entry_happy_path(tmp_path):
+    # entry_point points at an existing .sh file inside a project dir.
+    project = tmp_path / "svc"
+    project.mkdir()
+    (project / "build.sh").write_text("#!/bin/sh\necho build\n")
+    (project / "main.go").write_text("package main\nfunc main() {}\n")
+
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(
+        common_config=_golang_common(entry_point="svc/build.sh"),
+        image_name="go-repo",
+        image_tag="v1",
+    )
+
+    result = builder.build(config)
+
+    assert result.success is True
+    assert result.image.repository == "go-repo"
+    assert result.image.digest == "sha256:deadbeefimageid"
+    # Sources were copied under workdir/src/<project>/ for the Docker context.
+    copied = tmp_path / "src" / "svc" / "build.sh"
+    assert copied.exists()
+    # The rendered Dockerfile references the .sh entry via the golang template
+    # (build script branch runs `sh <entry_relative_path>`).
+    dockerfile_text = (tmp_path / "Dockerfile").read_text()
+    assert "src/svc/build.sh" in dockerfile_text
+
+
+def test_golang_directory_entry_happy_path(tmp_path):
+    # entry_point points at an existing directory (a Go package).
+    pkg = tmp_path / "cmd"
+    pkg.mkdir()
+    (pkg / "main.go").write_text("package main\nfunc main() {}\n")
+
+    builder = _make_builder(tmp_path)
+    # CommonConfig entry_point validation requires .py/.go/.sh; use a .go file
+    # path whose resolution falls back to the go.mod project dir. Instead, to
+    # exercise the is_dir() branch we give an entry that resolves to a dir via
+    # the go.mod discovery fallback below.
+    (tmp_path / "go.mod").write_text("module example.com/m\n")
+    config = LocalDockerBuilderConfig(
+        common_config=_golang_common(entry_point="cmd/app.go"),
+    )
+
+    result = builder.build(config)
+
+    # cmd/app.go does not exist -> discovery walks up to tmp_path (has go.mod)
+    # -> entry_path becomes the directory tmp_path -> is_dir() branch.
+    assert result.success is True
+    dockerfile_text = (tmp_path / "Dockerfile").read_text()
+    # entry_relative_path is src/<workdir-name> (a directory) -> go build branch.
+    assert "src/" + tmp_path.name in dockerfile_text
+    assert "go build" in dockerfile_text
+
+
+def test_golang_single_go_file_entry_returns_config_invalid(tmp_path):
+    # An existing single .go file (not .sh, not a dir) -> unsupported entry.
+    (tmp_path / "main.go").write_text("package main\nfunc main() {}\n")
+
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(
+        common_config=_golang_common(entry_point="main.go"),
+    )
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert "single-file compilation is not supported" in result.error
+    assert _FakeDockerManager.build_calls == []
+
+
+def test_golang_missing_entry_and_no_go_mod_returns_config_invalid(tmp_path):
+    # entry_point does not exist and no go.mod anywhere -> project-not-found.
+    builder = _make_builder(tmp_path)
+    config = LocalDockerBuilderConfig(
+        common_config=_golang_common(entry_point="missing/app.go"),
+    )
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert "Project path not found" in result.error
+    assert _FakeDockerManager.build_calls == []

--- a/tests/toolkit/builders/test_ve_pipeline_build.py
+++ b/tests/toolkit/builders/test_ve_pipeline_build.py
@@ -1,0 +1,477 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavior tests for the VeCPCRBuilder.build() 6-step orchestration spine.
+
+The build() method (agentkit/toolkit/builders/ve_pipeline.py) wires together six
+private steps: _render_dockerfile, _create_project_archive, _upload_to_tos,
+_prepare_cr_resources, _prepare_pipeline_resources and _execute_build.  These
+tests replace each step on the *instance* with a hand-rolled fake so the real
+orchestration branch logic runs against controlled inputs -- asserting on the
+returned BuildResult shape, error codes, ImageInfo assembly, the accumulated
+`resources` metadata, and exactly which steps ran (and with which args).
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import datetime
+
+import pytest
+
+from agentkit.toolkit.builders.ve_pipeline import VeCPCRBuilder, VeCPCRBuilderConfig
+from agentkit.toolkit.config import CommonConfig
+from agentkit.toolkit.errors import ErrorCode
+from agentkit.toolkit.models import BuildResult, ImageInfo
+from agentkit.toolkit.reporter import Reporter
+
+
+# --------------------------------------------------------------------------- #
+# Fakes                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class _SpyReporter(Reporter):
+    """Records every reporter call so tests can assert on progress narration."""
+
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.successes: list[str] = []
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+
+    def info(self, message: str, **kwargs):
+        self.infos.append(message)
+
+    def success(self, message: str, **kwargs):
+        self.successes.append(message)
+
+    def warning(self, message: str, **kwargs):
+        self.warnings.append(message)
+
+    def error(self, message: str, **kwargs):
+        self.errors.append(message)
+
+    def progress(self, message: str, current: int, total: int = 100, **kwargs):
+        pass
+
+    def confirm(self, message: str, default: bool = False, **kwargs) -> bool:
+        return default
+
+    def long_task(self, description: str, total: float = 100):
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _cm():
+            class _T:
+                def update(self, description=None, completed=None):
+                    pass
+
+            yield _T()
+
+        return _cm()
+
+    def show_logs(self, title: str, lines, max_lines: int = 100):
+        pass
+
+
+class _StepRecorder:
+    """Shared mutable record of which build steps were invoked, with args.
+
+    Reset between tests by the autouse fixture so no state leaks across cases.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def record(self, name: str, *args, **kwargs) -> None:
+        self.calls.append((name, args, kwargs))
+
+    @property
+    def names(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
+@pytest.fixture()
+def recorder() -> _StepRecorder:
+    return _StepRecorder()
+
+
+def _make_config(agent_name: str = "myagent") -> VeCPCRBuilderConfig:
+    """Build a config whose real _validate_config() passes (all required truthy)."""
+    common = CommonConfig(
+        agent_name=agent_name,
+        entry_point="agent.py",
+        cloud_provider="volcengine",
+    )
+    return VeCPCRBuilderConfig(
+        common_config=common,
+        tos_bucket="my-bucket",
+        tos_region="cn-beijing",
+        cr_instance_name="my-instance",
+        cr_namespace_name="my-namespace",
+        cr_repo_name="my-repo",
+        cr_region="cn-beijing",
+        image_tag="v1",
+    )
+
+
+def _install_happy_steps(
+    builder: VeCPCRBuilder,
+    recorder: _StepRecorder,
+    *,
+    image_url: str = "registry.example.com/ns/repo:v1",
+    set_build_resources: bool = True,
+) -> None:
+    """Patch all six private steps on the instance with success fakes."""
+
+    def fake_render(self, config, docker_build_config=None):
+        recorder.record("_render_dockerfile", config, docker_build_config)
+        return "/tmp/Dockerfile"
+
+    def fake_archive(self, config):
+        recorder.record("_create_project_archive", config)
+        return "/tmp/archive.tar.gz"
+
+    def fake_upload(self, archive_path, config):
+        recorder.record("_upload_to_tos", archive_path, config)
+        # build() reads config.tos_object_key/tos_bucket right after; the real
+        # step sets tos_object_key, so mimic that side effect.
+        config.tos_object_key = "agentkit-builds/archive.tar.gz"
+        return "tos://my-bucket/agentkit-builds/archive.tar.gz", "cn-beijing-actual"
+
+    def fake_prepare_cr(self, config):
+        recorder.record("_prepare_cr_resources", config)
+        from agentkit.toolkit.volcengine.services import CRServiceConfig
+
+        cr_config = CRServiceConfig(
+            instance_name=config.cr_instance_name,
+            namespace_name=config.cr_namespace_name,
+            repo_name=config.cr_repo_name,
+            region=config.cr_region,
+        )
+        return cr_config, "cr-region-actual"
+
+    def fake_prepare_pipeline(self, config, tos_url, cr_config):
+        recorder.record("_prepare_pipeline_resources", config, tos_url, cr_config)
+        if set_build_resources:
+            # Mirror the real step recording pipeline metadata on the instance,
+            # which build() then lifts into resources (lines ~262-266).
+            self._build_resources = {
+                "pipeline_name": "agentkit-cli-myagent-abcd",
+                "pipeline_id": "pl-from-resources",
+            }
+        return "pl-returned"
+
+    def fake_execute(self, pipeline_id, config, runtime_overrides=None):
+        recorder.record(
+            "_execute_build", pipeline_id, config, runtime_overrides
+        )
+        return image_url
+
+    builder._render_dockerfile = types.MethodType(fake_render, builder)
+    builder._create_project_archive = types.MethodType(fake_archive, builder)
+    builder._upload_to_tos = types.MethodType(fake_upload, builder)
+    builder._prepare_cr_resources = types.MethodType(fake_prepare_cr, builder)
+    builder._prepare_pipeline_resources = types.MethodType(
+        fake_prepare_pipeline, builder
+    )
+    builder._execute_build = types.MethodType(fake_execute, builder)
+
+
+# --------------------------------------------------------------------------- #
+# Happy path                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_happy_path_returns_success_with_assembled_image_info(recorder):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config(agent_name="myagent")
+    _install_happy_steps(
+        builder, recorder, image_url="registry.example.com/ns/repo:v1"
+    )
+
+    result = builder.build(config)
+
+    assert isinstance(result, BuildResult)
+    assert result.success is True
+    assert result.error is None
+    assert result.error_code is None
+    # ImageInfo is split on the LAST ':' -> repository / tag.
+    assert isinstance(result.image, ImageInfo)
+    assert result.image.repository == "registry.example.com/ns/repo"
+    assert result.image.tag == "v1"
+    assert result.image.digest is None
+    assert result.image.full_name == "registry.example.com/ns/repo:v1"
+    assert isinstance(result.build_timestamp, datetime)
+
+
+def test_build_happy_path_invokes_all_six_steps_in_order(recorder):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(builder, recorder)
+
+    builder.build(config)
+
+    assert recorder.names == [
+        "_render_dockerfile",
+        "_create_project_archive",
+        "_upload_to_tos",
+        "_prepare_cr_resources",
+        "_prepare_pipeline_resources",
+        "_execute_build",
+    ]
+
+
+def test_build_happy_path_threads_step_outputs_into_downstream_calls(recorder):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(builder, recorder)
+
+    builder.build(config)
+
+    by_name = {c[0]: c for c in recorder.calls}
+
+    # _upload_to_tos gets the archive path produced by _create_project_archive.
+    upload_args = by_name["_upload_to_tos"][1]
+    assert upload_args[0] == "/tmp/archive.tar.gz"
+
+    # _prepare_pipeline_resources receives the tos_url from _upload_to_tos and
+    # the cr_config from _prepare_cr_resources.
+    pipeline_args = by_name["_prepare_pipeline_resources"][1]
+    assert pipeline_args[1] == "tos://my-bucket/agentkit-builds/archive.tar.gz"
+    assert pipeline_args[2].instance_name == "my-instance"
+
+    # _execute_build is called with the pipeline id returned by the resource
+    # prep step (overwritten from _build_resources -> "pl-from-resources"),
+    # and runtime_overrides carrying the *actual* resolved regions.
+    exec_call = by_name["_execute_build"]
+    assert exec_call[1][0] == "pl-from-resources"
+    runtime_overrides = exec_call[1][2]
+    assert runtime_overrides == {
+        "tos_region": "cn-beijing-actual",
+        "cr_region": "cr-region-actual",
+    }
+
+
+def test_build_happy_path_metadata_maps_all_resources(recorder):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(
+        builder, recorder, image_url="registry.example.com/ns/repo:v1"
+    )
+
+    result = builder.build(config)
+
+    md = result.metadata
+    assert md["cr_image_url"] == "registry.example.com/ns/repo:v1"
+    # pipeline id/name are captured from self._build_resources.
+    assert md["cp_pipeline_id"] == "pl-from-resources"
+    assert md["cp_pipeline_name"] == "agentkit-cli-myagent-abcd"
+    assert md["cr_instance_name"] == "my-instance"
+    assert md["cr_namespace_name"] == "my-namespace"
+    assert md["cr_repo_name"] == "my-repo"
+    assert md["tos_object_url"] == "tos://my-bucket/agentkit-builds/archive.tar.gz"
+    assert md["tos_object_key"] == "agentkit-builds/archive.tar.gz"
+    assert md["tos_bucket"] == "my-bucket"
+
+    # The nested resources dict accumulates every step output.
+    res = md["resources"]
+    assert res["dockerfile_path"] == "/tmp/Dockerfile"
+    assert res["archive_path"] == "/tmp/archive.tar.gz"
+    assert res["tos_url"] == "tos://my-bucket/agentkit-builds/archive.tar.gz"
+    assert res["tos_actual_region"] == "cn-beijing-actual"
+    assert res["cr_actual_region"] == "cr-region-actual"
+    assert res["image_url"] == "registry.example.com/ns/repo:v1"
+
+
+def test_build_happy_path_persists_results_back_onto_config(recorder):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(
+        builder, recorder, image_url="registry.example.com/ns/repo:v1"
+    )
+
+    builder.build(config)
+
+    # build() writes the final results onto the mutable config for persistence.
+    assert config.image_url == "registry.example.com/ns/repo:v1"
+    assert config.cp_pipeline_id == "pl-from-resources"
+    assert config.tos_object_key == "agentkit-builds/archive.tar.gz"
+    assert config.build_timestamp  # ISO string was set
+
+
+def test_build_image_url_without_tag_falls_back_to_config_image_tag(recorder):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    config.image_tag = "fallbacktag"
+    # _execute_build returns a URL that has no ':' tag segment.
+    _install_happy_steps(builder, recorder, image_url="registry.example.com/ns/repo")
+
+    result = builder.build(config)
+
+    assert result.success is True
+    assert result.image.repository == "registry.example.com/ns/repo"
+    assert result.image.tag == "fallbacktag"
+
+
+def test_build_without_build_resources_uses_returned_pipeline_id(recorder):
+    """When the pipeline step does not populate self._build_resources, build()
+    keeps the returned pipeline id and reports pipeline_name as None."""
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(builder, recorder, set_build_resources=False)
+
+    result = builder.build(config)
+
+    assert result.success is True
+    assert result.metadata["cp_pipeline_id"] == "pl-returned"
+    assert result.metadata["cp_pipeline_name"] is None
+    assert config.cp_pipeline_id == "pl-returned"
+
+
+# --------------------------------------------------------------------------- #
+# Validation failure (early return, no steps run)                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_validation_failure_returns_config_invalid_and_runs_no_steps(recorder):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(builder, recorder)
+
+    # Force validation to fail deterministically.
+    builder._validate_config = types.MethodType(
+        lambda self, cfg: False, builder
+    )
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert result.error == "Configuration validation failed"
+    assert result.image is None
+    # NONE of the six steps executed.
+    assert recorder.names == []
+
+
+def test_build_real_validation_fails_when_tos_bucket_missing(recorder):
+    """Exercise the real _validate_config branch: empty tos_bucket -> CONFIG_INVALID."""
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    config.tos_bucket = ""  # trips the first guard in real _validate_config
+    _install_happy_steps(builder, recorder)
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert recorder.names == []
+
+
+# --------------------------------------------------------------------------- #
+# Mid-pipeline failure (BUILD_FAILED, partial resources preserved)            #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_upload_failure_returns_build_failed_and_preserves_partial_resources(
+    recorder,
+):
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(builder, recorder)
+
+    # Replace _upload_to_tos with a raising fake AFTER the happy install so the
+    # first two steps still succeed and their outputs are in `resources`.
+    def boom_upload(self, archive_path, config):
+        recorder.record("_upload_to_tos", archive_path, config)
+        raise RuntimeError("network exploded")
+
+    builder._upload_to_tos = types.MethodType(boom_upload, builder)
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.BUILD_FAILED
+    assert "network exploded" in result.error
+    assert isinstance(result.build_timestamp, datetime)
+
+    # Steps before the failure ran; steps after did not.
+    assert recorder.names == [
+        "_render_dockerfile",
+        "_create_project_archive",
+        "_upload_to_tos",
+    ]
+
+    # Partial resources collected before the failure are preserved in metadata.
+    res = result.metadata["resources"]
+    assert res["dockerfile_path"] == "/tmp/Dockerfile"
+    assert res["archive_path"] == "/tmp/archive.tar.gz"
+    # tos_url was never set because _upload_to_tos raised before assignment.
+    assert "tos_url" not in res
+    assert "image_url" not in res
+
+
+def test_build_pipeline_failure_preserves_tos_and_pipeline_state_on_config(recorder):
+    """A failure in _execute_build (last step) still preserves the tos_object_key
+    and pipeline_id collected earlier, both in metadata and on the config."""
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(builder, recorder)
+
+    def boom_execute(self, pipeline_id, config, runtime_overrides=None):
+        recorder.record("_execute_build", pipeline_id, config, runtime_overrides)
+        raise RuntimeError("pipeline blew up")
+
+    builder._execute_build = types.MethodType(boom_execute, builder)
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.BUILD_FAILED
+    assert "pipeline blew up" in result.error
+
+    # All steps ran up to and including the failing _execute_build.
+    assert recorder.names[-1] == "_execute_build"
+
+    # tos_object_key and pipeline_id preserved for cleanup/debugging.
+    assert config.tos_object_key == "agentkit-builds/archive.tar.gz"
+    assert config.cp_pipeline_id == "pl-from-resources"
+    assert result.metadata["tos_object_key"] == "agentkit-builds/archive.tar.gz"
+    assert result.metadata["cp_pipeline_id"] == "pl-from-resources"
+    # Full resources dict is threaded into the failure metadata too.
+    assert result.metadata["resources"]["cr_actual_region"] == "cr-region-actual"
+
+
+def test_build_first_step_failure_still_returns_build_failed(recorder):
+    """A failure in the very first step (_render_dockerfile) yields BUILD_FAILED
+    with an essentially empty resources map (nothing collected yet)."""
+    builder = VeCPCRBuilder(reporter=_SpyReporter())
+    config = _make_config()
+    _install_happy_steps(builder, recorder)
+
+    def boom_render(self, config, docker_build_config=None):
+        recorder.record("_render_dockerfile", config, docker_build_config)
+        raise RuntimeError("no docker deps")
+
+    builder._render_dockerfile = types.MethodType(boom_render, builder)
+
+    result = builder.build(config)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.BUILD_FAILED
+    assert "no docker deps" in result.error
+    assert recorder.names == ["_render_dockerfile"]
+    # resources is empty -> no dockerfile_path recorded.
+    assert result.metadata["resources"] == {}

--- a/tests/toolkit/builders/test_ve_pipeline_upload_tos.py
+++ b/tests/toolkit/builders/test_ve_pipeline_upload_tos.py
@@ -1,0 +1,476 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral guards for ``VeCPCRBuilder._upload_to_tos``.
+
+This method is security-critical: before uploading source code (which can
+contain secrets) it verifies via ListBuckets that the target TOS bucket is
+owned by the current account, and it maps low-level TOS/service errors into
+actionable, non-leaky messages. These tests exercise the real branch logic by
+substituting a hand-rolled ``_FakeTOSService`` for the lazily-imported
+``agentkit.toolkit.volcengine.services.tos_service.TOSService`` symbol, matching
+the exact method surface the production code calls:
+
+  - ``bucket_exists()``          -> bool
+  - ``create_bucket()``          -> raises tos.exceptions.TosServerError on conflict
+  - ``bucket_is_owned(name)``    -> bool  (ListBuckets ownership gate)
+  - ``get_bucket_location(name)``-> Optional[str]
+  - ``upload_file(path, key)``   -> str (URL)
+  - ``generate_bucket_name()``   -> staticmethod
+  - ``.config`` (has a mutable ``.bucket`` attr) and ``.actual_region``
+
+``time.sleep`` is patched so the eventual-consistency polling loops never wait.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import tos.exceptions as _tos_exceptions
+from agentkit.toolkit.builders.ve_pipeline import VeCPCRBuilder, VeCPCRBuilderConfig
+
+# Source module where _upload_to_tos performs its lazy import; this is the
+# symbol we must replace so the fake is picked up.
+_TOS_MODULE = "agentkit.toolkit.volcengine.services.tos_service"
+
+# A secret-shaped token we inject into low-level error strings to prove the
+# mapped, user-facing messages never echo raw response contents / credentials.
+_SECRET_MARKER = "AKLTsecret-do-not-leak-1234567890"
+
+
+def _make_tos_server_error(status_code: int, message: str = "conflict") -> _tos_exceptions.TosServerError:
+    """Build a genuine ``tos.exceptions.TosServerError`` with a chosen status.
+
+    The real constructor reads ``request_id``, ``headers`` and ``status`` off a
+    response object, so we hand it a minimal fake response. The result is a true
+    instance (isinstance passes) with a working ``__str__``.
+    """
+
+    class _FakeResp:
+        def __init__(self, status: int) -> None:
+            self.request_id = "req-fake"
+            self.headers = {}
+            self.status = status
+
+    return _tos_exceptions.TosServerError(
+        _FakeResp(status_code), message, "Conflict", "host-fake", "resource-fake"
+    )
+
+
+class _FakeTOSService:
+    """Stand-in for the real TOSService with recorded, scriptable behavior.
+
+    Class-level knobs let each test script the outcome of every collaborator
+    method the production code touches. Instances record their calls so tests
+    can assert *which* methods ran (e.g. that ``upload_file`` was NEVER reached
+    when ownership verification failed).
+    """
+
+    # ---- scriptable behavior (reset by the autouse fixture) -----------------
+    bucket_exists_returns = True
+    bucket_exists_raises: Exception | None = None
+    create_bucket_raises: Exception | None = None
+    bucket_is_owned_returns = True
+    bucket_is_owned_raises: Exception | None = None
+    get_bucket_location_returns: str | None = None
+    upload_file_returns = "https://bucket.tos-cn-beijing.volces.com/agentkit-builds/app.tar.gz"
+    generated_names: list[str] = ["auto-generated-bucket"]
+
+    # ---- recorded calls (reset by the autouse fixture) ----------------------
+    instances: list["_FakeTOSService"] = []
+
+    def __init__(self, config, provider=None):
+        self.config = config
+        self.provider = provider
+        # Mirror the real service attribute used for region resolution.
+        self.actual_region = getattr(config, "region", "") or "cn-beijing"
+        self.calls: list[tuple] = []
+        type(self).instances.append(self)
+
+    # generate_bucket_name is a *staticmethod* on the real class and is called
+    # as TOSService.generate_bucket_name(); model it the same way.
+    _name_cursor = 0
+
+    @staticmethod
+    def generate_bucket_name(prefix: str = "agentkit") -> str:
+        names = _FakeTOSService.generated_names
+        idx = min(_FakeTOSService._name_cursor, len(names) - 1)
+        _FakeTOSService._name_cursor += 1
+        return names[idx]
+
+    def bucket_exists(self) -> bool:
+        self.calls.append(("bucket_exists", self.config.bucket))
+        if self.bucket_exists_raises is not None:
+            raise self.bucket_exists_raises
+        return self.bucket_exists_returns
+
+    def create_bucket(self) -> bool:
+        self.calls.append(("create_bucket", self.config.bucket))
+        if self.create_bucket_raises is not None:
+            raise self.create_bucket_raises
+        return True
+
+    def bucket_is_owned(self, bucket_name=None) -> bool:
+        self.calls.append(("bucket_is_owned", bucket_name))
+        if self.bucket_is_owned_raises is not None:
+            raise self.bucket_is_owned_raises
+        return self.bucket_is_owned_returns
+
+    def get_bucket_location(self, bucket_name=None):
+        self.calls.append(("get_bucket_location", bucket_name))
+        return self.get_bucket_location_returns
+
+    def upload_file(self, local_path: str, object_key: str) -> str:
+        self.calls.append(("upload_file", local_path, object_key))
+        return self.upload_file_returns
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_state(monkeypatch):
+    """Reset all class-level fake state and neutralize sleeps for each test."""
+    _FakeTOSService.bucket_exists_returns = True
+    _FakeTOSService.bucket_exists_raises = None
+    _FakeTOSService.create_bucket_raises = None
+    _FakeTOSService.bucket_is_owned_returns = True
+    _FakeTOSService.bucket_is_owned_raises = None
+    _FakeTOSService.get_bucket_location_returns = None
+    _FakeTOSService.upload_file_returns = (
+        "https://bucket.tos-cn-beijing.volces.com/agentkit-builds/app.tar.gz"
+    )
+    _FakeTOSService.generated_names = ["auto-generated-bucket"]
+    _FakeTOSService._name_cursor = 0
+    _FakeTOSService.instances = []
+
+    # The polling loops call time.sleep; patch the module-level import in the
+    # tos_service source is not where sleep lives -- _upload_to_tos does
+    # `import time` locally, so patch time.sleep globally.
+    import time as _time
+
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+    yield
+
+
+def _install_fake_tos(monkeypatch):
+    """Patch the TOSService symbol at its source module path."""
+    monkeypatch.setattr(f"{_TOS_MODULE}.TOSService", _FakeTOSService)
+
+
+def _make_config(**overrides) -> VeCPCRBuilderConfig:
+    """Build a config with a concrete (rendered) bucket by default.
+
+    ``__post_init__`` renders template fields, so we must pass an already-valid
+    bucket name and mutate it afterwards if a test needs an unrendered one.
+    """
+    params = dict(
+        tos_bucket="my-real-bucket",
+        tos_region="cn-beijing",
+        tos_prefix="agentkit-builds",
+    )
+    params.update(overrides)
+    return VeCPCRBuilderConfig(**params)
+
+
+# ---------------------------------------------------------------------------
+# Ownership gate: bucket exists but is NOT owned by the current account.
+# ---------------------------------------------------------------------------
+
+def test_upload_blocked_when_bucket_not_owned_by_current_account(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    # User-specified bucket that DOES exist (so no create attempt) but is NOT
+    # in the current account's ListBuckets result.
+    _FakeTOSService.bucket_exists_returns = True
+    _FakeTOSService.bucket_is_owned_returns = False
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="someone-elses-bucket")
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    msg = str(excinfo.value)
+    # Security notice message from L1026-1032.
+    assert "is not owned by the current account" in msg
+    assert "someone-elses-bucket" in msg
+
+    # The gate must fire BEFORE any upload: upload_file must never run.
+    svc = _FakeTOSService.instances[-1]
+    called_methods = [c[0] for c in svc.calls]
+    assert "bucket_is_owned" in called_methods
+    assert "upload_file" not in called_methods
+
+
+# ---------------------------------------------------------------------------
+# Cross-region conflict: name taken (409, not created here) but owned, and it
+# lives in a different region than the one currently targeted.
+# ---------------------------------------------------------------------------
+
+def test_cross_region_bucket_conflict_raises_region_scoped_error(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    # Bucket does not exist in the current region -> attempt create -> 409
+    # conflict -> name_conflict_not_created=True; ownership check passes;
+    # location resolves to a *different* region.
+    _FakeTOSService.bucket_exists_returns = False
+    _FakeTOSService.create_bucket_raises = _make_tos_server_error(409)
+    _FakeTOSService.bucket_is_owned_returns = True
+    _FakeTOSService.get_bucket_location_returns = "cn-shanghai"
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="regional-bucket", tos_region="cn-beijing")
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    msg = str(excinfo.value)
+    # Conflict/region-scoped message from L1040-1046.
+    assert "regional-bucket" in msg
+    assert "cn-shanghai" in msg
+    assert "cannot be accessed across regions" in msg
+
+    # Upload must not have happened for a bucket we cannot reach.
+    svc = _FakeTOSService.instances[-1]
+    assert "upload_file" not in [c[0] for c in svc.calls]
+
+
+def test_owned_conflict_without_location_raises_generic_region_error(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    # Same as above but location lookup returns None -> the else branch
+    # (L1048-1053) fires instead of the specific-region message.
+    _FakeTOSService.bucket_exists_returns = False
+    _FakeTOSService.create_bucket_raises = _make_tos_server_error(409)
+    _FakeTOSService.bucket_is_owned_returns = True
+    _FakeTOSService.get_bucket_location_returns = None
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="regional-bucket", tos_region="cn-beijing")
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    msg = str(excinfo.value)
+    assert "does not exist" in msg
+    assert "cannot be accessed across regions" in msg
+    assert "cn-beijing" in msg
+
+
+# ---------------------------------------------------------------------------
+# Error-string mapping in the except tail (L1091-1120).
+# ---------------------------------------------------------------------------
+
+def test_account_disable_error_is_mapped_to_enable_services_message(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    # A user-specified bucket whose accessibility check raises a plain
+    # Exception (NOT a TosServerError, so it is not swallowed by the inner
+    # handler) carrying the AccountDisable signature plus a fake secret.
+    inner = Exception(
+        f"ServiceError code=AccountDisable token={_SECRET_MARKER} raw-response-body"
+    )
+    _FakeTOSService.bucket_exists_raises = inner
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="user-bucket", tos_region="cn-beijing")
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    msg = str(excinfo.value)
+    # L1112-1115 message: enable TOS + include the enable-services console URL.
+    assert "Tos Service is not enabled" in msg
+    assert "Enable services at:" in msg
+    # Provider-independent: the console host differs by cloud provider
+    # (volcengine vs byteplus), and provider global state can leak across the
+    # full suite; assert the invariant enable-URL shape, not a specific host.
+    assert "https://console." in msg and "/agentkit" in msg
+    # No secret / raw-response leakage into the user-facing message.
+    assert _SECRET_MARKER not in msg
+    assert "raw-response-body" not in msg
+
+
+def test_account_disable_url_honors_region_hint_from_config(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    _FakeTOSService.bucket_exists_raises = Exception("boom AccountDisable")
+
+    builder = VeCPCRBuilder()
+    # agentkit_region takes precedence over cp/cr/tos region in the hint chain
+    # (L1101-1106). Feed a distinct region and assert it lands in the URL.
+    config = _make_config(tos_bucket="user-bucket", tos_region="cn-beijing")
+    config.agentkit_region = "ap-southeast-1"
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    assert "ap-southeast-1" in str(excinfo.value)
+
+
+def test_too_many_buckets_error_is_mapped_to_quota_message(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    _FakeTOSService.bucket_exists_raises = Exception(
+        f"TooManyBuckets secret={_SECRET_MARKER}"
+    )
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="user-bucket")
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    msg = str(excinfo.value)
+    # L1116-1119 quota message.
+    assert "maximum number of buckets" in msg
+    assert "delete some buckets" in msg
+    # Fixed message must not echo the raw secret.
+    assert _SECRET_MARKER not in msg
+
+
+def test_generic_error_is_wrapped_with_failed_to_upload_prefix(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    # An error with none of the recognized signatures -> generic wrap (L1120).
+    _FakeTOSService.bucket_exists_raises = Exception("unexpected transient network glitch")
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="user-bucket")
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    msg = str(excinfo.value)
+    assert msg.startswith("Failed to upload to TOS:")
+    assert "unexpected transient network glitch" in msg
+    # AccountDisable/TooManyBuckets branches must NOT have fired.
+    assert "Tos Service is not enabled" not in msg
+    assert "maximum number of buckets" not in msg
+
+
+def test_ownership_check_failure_is_wrapped_as_blocked_for_security(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    # bucket exists but the ListBuckets ownership probe itself throws (e.g. no
+    # ListBuckets permission). check_owned() (L999-1010) converts this into a
+    # security-blocking Exception, which then flows through the generic wrap.
+    _FakeTOSService.bucket_exists_returns = True
+    _FakeTOSService.bucket_is_owned_raises = Exception(
+        f"AccessDenied listing buckets {_SECRET_MARKER}"
+    )
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="user-bucket")
+
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    msg = str(excinfo.value)
+    assert "Upload has been blocked for security reasons" in msg
+    assert "ListBuckets permission" in msg
+    # The raw underlying error string (with the fake secret) is logged, not
+    # surfaced in the wrapped user message.
+    assert _SECRET_MARKER not in msg
+
+    svc = _FakeTOSService.instances[-1]
+    assert "upload_file" not in [c[0] for c in svc.calls]
+
+
+# ---------------------------------------------------------------------------
+# Unrendered template variables in bucket name -> ValueError before any
+# service call (L933-936). The config is constructed valid then mutated so
+# __post_init__ template rendering does not intercept first.
+# ---------------------------------------------------------------------------
+
+def test_unrendered_template_bucket_name_raises_value_error_before_service_use(
+    monkeypatch, tmp_path
+):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="placeholder-bucket")
+    # Inject an unrendered template AFTER construction to reach the L933 guard.
+    config.tos_bucket = "{{agent_name}}-bucket"
+
+    # NOTE: latent bug -- the docstring advertises `Raises: ValueError` for an
+    # unrendered bucket name, and the guard at L933-936 does raise ValueError.
+    # But that raise happens INSIDE the outer try/except (L914/L1091), so the
+    # broad `except Exception` tail swallows the ValueError and re-raises it as
+    # a plain Exception wrapped with the generic "Failed to upload to TOS:"
+    # prefix (L1120). Callers can therefore never catch this specific failure
+    # as ValueError. We pin the ACTUAL current behavior.
+    with pytest.raises(Exception) as excinfo:
+        builder._upload_to_tos(str(archive), config)
+
+    assert not isinstance(excinfo.value, ValueError)
+    msg = str(excinfo.value)
+    assert msg.startswith("Failed to upload to TOS:")
+    assert "unrendered template variables" in msg
+    assert "{{agent_name}}-bucket" in msg
+
+    # The guard still runs before any real upload flow: because the bucket name
+    # is validated before a TOSService instance is constructed, no fake service
+    # instance is created and no upload is attempted.
+    assert _FakeTOSService.instances == []
+
+
+# ---------------------------------------------------------------------------
+# Happy path: owned, existing bucket -> upload proceeds and returns URL+region.
+# ---------------------------------------------------------------------------
+
+def test_happy_path_uploads_and_returns_url_and_actual_region(monkeypatch, tmp_path):
+    _install_fake_tos(monkeypatch)
+    archive = tmp_path / "app.tar.gz"
+    archive.write_bytes(b"payload")
+
+    _FakeTOSService.bucket_exists_returns = True
+    _FakeTOSService.bucket_is_owned_returns = True
+    _FakeTOSService.upload_file_returns = (
+        "https://user-bucket.tos-cn-beijing.volces.com/agentkit-builds/app.tar.gz"
+    )
+
+    builder = VeCPCRBuilder()
+    config = _make_config(tos_bucket="user-bucket", tos_region="cn-beijing", tos_prefix="agentkit-builds")
+
+    url, region = builder._upload_to_tos(str(archive), config)
+
+    assert url == "https://user-bucket.tos-cn-beijing.volces.com/agentkit-builds/app.tar.gz"
+    assert region == "cn-beijing"
+
+    svc = _FakeTOSService.instances[-1]
+    # upload_file called with the object key derived from prefix + archive name.
+    upload_calls = [c for c in svc.calls if c[0] == "upload_file"]
+    assert len(upload_calls) == 1
+    assert upload_calls[0][1] == str(archive)
+    assert upload_calls[0][2] == "agentkit-builds/app.tar.gz"
+
+    # object key persisted back onto the config for later reference (L1086).
+    assert config.tos_object_key == "agentkit-builds/app.tar.gz"

--- a/tests/toolkit/cli/test_cli_sandbox.py
+++ b/tests/toolkit/cli/test_cli_sandbox.py
@@ -1136,7 +1136,7 @@ def test_cli_mount_uses_stored_session_tool_and_opens_tosbrowser(
         def read(self):
             return json.dumps(discovery).encode("utf-8")
 
-    def fake_urlopen(url):
+    def fake_urlopen(url, *args, **kwargs):
         captured["url"] = url
         return FakeResponse()
 
@@ -1235,7 +1235,7 @@ def test_cli_mount_uses_tool_tos_bucket_when_option_omitted(
             return json.dumps(discovery).encode("utf-8")
 
     opened = {}
-    monkeypatch.setattr(cli_mount, "urlopen", lambda _url: FakeResponse())
+    monkeypatch.setattr(cli_mount, "urlopen", lambda _url, *a, **k: FakeResponse())
     monkeypatch.setattr(
         cli_mount,
         "_open_tosbrowser",
@@ -1335,7 +1335,7 @@ def test_cli_mount_uses_latest_auth_session_when_oauth_url_omitted(
         def read(self):
             return json.dumps(discovery).encode("utf-8")
 
-    def fake_urlopen(url):
+    def fake_urlopen(url, *args, **kwargs):
         captured["url"] = url
         return FakeResponse()
 
@@ -1546,7 +1546,7 @@ def test_cli_mount_syncs_current_tool_sessions_when_session_not_cached(
             return json.dumps(discovery).encode("utf-8")
 
     opened = {}
-    monkeypatch.setattr(cli_mount, "urlopen", lambda _url: FakeResponse())
+    monkeypatch.setattr(cli_mount, "urlopen", lambda _url, *a, **k: FakeResponse())
     monkeypatch.setattr(
         cli_mount,
         "_open_tosbrowser",
@@ -1665,7 +1665,7 @@ def test_cli_mount_returns_install_hint_when_tosbrowser_is_missing(
         '"kLSApplicationNotFoundErr")'
     )
 
-    monkeypatch.setattr(cli_mount, "urlopen", lambda _url: FakeResponse())
+    monkeypatch.setattr(cli_mount, "urlopen", lambda _url, *a, **k: FakeResponse())
     monkeypatch.setattr(
         cli_mount,
         "_open_tosbrowser",

--- a/tests/toolkit/executors/test_base_executor_errors.py
+++ b/tests/toolkit/executors/test_base_executor_errors.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit tests for :mod:`agentkit.toolkit.executors.base_executor`.
+
+Covers the pure, side-effect-free helpers on ``BaseExecutor``: error
+classification (``_classify_error``), user-friendly error shaping
+(``_handle_exception``), strategy-class lookup (``_get_strategy_class``),
+preflight-result handling across every ``PreflightMode`` (``_handle_preflight_result``),
+and the ``ServiceNotEnabledException`` constructor. No network, docker, or
+``.run()`` is touched; the reporter is a hand-rolled recording fake so the
+WARN/PROMPT branches can be spied on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentkit.toolkit.executors.base_executor import (
+    BaseExecutor,
+    ServiceNotEnabledException,
+)
+from agentkit.toolkit.models import PreflightMode, PreflightResult
+from agentkit.toolkit.strategies import (
+    CloudStrategy,
+    HybridStrategy,
+    LocalStrategy,
+)
+
+
+class _FakeReporter:
+    """Recording reporter double.
+
+    Captures every message routed through the executor and lets a test dictate
+    the ``confirm`` return value, so the WARN and PROMPT preflight branches can
+    be asserted without any UI.
+    """
+
+    def __init__(self, confirm_return: bool = False) -> None:
+        self.confirm_return = confirm_return
+        self.info_calls: list[str] = []
+        self.warning_calls: list[str] = []
+        self.error_calls: list[str] = []
+        self.success_calls: list[str] = []
+        self.confirm_calls: list[tuple[str, bool]] = []
+
+    def info(self, message: str, **kwargs) -> None:
+        self.info_calls.append(message)
+
+    def success(self, message: str, **kwargs) -> None:
+        self.success_calls.append(message)
+
+    def warning(self, message: str, **kwargs) -> None:
+        self.warning_calls.append(message)
+
+    def error(self, message: str, **kwargs) -> None:
+        self.error_calls.append(message)
+
+    def progress(self, message: str, current: int, total: int = 100, **kwargs) -> None:
+        pass
+
+    def confirm(self, message: str, default: bool = False, **kwargs) -> bool:
+        self.confirm_calls.append((message, default))
+        return self.confirm_return
+
+
+# ---------------------------------------------------------------------------
+# ServiceNotEnabledException.__init__
+# ---------------------------------------------------------------------------
+
+
+def test_service_not_enabled_exception_exposes_missing_services_and_auth_url():
+    exc = ServiceNotEnabledException(
+        missing_services=["cr", "vefaas"],
+        auth_url="https://console.example.com/enable",
+    )
+    assert exc.missing_services == ["cr", "vefaas"]
+    assert exc.auth_url == "https://console.example.com/enable"
+
+
+def test_service_not_enabled_exception_formats_message_with_joined_services_and_url():
+    exc = ServiceNotEnabledException(
+        missing_services=["cr", "vefaas"],
+        auth_url="https://console.example.com/enable",
+    )
+    assert str(exc) == (
+        "Required services not enabled: cr, vefaas. "
+        "Please enable them at: https://console.example.com/enable"
+    )
+
+
+def test_service_not_enabled_exception_is_an_exception_subclass():
+    exc = ServiceNotEnabledException(missing_services=["cr"], auth_url="url")
+    assert isinstance(exc, Exception)
+
+
+# ---------------------------------------------------------------------------
+# _classify_error : exception type -> error code
+# ---------------------------------------------------------------------------
+
+
+def test_classify_error_maps_service_not_enabled_to_service_not_enabled_code():
+    ex = BaseExecutor()
+    error = ServiceNotEnabledException(missing_services=["cr"], auth_url="url")
+    assert ex._classify_error(error) == "SERVICE_NOT_ENABLED"
+
+
+def test_classify_error_maps_file_not_found_to_file_not_found_code():
+    ex = BaseExecutor()
+    assert ex._classify_error(FileNotFoundError("missing.yaml")) == "FILE_NOT_FOUND"
+
+
+def test_classify_error_maps_value_error_to_invalid_config_code():
+    ex = BaseExecutor()
+    assert ex._classify_error(ValueError("bad value")) == "INVALID_CONFIG"
+
+
+def test_classify_error_maps_permission_error_to_permission_denied_code():
+    ex = BaseExecutor()
+    assert ex._classify_error(PermissionError("nope")) == "PERMISSION_DENIED"
+
+
+def test_classify_error_maps_timeout_error_to_timeout_code():
+    ex = BaseExecutor()
+    assert ex._classify_error(TimeoutError("too slow")) == "TIMEOUT"
+
+
+def test_classify_error_maps_import_error_to_dependency_missing_code():
+    ex = BaseExecutor()
+    assert ex._classify_error(ImportError("no module")) == "DEPENDENCY_MISSING"
+
+
+def test_classify_error_maps_generic_exception_to_unknown_error_code():
+    ex = BaseExecutor()
+    assert ex._classify_error(RuntimeError("something odd")) == "UNKNOWN_ERROR"
+
+
+def test_classify_error_treats_service_not_enabled_ahead_of_generic_exception():
+    # ServiceNotEnabledException derives from Exception; the isinstance ladder
+    # must still classify it as the specific code, not fall through to UNKNOWN.
+    ex = BaseExecutor()
+    error = ServiceNotEnabledException(missing_services=["cr"], auth_url="url")
+    assert ex._classify_error(error) == "SERVICE_NOT_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# _handle_exception : user-friendly message + matching error_code
+# ---------------------------------------------------------------------------
+
+
+def test_handle_exception_returns_success_false_with_error_and_error_code_keys():
+    ex = BaseExecutor()
+    result = ex._handle_exception("build", RuntimeError("boom"))
+    assert set(result) == {"success", "error", "error_code"}
+    assert result["success"] is False
+
+
+def test_handle_exception_service_not_enabled_keeps_original_message_and_code():
+    ex = BaseExecutor()
+    error = ServiceNotEnabledException(
+        missing_services=["cr"], auth_url="https://enable.example"
+    )
+    result = ex._handle_exception("deploy", error)
+    assert result["error"] == str(error)
+    assert result["error_code"] == "SERVICE_NOT_ENABLED"
+
+
+def test_handle_exception_file_not_found_prefixes_file_not_found_message():
+    ex = BaseExecutor()
+    result = ex._handle_exception("build", FileNotFoundError("agentkit.yaml"))
+    assert result["error"] == "File not found: agentkit.yaml"
+    assert result["error_code"] == "FILE_NOT_FOUND"
+
+
+def test_handle_exception_value_error_prefixes_invalid_configuration_message():
+    ex = BaseExecutor()
+    result = ex._handle_exception("build", ValueError("missing agent_name"))
+    assert result["error"] == "Invalid configuration: missing agent_name"
+    assert result["error_code"] == "INVALID_CONFIG"
+
+
+def test_handle_exception_permission_error_prefixes_permission_denied_message():
+    ex = BaseExecutor()
+    result = ex._handle_exception("deploy", PermissionError("/etc/thing"))
+    assert result["error"] == "Permission denied: /etc/thing"
+    assert result["error_code"] == "PERMISSION_DENIED"
+
+
+def test_handle_exception_timeout_error_prefixes_operation_timeout_message():
+    ex = BaseExecutor()
+    result = ex._handle_exception("deploy", TimeoutError("waited 600s"))
+    assert result["error"] == "Operation timeout: waited 600s"
+    assert result["error_code"] == "TIMEOUT"
+
+
+def test_handle_exception_import_error_prefixes_missing_dependency_message():
+    ex = BaseExecutor()
+    result = ex._handle_exception("build", ImportError("no docker sdk"))
+    assert result["error"] == "Missing dependency: no docker sdk"
+    assert result["error_code"] == "DEPENDENCY_MISSING"
+
+
+def test_handle_exception_generic_exception_uses_raw_message_and_unknown_code():
+    ex = BaseExecutor()
+    result = ex._handle_exception("destroy", RuntimeError("weird failure"))
+    assert result["error"] == "weird failure"
+    assert result["error_code"] == "UNKNOWN_ERROR"
+
+
+def test_handle_exception_error_code_always_matches_classify_error():
+    ex = BaseExecutor()
+    for error in (
+        ServiceNotEnabledException(missing_services=["cr"], auth_url="u"),
+        FileNotFoundError("f"),
+        ValueError("v"),
+        PermissionError("p"),
+        TimeoutError("t"),
+        ImportError("i"),
+        RuntimeError("r"),
+    ):
+        result = ex._handle_exception("op", error)
+        assert result["error_code"] == ex._classify_error(error)
+
+
+# ---------------------------------------------------------------------------
+# _get_strategy_class : launch_type -> strategy class / ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_get_strategy_class_returns_local_strategy_for_local():
+    ex = BaseExecutor()
+    assert ex._get_strategy_class("local") is LocalStrategy
+
+
+def test_get_strategy_class_returns_cloud_strategy_for_cloud():
+    ex = BaseExecutor()
+    assert ex._get_strategy_class("cloud") is CloudStrategy
+
+
+def test_get_strategy_class_returns_hybrid_strategy_for_hybrid():
+    ex = BaseExecutor()
+    assert ex._get_strategy_class("hybrid") is HybridStrategy
+
+
+def test_get_strategy_class_raises_value_error_listing_available_strategies_for_unknown():
+    ex = BaseExecutor()
+    with pytest.raises(ValueError) as excinfo:
+        ex._get_strategy_class("serverless")
+    message = str(excinfo.value)
+    assert "serverless" in message
+    assert "local" in message
+    assert "cloud" in message
+    assert "hybrid" in message
+
+
+# ---------------------------------------------------------------------------
+# _handle_preflight_result : behaviour across every PreflightMode
+# ---------------------------------------------------------------------------
+
+
+def test_handle_preflight_result_returns_true_when_result_passed_regardless_of_mode():
+    ex = BaseExecutor(reporter=_FakeReporter())
+    passed = PreflightResult(passed=True, missing_services=[])
+    # A passing result short-circuits before mode is even consulted.
+    assert ex._handle_preflight_result(passed, PreflightMode.FAIL) is True
+
+
+def test_handle_preflight_result_skip_mode_returns_true_without_reporting():
+    reporter = _FakeReporter()
+    ex = BaseExecutor(reporter=reporter)
+    result = PreflightResult(
+        passed=False, missing_services=["cr"], auth_url="https://enable.example"
+    )
+    assert ex._handle_preflight_result(result, PreflightMode.SKIP) is True
+    assert reporter.warning_calls == []
+    assert reporter.info_calls == []
+
+
+def test_handle_preflight_result_warn_mode_returns_true_and_reports_message_and_url():
+    reporter = _FakeReporter()
+    ex = BaseExecutor(reporter=reporter)
+    result = PreflightResult(
+        passed=False, missing_services=["cr"], auth_url="https://enable.example"
+    )
+    assert ex._handle_preflight_result(result, PreflightMode.WARN) is True
+    assert reporter.warning_calls == [result.message]
+    assert reporter.info_calls == ["Enable services at: https://enable.example"]
+
+
+def test_handle_preflight_result_fail_mode_raises_service_not_enabled_with_details():
+    ex = BaseExecutor(reporter=_FakeReporter())
+    result = PreflightResult(
+        passed=False,
+        missing_services=["cr", "vefaas"],
+        auth_url="https://enable.example",
+    )
+    with pytest.raises(ServiceNotEnabledException) as excinfo:
+        ex._handle_preflight_result(result, PreflightMode.FAIL)
+    assert excinfo.value.missing_services == ["cr", "vefaas"]
+    assert excinfo.value.auth_url == "https://enable.example"
+
+
+def test_handle_preflight_result_prompt_mode_delegates_to_reporter_confirm_true():
+    reporter = _FakeReporter(confirm_return=True)
+    ex = BaseExecutor(reporter=reporter)
+    result = PreflightResult(
+        passed=False, missing_services=["cr"], auth_url="https://enable.example"
+    )
+    assert ex._handle_preflight_result(result, PreflightMode.PROMPT) is True
+    # The warning + info are emitted before the prompt, and confirm drives the result.
+    assert reporter.warning_calls == [result.message]
+    assert reporter.info_calls == ["Enable services at: https://enable.example"]
+    assert reporter.confirm_calls == [
+        ("Continue without enabling services?", False)
+    ]
+
+
+def test_handle_preflight_result_prompt_mode_returns_false_when_reporter_declines():
+    reporter = _FakeReporter(confirm_return=False)
+    ex = BaseExecutor(reporter=reporter)
+    result = PreflightResult(
+        passed=False, missing_services=["cr"], auth_url="https://enable.example"
+    )
+    assert ex._handle_preflight_result(result, PreflightMode.PROMPT) is False
+    assert reporter.confirm_calls == [
+        ("Continue without enabling services?", False)
+    ]

--- a/tests/toolkit/executors/test_init_executor.py
+++ b/tests/toolkit/executors/test_init_executor.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit tests for ``InitExecutor`` scaffolding behavior.
+
+These tests exercise the pure, filesystem-only surface of
+``agentkit.toolkit.executors.init_executor.InitExecutor`` -- the render-context
+builder, the template registry accessor, ``init_project`` validation gates and
+its Python happy path, and the harness scaffold. ``_setup_config_launch_type`` /
+cloud-provider region defaults are intentionally NOT re-covered here; that lives
+in ``test_init_cloud_provider_defaults.py``.
+
+All filesystem writes go to ``tmp_path``. No network, docker, or ``.run()`` is
+touched: ``init_project`` only renders a Jinja template to text and writes
+config/dockerignore files, none of which import the agent's runtime deps.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agentkit.toolkit.executors.init_executor import InitExecutor, TEMPLATES
+from agentkit.toolkit.models import InitResult
+
+
+def _read_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    assert isinstance(data, dict)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# _build_render_context
+# ---------------------------------------------------------------------------
+
+
+def test_build_render_context_omits_all_none_arguments() -> None:
+    executor = InitExecutor()
+    ctx = executor._build_render_context(None, None, None, None, None)
+    assert ctx == {}
+
+
+def test_build_render_context_includes_only_non_none_keys() -> None:
+    executor = InitExecutor()
+    ctx = executor._build_render_context(
+        agent_name="MyAgent",
+        description=None,
+        system_prompt="be helpful",
+        model_name=None,
+        tools=None,
+    )
+    assert ctx == {"agent_name": "MyAgent", "system_prompt": "be helpful"}
+    assert "description" not in ctx
+    assert "model_name" not in ctx
+    assert "tools" not in ctx
+
+
+def test_build_render_context_splits_and_trims_tools_into_list() -> None:
+    executor = InitExecutor()
+    ctx = executor._build_render_context(
+        None, None, None, None, tools=" web_search , run_code ,,  calculator "
+    )
+    # Comma-split, each entry stripped, blank entries dropped.
+    assert ctx["tools"] == ["web_search", "run_code", "calculator"]
+
+
+def test_build_render_context_empty_tools_string_yields_empty_list_but_key_present() -> None:
+    executor = InitExecutor()
+    # tools is not None, so the key is added even though every entry is blank.
+    ctx = executor._build_render_context(None, None, None, None, tools="  , ,")
+    assert ctx["tools"] == []
+    assert "tools" in ctx
+
+
+# ---------------------------------------------------------------------------
+# get_available_templates
+# ---------------------------------------------------------------------------
+
+
+def test_get_available_templates_returns_the_registered_template_keys() -> None:
+    executor = InitExecutor()
+    templates = executor.get_available_templates()
+    # Pin the shape: at least the "basic" Python template is present and typed.
+    assert "basic" in templates
+    assert templates["basic"]["language"] == "Python"
+    assert templates["basic"]["name"] == "Basic Agent App"
+
+
+def test_get_available_templates_returns_a_copy_that_does_not_mutate_source() -> None:
+    executor = InitExecutor()
+    templates = executor.get_available_templates()
+
+    original_keys = set(TEMPLATES.keys())
+    templates["__injected__"] = {"name": "bogus"}
+    del templates["basic"]
+
+    # The returned dict is a shallow copy: top-level mutation must not leak.
+    assert "__injected__" not in TEMPLATES
+    assert "basic" in TEMPLATES
+    assert set(TEMPLATES.keys()) == original_keys
+
+
+# ---------------------------------------------------------------------------
+# init_project validation early-returns
+# ---------------------------------------------------------------------------
+
+
+def test_init_project_rejects_invalid_project_name(tmp_path: Path) -> None:
+    executor = InitExecutor()
+    result = executor.init_project(
+        project_name="bad name!",
+        template="basic",
+        directory=str(tmp_path),
+    )
+    assert isinstance(result, InitResult)
+    assert result.success is False
+    assert result.error_code == "INVALID_CONFIG"
+    assert "invalid characters" in result.error
+    # Early return: no scaffolding happened.
+    assert not (tmp_path / "agentkit.yaml").exists()
+
+
+def test_init_project_rejects_unknown_template_and_lists_available(
+    tmp_path: Path,
+) -> None:
+    executor = InitExecutor()
+    result = executor.init_project(
+        project_name="demo",
+        template="does_not_exist",
+        directory=str(tmp_path),
+    )
+    assert result.success is False
+    assert result.error_code == "INVALID_CONFIG"
+    assert "Unknown template 'does_not_exist'" in result.error
+    assert "Available:" in result.error
+    # The available list must name a real registered template.
+    assert "basic" in result.error
+
+
+def test_init_project_rejects_unsupported_language_template(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Inject a fake template whose language is neither Python nor Golang so the
+    # language branch falls through to the "Unsupported language" early return.
+    import agentkit.toolkit.executors.init_executor as init_mod
+
+    fake_templates = dict(TEMPLATES)
+    fake_templates["_ruby_"] = {
+        "file": "nope.rb",
+        "name": "Ruby App",
+        "language": "Ruby",
+        "language_version": "3.3",
+        "description": "unsupported",
+        "type": "Basic App",
+    }
+    monkeypatch.setattr(init_mod, "TEMPLATES", fake_templates)
+
+    executor = InitExecutor()
+    result = executor.init_project(
+        project_name="demo",
+        template="_ruby_",
+        directory=str(tmp_path),
+    )
+    assert result.success is False
+    assert result.error_code == "INVALID_CONFIG"
+    assert "Unsupported language: Ruby" in result.error
+
+
+# ---------------------------------------------------------------------------
+# init_project happy path (Python "basic")
+# ---------------------------------------------------------------------------
+
+
+def test_init_project_python_basic_scaffolds_expected_files_and_metadata(
+    tmp_path: Path,
+) -> None:
+    executor = InitExecutor()
+    result = executor.init_project(
+        project_name="demo_agent",
+        template="basic",
+        directory=str(tmp_path),
+    )
+
+    assert result.success is True
+    assert result.template == "basic"
+    assert result.project_name == "demo_agent"
+    assert Path(result.project_path) == tmp_path.resolve()
+
+    # Entry file is named after the project, ends in .py, and was rendered from
+    # the Jinja template (license header survives the render).
+    entry_file = tmp_path / "demo_agent.py"
+    assert entry_file.exists()
+    assert "Apache License" in entry_file.read_text(encoding="utf-8")
+
+    requirements = tmp_path / "requirements.txt"
+    assert requirements.exists()
+    assert "veadk-python" in requirements.read_text(encoding="utf-8")
+
+    config_file = tmp_path / "agentkit.yaml"
+    assert config_file.exists()
+
+    dockerignore = tmp_path / ".dockerignore"
+    assert dockerignore.exists()
+
+    # created_files tracks the files produced this run.
+    assert "demo_agent.py" in result.created_files
+    assert "requirements.txt" in result.created_files
+    assert "agentkit.yaml" in result.created_files
+    assert ".dockerignore" in result.created_files
+
+    # Metadata reflects the resolved template.
+    assert result.metadata["language"] == "Python"
+    assert result.metadata["entry_point"] == "demo_agent.py"
+    assert result.metadata["template_name"] == "Basic Agent App"
+
+
+def test_init_project_python_basic_writes_project_name_into_config(
+    tmp_path: Path,
+) -> None:
+    executor = InitExecutor()
+    result = executor.init_project(
+        project_name="demo_agent",
+        template="basic",
+        directory=str(tmp_path),
+    )
+    assert result.success is True
+
+    data = _read_yaml(tmp_path / "agentkit.yaml")
+    common = data.get("common") or {}
+    assert common.get("agent_name") == "demo_agent"
+    assert common.get("language") == "Python"
+    assert common.get("entry_point") == "demo_agent.py"
+
+
+# ---------------------------------------------------------------------------
+# init_harness
+# ---------------------------------------------------------------------------
+
+
+def test_init_harness_writes_env_example_and_dockerfile(tmp_path: Path) -> None:
+    executor = InitExecutor()
+    result = executor.init_harness(project_name="myharness", directory=str(tmp_path))
+
+    assert result.success is True
+    assert result.template == "harness"
+    assert result.metadata["template_name"] == "Harness"
+
+    harness_dir = tmp_path / "myharness"
+    env_example = harness_dir / ".env.example"
+    dockerfile = harness_dir / "Dockerfile"
+
+    assert env_example.exists()
+    assert dockerfile.exists()
+    assert ".env.example" in result.created_files
+    assert "Dockerfile" in result.created_files
+
+    dockerfile_text = dockerfile.read_text(encoding="utf-8")
+    assert dockerfile_text.startswith("FROM ")
+    assert 'CMD ["python"' in dockerfile_text
+
+
+def test_init_harness_env_example_ships_empty_credential_placeholders(
+    tmp_path: Path,
+) -> None:
+    executor = InitExecutor()
+    executor.init_harness(project_name="myharness", directory=str(tmp_path))
+
+    env_text = (tmp_path / "myharness" / ".env.example").read_text(encoding="utf-8")
+
+    # Secret-hygiene pin: credential keys are present but carry NO value. The
+    # AK/SK placeholders must be empty (key= with nothing after the '=').
+    lines = {
+        line.split("=", 1)[0]: line.split("=", 1)[1]
+        for line in env_text.splitlines()
+        if "=" in line and not line.lstrip().startswith("#")
+    }
+    assert lines["VOLCENGINE_ACCESS_KEY"] == ""
+    assert lines["VOLCENGINE_SECRET_KEY"] == ""
+
+
+def test_init_harness_is_idempotent_and_skips_existing_files(tmp_path: Path) -> None:
+    executor = InitExecutor()
+
+    first = executor.init_harness(project_name="myharness", directory=str(tmp_path))
+    assert first.success is True
+    assert set(first.created_files) == {".env.example", "Dockerfile"}
+
+    harness_dir = tmp_path / "myharness"
+    # User customizes .env.example after the first init.
+    sentinel = "VOLCENGINE_ACCESS_KEY=preserved\n"
+    (harness_dir / ".env.example").write_text(sentinel, encoding="utf-8")
+
+    second = executor.init_harness(project_name="myharness", directory=str(tmp_path))
+    assert second.success is True
+    # Both files already exist: nothing is re-created and edits are preserved.
+    assert second.created_files == []
+    assert (harness_dir / ".env.example").read_text(encoding="utf-8") == sentinel
+
+
+def test_init_harness_rejects_invalid_project_name(tmp_path: Path) -> None:
+    executor = InitExecutor()
+    result = executor.init_harness(project_name="bad name!", directory=str(tmp_path))
+    assert result.success is False
+    assert result.error_code == "INVALID_CONFIG"
+    assert "invalid characters" in result.error

--- a/tests/toolkit/runners/test_runner_base_helpers.py
+++ b/tests/toolkit/runners/test_runner_base_helpers.py
@@ -1,0 +1,404 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit coverage for the pure helper methods on ``Runner``.
+
+These pin the request/response shape helpers on
+``agentkit.toolkit.runners.base.Runner`` -- backend classification
+(``_is_adk_list_apps_response`` / ``_is_a2a_agent_card_response``), fallback
+signature detection (``_should_fallback_to_adk``), the camelCase ADK and
+JSON-RPC A2A payload builders, endpoint normalization, and the TTL-based
+backend cache. ``_invoke_with_adk_compat`` is exercised elsewhere
+(test_runner_backend_autodetect.py) and is intentionally not re-covered here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class _DummyRunner:
+    """Concrete stand-in for the abstract ``Runner`` base class.
+
+    Mirrors the pattern in test_runner_backend_autodetect.py: build an
+    ``_Impl`` subclass that stubs the abstract methods so ``Runner`` can be
+    instantiated to reach its concrete helper methods.
+    """
+
+    def __new__(cls):
+        from agentkit.toolkit.runners.base import Runner
+
+        class _Impl(Runner):
+            def deploy(self, config):
+                raise NotImplementedError()
+
+            def destroy(self, config):
+                raise NotImplementedError()
+
+            def status(self, config):
+                raise NotImplementedError()
+
+            def invoke(self, config, payload, headers=None, stream=None):
+                raise NotImplementedError()
+
+        return _Impl()
+
+
+# ===== _is_a2a =====
+
+
+class _FakeCommonConfig:
+    def __init__(self, agent_type: Any = None, template_type: Any = None) -> None:
+        self.agent_type = agent_type
+        self.template_type = template_type
+
+
+def test_is_a2a_true_when_agent_type_contains_a2a_case_insensitive() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a(_FakeCommonConfig(agent_type="A2A")) is True
+    assert runner._is_a2a(_FakeCommonConfig(agent_type="my-a2a-agent")) is True
+
+
+def test_is_a2a_true_when_only_template_type_contains_a2a() -> None:
+    runner = _DummyRunner()
+    cfg = _FakeCommonConfig(agent_type=None, template_type="a2a-template")
+    assert runner._is_a2a(cfg) is True
+
+
+def test_is_a2a_false_when_neither_field_mentions_a2a() -> None:
+    runner = _DummyRunner()
+    cfg = _FakeCommonConfig(agent_type="adk", template_type="langgraph")
+    assert runner._is_a2a(cfg) is False
+
+
+def test_is_a2a_false_when_common_config_is_none() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a(None) is False
+
+
+def test_is_a2a_none_safe_when_both_fields_are_none() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a(_FakeCommonConfig(agent_type=None, template_type=None)) is False
+
+
+# ===== _is_adk_list_apps_response =====
+
+
+def test_is_adk_list_apps_response_true_for_list() -> None:
+    runner = _DummyRunner()
+    assert runner._is_adk_list_apps_response([]) is True
+    assert runner._is_adk_list_apps_response(["app_a", "app_b"]) is True
+
+
+def test_is_adk_list_apps_response_true_for_dict_with_apps_key() -> None:
+    runner = _DummyRunner()
+    assert runner._is_adk_list_apps_response({"apps": ["x"]}) is True
+    # Presence of the key is sufficient regardless of the value.
+    assert runner._is_adk_list_apps_response({"apps": None}) is True
+
+
+def test_is_adk_list_apps_response_false_for_dict_without_apps_key() -> None:
+    runner = _DummyRunner()
+    assert runner._is_adk_list_apps_response({"name": "x"}) is False
+
+
+def test_is_adk_list_apps_response_false_for_scalar_types() -> None:
+    runner = _DummyRunner()
+    assert runner._is_adk_list_apps_response(None) is False
+    assert runner._is_adk_list_apps_response("apps") is False
+    assert runner._is_adk_list_apps_response(42) is False
+
+
+# ===== _is_a2a_agent_card_response =====
+
+
+def test_is_a2a_agent_card_response_true_with_name_and_capabilities_dict() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a_agent_card_response({"name": "a", "capabilities": {}}) is True
+
+
+def test_is_a2a_agent_card_response_true_with_name_and_skills_list() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a_agent_card_response({"name": "a", "skills": []}) is True
+
+
+def test_is_a2a_agent_card_response_true_with_name_and_endpoints() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a_agent_card_response({"name": "a", "endpoints": {}}) is True
+    assert runner._is_a2a_agent_card_response({"name": "a", "endpoints": []}) is True
+
+
+def test_is_a2a_agent_card_response_true_with_name_and_protocol_version() -> None:
+    runner = _DummyRunner()
+    assert (
+        runner._is_a2a_agent_card_response({"name": "a", "protocol_version": "1.0"})
+        is True
+    )
+    assert (
+        runner._is_a2a_agent_card_response({"name": "a", "protocolVersion": "1.0"})
+        is True
+    )
+
+
+def test_is_a2a_agent_card_response_false_when_name_present_but_no_signal_field() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a_agent_card_response({"name": "a"}) is False
+
+
+def test_is_a2a_agent_card_response_false_when_name_missing_or_empty() -> None:
+    runner = _DummyRunner()
+    # Signal fields present but no valid name -> False.
+    assert runner._is_a2a_agent_card_response({"capabilities": {}}) is False
+    assert runner._is_a2a_agent_card_response({"name": "", "capabilities": {}}) is False
+    assert runner._is_a2a_agent_card_response({"name": 123, "capabilities": {}}) is False
+
+
+def test_is_a2a_agent_card_response_false_for_non_dict() -> None:
+    runner = _DummyRunner()
+    assert runner._is_a2a_agent_card_response(None) is False
+    assert runner._is_a2a_agent_card_response(["name"]) is False
+
+
+def test_is_a2a_agent_card_response_false_when_signal_fields_wrong_types() -> None:
+    runner = _DummyRunner()
+    # capabilities must be dict, skills must be list, protocol_version must be str.
+    data = {
+        "name": "a",
+        "capabilities": ["not-a-dict"],
+        "skills": {"not": "a-list"},
+        "protocol_version": 1.0,
+    }
+    assert runner._is_a2a_agent_card_response(data) is False
+
+
+# ===== _should_fallback_to_adk =====
+
+
+def test_should_fallback_to_adk_true_for_404_signatures() -> None:
+    runner = _DummyRunner()
+    assert runner._should_fallback_to_adk("Invocation failed: 404") is True
+    assert runner._should_fallback_to_adk("HTTP 404 Not Found") is True
+
+
+def test_should_fallback_to_adk_true_for_405_signatures() -> None:
+    runner = _DummyRunner()
+    assert runner._should_fallback_to_adk("Invocation failed: 405") is True
+    assert runner._should_fallback_to_adk("got 405 method not allowed") is True
+
+
+def test_should_fallback_to_adk_false_for_other_errors_and_empty() -> None:
+    runner = _DummyRunner()
+    assert runner._should_fallback_to_adk("Invocation failed: 500") is False
+    assert runner._should_fallback_to_adk("connection refused") is False
+    assert runner._should_fallback_to_adk("") is False
+    # None is tolerated (coerced to "") and yields False.
+    assert runner._should_fallback_to_adk(None) is False
+
+
+def test_should_fallback_to_adk_false_when_404_lacks_surrounding_spaces() -> None:
+    runner = _DummyRunner()
+    # The bare-code check requires " 404 " with spaces on both sides and the
+    # prefix check requires the exact "Invocation failed: 404" start, so a
+    # substring like "err404code" matches neither.
+    assert runner._should_fallback_to_adk("err404code") is False
+
+
+# ===== _build_adk_run_sse_payload =====
+
+
+def test_build_adk_run_sse_payload_uses_camelcase_and_prompt_text() -> None:
+    runner = _DummyRunner()
+    req = runner._build_adk_run_sse_payload(
+        app_name="my_app",
+        headers={"user_id": "u1", "session_id": "s1"},
+        original_payload={"prompt": "hello"},
+    )
+    assert req == {
+        "appName": "my_app",
+        "userId": "u1",
+        "sessionId": "s1",
+        "newMessage": {"role": "user", "parts": [{"text": "hello"}]},
+        "streaming": True,
+    }
+
+
+def test_build_adk_run_sse_payload_falls_back_to_x_prefixed_headers() -> None:
+    runner = _DummyRunner()
+    req = runner._build_adk_run_sse_payload(
+        app_name="app",
+        headers={"x-user-id": "xu", "x-session-id": "xs"},
+        original_payload={"prompt": "hi"},
+    )
+    assert req["userId"] == "xu"
+    assert req["sessionId"] == "xs"
+
+
+def test_build_adk_run_sse_payload_uses_defaults_when_headers_missing() -> None:
+    runner = _DummyRunner()
+    req = runner._build_adk_run_sse_payload(
+        app_name="app", headers={}, original_payload={"prompt": "hi"}
+    )
+    assert req["userId"] == "agentkit_user"
+    assert req["sessionId"] == "agentkit_sample_session"
+
+
+def test_build_adk_run_sse_payload_json_dumps_fallback_when_no_prompt() -> None:
+    runner = _DummyRunner()
+    req = runner._build_adk_run_sse_payload(
+        app_name="app", headers={}, original_payload={"foo": "bar"}
+    )
+    # No string "prompt" key -> the whole payload is JSON-serialized as the text.
+    assert req["newMessage"]["parts"][0]["text"] == '{"foo": "bar"}'
+
+
+def test_build_adk_run_sse_payload_json_dumps_fallback_when_prompt_not_a_string() -> None:
+    runner = _DummyRunner()
+    req = runner._build_adk_run_sse_payload(
+        app_name="app", headers={}, original_payload={"prompt": 123}
+    )
+    # Non-string prompt is ignored; falls back to serializing the payload.
+    assert req["newMessage"]["parts"][0]["text"] == '{"prompt": 123}'
+
+
+def test_build_adk_run_sse_payload_maps_state_delta_to_camelcase() -> None:
+    runner = _DummyRunner()
+    req = runner._build_adk_run_sse_payload(
+        app_name="app",
+        headers={},
+        original_payload={"prompt": "hi", "state_delta": {"k": "v"}},
+    )
+    assert req["stateDelta"] == {"k": "v"}
+
+
+def test_build_adk_run_sse_payload_omits_state_delta_when_absent() -> None:
+    runner = _DummyRunner()
+    req = runner._build_adk_run_sse_payload(
+        app_name="app", headers={}, original_payload={"prompt": "hi"}
+    )
+    assert "stateDelta" not in req
+
+
+# ===== _build_a2a_jsonrpc_payload =====
+
+
+def test_build_a2a_jsonrpc_payload_passthrough_when_already_jsonrpc() -> None:
+    runner = _DummyRunner()
+    original = {"jsonrpc": "2.0", "method": "custom", "params": {}, "id": 7}
+    result = runner._build_a2a_jsonrpc_payload(original, headers={"h": "v"})
+    # Returned object is the same dict, untouched.
+    assert result is original
+
+
+def test_build_a2a_jsonrpc_payload_builds_message_stream_envelope(monkeypatch) -> None:
+    import agentkit.toolkit.runners.base as base_mod
+
+    runner = _DummyRunner()
+
+    class _FixedUUID:
+        def __str__(self) -> str:
+            return "fixed-message-id"
+
+    monkeypatch.setattr(base_mod.uuid, "uuid4", lambda: _FixedUUID())
+    monkeypatch.setattr(base_mod.random, "randint", lambda a, b: 4242)
+
+    headers = {"user_id": "u", "session_id": "s"}
+    result = runner._build_a2a_jsonrpc_payload({"prompt": "hey"}, headers=headers)
+
+    assert result == {
+        "jsonrpc": "2.0",
+        "method": "message/stream",
+        "params": {
+            "message": {
+                "role": "user",
+                "messageId": "fixed-message-id",
+                "parts": [{"kind": "text", "text": "hey"}],
+            },
+            "metadata": headers,
+        },
+        "id": 4242,
+    }
+
+
+def test_build_a2a_jsonrpc_payload_json_dumps_fallback_when_no_prompt(monkeypatch) -> None:
+    import agentkit.toolkit.runners.base as base_mod
+
+    runner = _DummyRunner()
+
+    class _FixedUUID:
+        def __str__(self) -> str:
+            return "mid"
+
+    monkeypatch.setattr(base_mod.uuid, "uuid4", lambda: _FixedUUID())
+    monkeypatch.setattr(base_mod.random, "randint", lambda a, b: 1)
+
+    result = runner._build_a2a_jsonrpc_payload({"foo": "bar"}, headers={})
+    text = result["params"]["message"]["parts"][0]["text"]
+    assert text == '{"foo": "bar"}'
+
+
+# ===== _normalize_base_endpoint =====
+
+
+def test_normalize_base_endpoint_strips_trailing_slashes() -> None:
+    runner = _DummyRunner()
+    assert runner._normalize_base_endpoint("https://x/") == "https://x"
+    assert runner._normalize_base_endpoint("https://x///") == "https://x"
+
+
+def test_normalize_base_endpoint_leaves_clean_url_untouched() -> None:
+    runner = _DummyRunner()
+    assert runner._normalize_base_endpoint("https://x/path") == "https://x/path"
+
+
+def test_normalize_base_endpoint_handles_empty_string() -> None:
+    runner = _DummyRunner()
+    assert runner._normalize_base_endpoint("") == ""
+
+
+# ===== _get_cached_backend / _set_cached_backend =====
+
+
+def test_cached_backend_roundtrip_and_key_normalization() -> None:
+    runner = _DummyRunner()
+    runner._backend_detect_cache_ttl_s = 9999
+    # Trailing slashes normalize to the same key.
+    runner._set_cached_backend("https://x/", "adk")
+    assert runner._get_cached_backend("https://x") == "adk"
+    assert runner._get_cached_backend("https://x///") == "adk"
+
+
+def test_get_cached_backend_returns_none_when_unset() -> None:
+    runner = _DummyRunner()
+    assert runner._get_cached_backend("https://never-set") is None
+
+
+def test_get_cached_backend_evicts_expired_entry(monkeypatch) -> None:
+    import agentkit.toolkit.runners.base as base_mod
+
+    runner = _DummyRunner()
+    runner._backend_detect_cache_ttl_s = 100
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(base_mod.time, "monotonic", lambda: clock["t"])
+
+    runner._set_cached_backend("https://x", "a2a")
+    # Still within TTL.
+    clock["t"] = 1000.0 + 100
+    assert runner._get_cached_backend("https://x") == "a2a"
+
+    # Advance strictly past the TTL -> entry is evicted and None is returned.
+    clock["t"] = 1000.0 + 100 + 1
+    assert runner._get_cached_backend("https://x") is None
+    # Eviction removed the key from the underlying cache dict.
+    assert "https://x" not in runner._backend_detect_cache

--- a/tests/toolkit/runners/test_runner_base_invoke.py
+++ b/tests/toolkit/runners/test_runner_base_invoke.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+"""Behavioral coverage for Runner._http_post_invoke -- the core invoke transport
+that serves all agent traffic. Each test drives a REAL branch of the transport
+by patching agentkit.toolkit.runners.base.requests.post with a hand-rolled
+_FakeResponse and asserting on the (ok, payload_or_error) contract, the request
+args the transport sent, and (for streaming) the assembled generator output.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+
+class _DummyRunner:
+    """Concrete Runner with abstract methods stubbed, mirroring the seam used by
+    tests/toolkit/runners/test_runner_backend_autodetect.py."""
+
+    def __new__(cls):
+        from agentkit.toolkit.runners.base import Runner
+
+        class _Impl(Runner):
+            def deploy(self, config):  # pragma: no cover - not exercised here
+                raise NotImplementedError()
+
+            def destroy(self, config):  # pragma: no cover
+                raise NotImplementedError()
+
+            def status(self, config):  # pragma: no cover
+                raise NotImplementedError()
+
+            def invoke(self, config, payload, headers=None, stream=None):  # pragma: no cover
+                raise NotImplementedError()
+
+        return _Impl()
+
+
+class _FakeResponse:
+    """Mimics the subset of requests.Response that _http_post_invoke touches:
+    status_code, headers (Content-Type lookup), .text, .json(), .iter_lines()."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        content_type: str = "application/json",
+        text: str = "",
+        json_data: Any = None,
+        json_error: Optional[Exception] = None,
+        lines: Optional[List[str]] = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type}
+        self.text = text
+        self._json_data = json_data
+        self._json_error = json_error
+        self._lines = lines or []
+
+    def json(self) -> Any:
+        if self._json_error is not None:
+            raise self._json_error
+        return self._json_data
+
+    def iter_lines(self, decode_unicode: bool = False):  # noqa: ARG002
+        for line in self._lines:
+            yield line
+
+    def iter_content(self, *args, **kwargs):  # pragma: no cover - unused by transport
+        return iter(())
+
+
+@pytest.fixture
+def runner():
+    return _DummyRunner()
+
+
+@pytest.fixture
+def patched_post(monkeypatch):
+    """Install a controllable fake requests.post at the base module. Returns a
+    (set_response, calls) pair: set_response(resp_or_exc) installs the next
+    response (or an exception the fake should raise), and calls records the
+    kwargs each POST was made with."""
+    import agentkit.toolkit.runners.base as base_mod
+
+    state: Dict[str, Any] = {"response": None, "raise": None}
+    calls: List[Dict[str, Any]] = []
+
+    def _fake_post(url=None, json=None, headers=None, timeout=None, stream=None, **kwargs):
+        calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+                "stream": stream,
+            }
+        )
+        if state["raise"] is not None:
+            raise state["raise"]
+        return state["response"]
+
+    monkeypatch.setattr(base_mod.requests, "post", _fake_post)
+
+    def set_response(resp: _FakeResponse) -> None:
+        state["response"] = resp
+        state["raise"] = None
+
+    def set_raise(exc: Exception) -> None:
+        state["raise"] = exc
+        state["response"] = None
+
+    return set_response, set_raise, calls
+
+
+def test_non_200_status_returns_error_string_echoing_status(runner, patched_post):
+    set_response, _set_raise, calls = patched_post
+    set_response(
+        _FakeResponse(status_code=503, text="upstream down", content_type="text/plain")
+    )
+
+    ok, payload = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={"authorization": "token"},
+        stream=False,
+    )
+
+    assert ok is False
+    assert isinstance(payload, str)
+    assert "503" in payload
+    assert "upstream down" in payload
+    assert payload.startswith("Invocation failed: 503")
+    # The transport must actually have POSTed the given endpoint/payload/headers.
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://svc/invoke"
+    assert calls[0]["json"] == {"prompt": "hi"}
+    assert calls[0]["headers"] == {"authorization": "token"}
+
+
+def test_streaming_sse_detected_via_content_type_assembles_events(runner, patched_post):
+    set_response, _set_raise, _calls = patched_post
+    set_response(
+        _FakeResponse(
+            status_code=200,
+            content_type="text/event-stream; charset=utf-8",
+            lines=[
+                'data: {"delta": "he"}',
+                "",
+                ": this is an SSE comment line",
+                'data: {"delta": "llo"}',
+                "data: not-json-should-be-skipped",
+                "",
+                'data: {"done": true}',
+            ],
+        )
+    )
+
+    ok, gen = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={},
+        stream=None,  # auto-detect -> Content-Type says event-stream -> stream
+    )
+
+    assert ok is True
+    # Generator, not a materialized structure.
+    assert not isinstance(gen, (dict, list, str, bytes))
+    events = list(gen)
+    # Comment line, blank lines, and the un-parseable data line are all dropped.
+    assert events == [{"delta": "he"}, {"delta": "llo"}, {"done": True}]
+
+
+def test_non_stream_json_body_is_parsed_and_returned(runner, patched_post):
+    set_response, _set_raise, calls = patched_post
+    body = {"result": {"text": "done"}, "usage": {"tokens": 7}}
+    set_response(
+        _FakeResponse(
+            status_code=200,
+            content_type="application/json",
+            text='{"result": {"text": "done"}, "usage": {"tokens": 7}}',
+            json_data=body,
+        )
+    )
+
+    ok, payload = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={},
+        stream=None,  # auto-detect -> non-event-stream content-type -> non-stream JSON
+    )
+
+    assert ok is True
+    assert payload == body
+    # Auto-detect starts in stream mode, so the transport requests a streamed POST
+    # and bumps the timeout to at least 300s (line ~166 of base.py).
+    assert calls[0]["stream"] is True
+    assert calls[0]["timeout"] == 300
+
+
+def test_sse_masquerade_body_starting_with_data_is_parsed_as_sse(runner, patched_post):
+    set_response, _set_raise, _calls = patched_post
+    # 200 + non-event-stream Content-Type, but the body is actually SSE. The
+    # transport's ~L210 double-check must switch to the fallback SSE parser.
+    sse_text = (
+        'data: {"delta": "a"}\n'
+        "\n"
+        'data: {"delta": "b"}\n'
+        "data: broken-json\n"
+        'data: {"end": 1}\n'
+    )
+    set_response(
+        _FakeResponse(
+            status_code=200,
+            content_type="application/json",
+            text=sse_text,
+        )
+    )
+
+    ok, gen = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={},
+        stream=None,
+    )
+
+    assert ok is True
+    assert not isinstance(gen, (dict, list, str, bytes))
+    events = list(gen)
+    # Un-parseable "broken-json" line skipped; blank line skipped.
+    assert events == [{"delta": "a"}, {"delta": "b"}, {"end": 1}]
+
+
+def test_json_parse_error_on_200_body_returns_error_not_exception(runner, patched_post):
+    set_response, _set_raise, _calls = patched_post
+    # 200, content-type not event-stream, body does NOT start with "data: ",
+    # but .json() raises ValueError -> mapped to (False, "Response parsing failed: ...").
+    set_response(
+        _FakeResponse(
+            status_code=200,
+            content_type="application/json",
+            text="<html>not json</html>",
+            json_error=ValueError("Expecting value: line 1 column 1 (char 0)"),
+        )
+    )
+
+    ok, payload = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={},
+        stream=False,  # force non-stream so we hit the JSON parse path directly
+    )
+
+    assert ok is False
+    assert isinstance(payload, str)
+    assert payload.startswith("Response parsing failed:")
+    assert "Expecting value" in payload
+
+
+def test_requests_timeout_is_mapped_to_error_with_actual_timeout(runner, patched_post):
+    import requests as real_requests
+
+    _set_response, set_raise, _calls = patched_post
+    set_raise(real_requests.exceptions.Timeout("timed out"))
+
+    ok, payload = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={},
+        stream=False,
+        timeout=42,
+    )
+
+    assert ok is False
+    assert isinstance(payload, str)
+    assert payload.startswith("Request timeout after")
+    # stream=False path uses the passed timeout verbatim.
+    assert "42 seconds" in payload
+
+
+def test_requests_request_exception_is_mapped_to_error(runner, patched_post):
+    import requests as real_requests
+
+    _set_response, set_raise, _calls = patched_post
+    set_raise(real_requests.exceptions.ConnectionError("connection refused"))
+
+    ok, payload = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={},
+        stream=False,
+    )
+
+    assert ok is False
+    assert isinstance(payload, str)
+    assert payload.startswith("Request error:")
+    assert "connection refused" in payload
+
+
+def test_forced_stream_true_returns_generator_and_uses_min_300_timeout(runner, patched_post):
+    set_response, _set_raise, calls = patched_post
+    set_response(
+        _FakeResponse(
+            status_code=200,
+            content_type="text/event-stream",
+            lines=['data: {"chunk": 1}', 'data: {"chunk": 2}'],
+        )
+    )
+
+    ok, gen = runner._http_post_invoke(
+        endpoint="https://svc/invoke",
+        payload={"prompt": "hi"},
+        headers={},
+        stream=True,  # explicit stream, not auto-detect
+        timeout=10,
+    )
+
+    assert ok is True
+    events = list(gen)
+    assert events == [{"chunk": 1}, {"chunk": 2}]
+    # stream=True forces actual_timeout = max(timeout, 300).
+    assert calls[0]["stream"] is True
+    assert calls[0]["timeout"] == 300

--- a/tests/toolkit/runners/test_ve_agentkit_helpers.py
+++ b/tests/toolkit/runners/test_ve_agentkit_helpers.py
@@ -1,0 +1,652 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit coverage for pure/dispatch helpers on VeAgentkitRuntimeRunner.
+
+These tests exercise the small deterministic pieces of
+``agentkit.toolkit.runners.ve_agentkit`` that do not require any real I/O:
+
+- ``_build_authorizer_config_for_create``: JWT vs key_auth branch shape.
+- ``_needs_runtime_update``: pure diff over image URL + env vars, including the
+  system-env-prefix filtering and the several env-object representations.
+- ``get_public_endpoint_of_runtime``: static endpoint selection.
+- ``_prepare_runtime_config``: AUTO/empty triggers name generation.
+- ``deploy``: config-missing guard and the create-vs-update dispatch.
+- ``destroy``: skip / NotFound / other-error branches.
+- ``status``: not-deployed short-circuit, status mapping, and health probe.
+
+Network-config building and invoke-time auth inference are covered by sibling
+files (test_ve_agentkit_network_config.py / test_ve_agentkit_invoke_auth_infer.py)
+and are intentionally not duplicated here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentkit.toolkit.runners import ve_agentkit
+from agentkit.toolkit.runners.ve_agentkit import (
+    VeAgentkitRuntimeRunner,
+    VeAgentkitRunnerConfig,
+)
+from agentkit.toolkit.config import CommonConfig, AUTO_CREATE_VE
+from agentkit.toolkit.errors import ErrorCode
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeEnvLower:
+    """Env object exposing lowercase key/value attributes."""
+
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+
+
+class _FakeEnvUpper:
+    """Env object exposing uppercase Key/Value attributes (compat path)."""
+
+    def __init__(self, Key, Value):
+        self.Key = Key
+        self.Value = Value
+
+
+class _FakeNetworkConfiguration:
+    def __init__(self, network_type, endpoint):
+        self.network_type = network_type
+        self.endpoint = endpoint
+
+
+class _FakeRuntime:
+    """Minimal stand-in for a GetRuntime response object.
+
+    Only the attributes touched by the methods under test are populated;
+    callers pass whatever subset they need.
+    """
+
+    def __init__(
+        self,
+        *,
+        artifact_url="",
+        artifact_type="image",
+        envs=None,
+        status="Ready",
+        name="rt-name",
+        network_configurations=None,
+        authorizer_configuration=None,
+    ):
+        self.artifact_url = artifact_url
+        self.artifact_type = artifact_type
+        self.envs = envs
+        self.status = status
+        self.name = name
+        self.network_configurations = network_configurations or []
+        self.authorizer_configuration = authorizer_configuration
+
+
+class _FakeRuntimeClient:
+    """Runtime client returning a canned runtime; records delete calls."""
+
+    def __init__(self, runtime=None, delete_error=None):
+        self._runtime = runtime
+        self._delete_error = delete_error
+        self.deleted = []
+
+    def get_runtime(self, req):
+        return self._runtime
+
+    def delete_runtime(self, req):
+        self.deleted.append(req)
+        if self._delete_error is not None:
+            raise self._delete_error
+        return object()
+
+
+class _FakeVeIAM:
+    """Fake VeIAM that always reports the role is ensured."""
+
+    ensure_ok = True
+
+    def __init__(self, region=""):
+        self.region = region
+
+    def ensure_role_for_agentkit(self, role_name):
+        return type(self).ensure_ok
+
+
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_veiam_state():
+    # _FakeVeIAM holds a class-level toggle; reset before each test.
+    _FakeVeIAM.ensure_ok = True
+    yield
+    _FakeVeIAM.ensure_ok = True
+
+
+def _make_config(**kwargs) -> VeAgentkitRunnerConfig:
+    kwargs.setdefault("common_config", CommonConfig(agent_name="myagent"))
+    return VeAgentkitRunnerConfig(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# _build_authorizer_config_for_create
+# ---------------------------------------------------------------------------
+
+
+def test_build_authorizer_config_for_create_uses_jwt_branch_with_discovery_and_clients():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_auth_type="custom_jwt",
+        runtime_jwt_discovery_url="https://issuer/.well-known/openid-configuration",
+        runtime_jwt_allowed_clients=["client-a", "client-b"],
+    )
+
+    authorizer = runner._build_authorizer_config_for_create(cfg)
+
+    assert authorizer.custom_jwt_authorizer is not None
+    assert authorizer.key_auth is None
+    assert (
+        authorizer.custom_jwt_authorizer.discovery_url
+        == "https://issuer/.well-known/openid-configuration"
+    )
+    assert authorizer.custom_jwt_authorizer.allowed_clients == ["client-a", "client-b"]
+
+
+def test_build_authorizer_config_for_create_jwt_branch_maps_empty_clients_to_none():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_auth_type="custom_jwt",
+        runtime_jwt_discovery_url="https://issuer/.well-known/openid-configuration",
+        runtime_jwt_allowed_clients=[],
+    )
+
+    authorizer = runner._build_authorizer_config_for_create(cfg)
+
+    assert authorizer.custom_jwt_authorizer is not None
+    assert authorizer.custom_jwt_authorizer.allowed_clients is None
+
+
+def test_build_authorizer_config_for_create_uses_key_auth_branch_with_name_and_location():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_auth_type="key_auth",
+        runtime_apikey_name="my-key-name",
+    )
+
+    authorizer = runner._build_authorizer_config_for_create(cfg)
+
+    assert authorizer.key_auth is not None
+    assert authorizer.custom_jwt_authorizer is None
+    assert authorizer.key_auth.api_key_name == "my-key-name"
+    # API_KEY_LOCATION module constant is "HEADER".
+    assert authorizer.key_auth.api_key_location == ve_agentkit.API_KEY_LOCATION == "HEADER"
+
+
+# ---------------------------------------------------------------------------
+# _needs_runtime_update
+# ---------------------------------------------------------------------------
+
+
+def test_needs_runtime_update_detects_image_url_change():
+    runner = VeAgentkitRuntimeRunner()
+    runtime = _FakeRuntime(artifact_url="repo/img:old", envs=[])
+    cfg = _make_config(image_url="repo/img:new", runtime_envs={})
+
+    needs_update, reason = runner._needs_runtime_update(runtime, cfg)
+
+    assert needs_update is True
+    assert "Image URL changed" in reason
+
+
+def test_needs_runtime_update_returns_false_when_image_and_envs_match():
+    runner = VeAgentkitRuntimeRunner()
+    runtime = _FakeRuntime(
+        artifact_url="repo/img:v1",
+        envs=[_FakeEnvLower("FOO", "bar")],
+    )
+    cfg = _make_config(image_url="repo/img:v1", runtime_envs={"FOO": "bar"})
+
+    needs_update, reason = runner._needs_runtime_update(runtime, cfg)
+
+    assert needs_update is False
+    assert reason == "No configuration changes"
+
+
+def test_needs_runtime_update_reports_added_removed_and_modified_env_vars():
+    runner = VeAgentkitRuntimeRunner()
+    runtime = _FakeRuntime(
+        artifact_url="repo/img:v1",
+        envs=[_FakeEnvLower("KEEP", "same"), _FakeEnvLower("DROP", "x"), _FakeEnvLower("CHANGE", "old")],
+    )
+    cfg = _make_config(
+        image_url="repo/img:v1",
+        runtime_envs={"KEEP": "same", "CHANGE": "new", "ADD": "y"},
+    )
+
+    needs_update, reason = runner._needs_runtime_update(runtime, cfg)
+
+    assert needs_update is True
+    assert "Added env vars: ADD" in reason
+    assert "Removed env vars: DROP" in reason
+    assert "Modified env vars: CHANGE" in reason
+
+
+def test_needs_runtime_update_ignores_system_env_prefixes():
+    runner = VeAgentkitRuntimeRunner()
+    # Runtime carries only system-injected env vars; config carries none.
+    runtime = _FakeRuntime(
+        artifact_url="repo/img:v1",
+        envs=[
+            _FakeEnvLower("OTEL_EXPORTER", "x"),
+            _FakeEnvLower("ENABLE_APMPLUS", "true"),
+            _FakeEnvLower("APMPLUS_APP_KEY", "k"),
+        ],
+    )
+    cfg = _make_config(image_url="repo/img:v1", runtime_envs={})
+
+    needs_update, reason = runner._needs_runtime_update(runtime, cfg)
+
+    assert needs_update is False
+    assert reason == "No configuration changes"
+
+
+def test_needs_runtime_update_reads_uppercase_env_attributes():
+    runner = VeAgentkitRuntimeRunner()
+    runtime = _FakeRuntime(
+        artifact_url="repo/img:v1",
+        envs=[_FakeEnvUpper(Key="FOO", Value="bar")],
+    )
+    cfg_match = _make_config(image_url="repo/img:v1", runtime_envs={"FOO": "bar"})
+    cfg_diff = _make_config(image_url="repo/img:v1", runtime_envs={"FOO": "other"})
+
+    assert runner._needs_runtime_update(runtime, cfg_match)[0] is False
+    assert runner._needs_runtime_update(runtime, cfg_diff)[0] is True
+
+
+def test_needs_runtime_update_reads_dict_env_entries():
+    runner = VeAgentkitRuntimeRunner()
+    runtime = _FakeRuntime(
+        artifact_url="repo/img:v1",
+        envs=[{"key": "FOO", "value": "bar"}, {"Key": "BAZ", "Value": "qux"}],
+    )
+    cfg = _make_config(
+        image_url="repo/img:v1",
+        runtime_envs={"FOO": "bar", "BAZ": "qux"},
+    )
+
+    needs_update, reason = runner._needs_runtime_update(runtime, cfg)
+
+    assert needs_update is False
+    assert reason == "No configuration changes"
+
+
+# ---------------------------------------------------------------------------
+# get_public_endpoint_of_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_get_public_endpoint_returns_public_network_endpoint():
+    runtime = _FakeRuntime(
+        network_configurations=[
+            _FakeNetworkConfiguration("private", "https://private/"),
+            _FakeNetworkConfiguration("public", "https://public/"),
+        ]
+    )
+
+    endpoint = VeAgentkitRuntimeRunner.get_public_endpoint_of_runtime(runtime)
+
+    assert endpoint == "https://public/"
+
+
+def test_get_public_endpoint_returns_empty_when_no_public_network():
+    runtime = _FakeRuntime(
+        network_configurations=[
+            _FakeNetworkConfiguration("private", "https://private/"),
+        ]
+    )
+
+    endpoint = VeAgentkitRuntimeRunner.get_public_endpoint_of_runtime(runtime)
+
+    assert endpoint == ""
+
+
+# ---------------------------------------------------------------------------
+# _prepare_runtime_config
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_runtime_config_generates_names_when_auto_and_returns_true(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_name=AUTO_CREATE_VE,
+        runtime_role_name=AUTO_CREATE_VE,
+        runtime_apikey_name=AUTO_CREATE_VE,
+    )
+
+    monkeypatch.setattr(
+        ve_agentkit, "generate_runtime_name", lambda agent_name: "gen-runtime"
+    )
+    monkeypatch.setattr(
+        ve_agentkit, "generate_runtime_role_name", lambda: "gen-role"
+    )
+    monkeypatch.setattr(ve_agentkit, "generate_apikey_name", lambda: "gen-apikey")
+
+    result = runner._prepare_runtime_config(cfg)
+
+    assert result is True
+    assert cfg.runtime_name == "gen-runtime"
+    assert cfg.runtime_role_name == "gen-role"
+    assert cfg.runtime_apikey_name == "gen-apikey"
+
+
+def test_prepare_runtime_config_generates_names_when_empty_strings(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_name="",
+        runtime_role_name="",
+        runtime_apikey_name="",
+    )
+
+    monkeypatch.setattr(
+        ve_agentkit, "generate_runtime_name", lambda agent_name: "gen-runtime"
+    )
+    monkeypatch.setattr(ve_agentkit, "generate_runtime_role_name", lambda: "gen-role")
+    monkeypatch.setattr(ve_agentkit, "generate_apikey_name", lambda: "gen-apikey")
+
+    result = runner._prepare_runtime_config(cfg)
+
+    assert result is True
+    assert cfg.runtime_name == "gen-runtime"
+    assert cfg.runtime_role_name == "gen-role"
+    assert cfg.runtime_apikey_name == "gen-apikey"
+
+
+def test_prepare_runtime_config_returns_false_when_generation_raises(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_name=AUTO_CREATE_VE)
+
+    def _boom(agent_name):
+        raise RuntimeError("cannot generate")
+
+    monkeypatch.setattr(ve_agentkit, "generate_runtime_name", _boom)
+
+    result = runner._prepare_runtime_config(cfg)
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# deploy: config-missing guard + create-vs-update dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_without_image_url_returns_config_missing():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(image_url="")
+
+    result = runner.deploy(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_MISSING
+
+
+def test_deploy_dispatches_to_create_when_runtime_id_is_auto(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(image_url="repo/img:v1", runtime_id=AUTO_CREATE_VE)
+
+    monkeypatch.setattr(ve_agentkit, "VeIAM", _FakeVeIAM)
+    monkeypatch.setattr(runner, "_prepare_runtime_config", lambda c: True)
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient()
+    )
+
+    create_sentinel = object()
+    monkeypatch.setattr(runner, "_create_new_runtime", lambda c: create_sentinel)
+    monkeypatch.setattr(
+        runner, "_update_existing_runtime", lambda c: pytest.fail("should not update")
+    )
+
+    result = runner.deploy(cfg)
+
+    assert result is create_sentinel
+
+
+def test_deploy_dispatches_to_update_when_runtime_id_is_valid(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(image_url="repo/img:v1", runtime_id="rt-existing")
+
+    monkeypatch.setattr(ve_agentkit, "VeIAM", _FakeVeIAM)
+    monkeypatch.setattr(runner, "_prepare_runtime_config", lambda c: True)
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient()
+    )
+
+    update_sentinel = object()
+    monkeypatch.setattr(
+        runner, "_create_new_runtime", lambda c: pytest.fail("should not create")
+    )
+    monkeypatch.setattr(runner, "_update_existing_runtime", lambda c: update_sentinel)
+
+    result = runner.deploy(cfg)
+
+    assert result is update_sentinel
+
+
+def test_deploy_returns_permission_denied_when_iam_role_not_ensured(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(image_url="repo/img:v1", runtime_id="rt-existing")
+
+    _FakeVeIAM.ensure_ok = False
+    monkeypatch.setattr(ve_agentkit, "VeIAM", _FakeVeIAM)
+    monkeypatch.setattr(runner, "_prepare_runtime_config", lambda c: True)
+
+    result = runner.deploy(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.PERMISSION_DENIED
+
+
+def test_deploy_returns_config_invalid_when_prepare_fails(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(image_url="repo/img:v1")
+
+    monkeypatch.setattr(runner, "_prepare_runtime_config", lambda c: False)
+
+    result = runner.deploy(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+
+
+# ---------------------------------------------------------------------------
+# destroy
+# ---------------------------------------------------------------------------
+
+
+def test_destroy_skips_and_succeeds_when_runtime_id_is_auto():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id=AUTO_CREATE_VE)
+
+    assert runner.destroy(cfg) is True
+
+
+def test_destroy_skips_and_succeeds_when_runtime_id_is_empty():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id="")
+
+    assert runner.destroy(cfg) is True
+
+
+def test_destroy_calls_client_and_returns_true_on_success(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id="rt-1")
+    client = _FakeRuntimeClient()
+
+    monkeypatch.setattr(runner, "_get_runtime_client", lambda region="": client)
+
+    assert runner.destroy(cfg) is True
+    assert len(client.deleted) == 1
+
+
+def test_destroy_treats_not_found_error_as_success(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id="rt-1")
+    client = _FakeRuntimeClient(
+        delete_error=Exception("InvalidAgentKitRuntime.NotFound: gone")
+    )
+
+    monkeypatch.setattr(runner, "_get_runtime_client", lambda region="": client)
+
+    assert runner.destroy(cfg) is True
+
+
+def test_destroy_returns_false_on_other_errors(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id="rt-1")
+    client = _FakeRuntimeClient(delete_error=Exception("SomethingElse.Boom"))
+
+    monkeypatch.setattr(runner, "_get_runtime_client", lambda region="": client)
+
+    assert runner.destroy(cfg) is False
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def test_status_short_circuits_as_not_deployed_when_runtime_id_is_auto():
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id=AUTO_CREATE_VE)
+
+    result = runner.status(cfg)
+
+    assert result.success is True
+    assert result.status == "not_deployed"
+
+
+def test_status_maps_ready_to_running(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_id="rt-1",
+        runtime_auth_type="custom_jwt",  # skip ping probe
+    )
+    runtime = _FakeRuntime(status="Ready", network_configurations=[])
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient(runtime)
+    )
+
+    result = runner.status(cfg)
+
+    assert result.success is True
+    assert result.status == "running"
+
+
+def test_status_maps_error_status_to_error(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id="rt-1", runtime_auth_type="custom_jwt")
+    runtime = _FakeRuntime(status="Error", network_configurations=[])
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient(runtime)
+    )
+
+    result = runner.status(cfg)
+
+    assert result.status == "error"
+
+
+def test_status_lowercases_other_statuses(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id="rt-1", runtime_auth_type="custom_jwt")
+    runtime = _FakeRuntime(status="Updating", network_configurations=[])
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient(runtime)
+    )
+
+    result = runner.status(cfg)
+
+    assert result.status == "updating"
+
+
+def test_status_health_is_healthy_when_ping_returns_200(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_id="rt-1",
+        runtime_auth_type="key_auth",
+        runtime_apikey="k-1",
+    )
+    runtime = _FakeRuntime(
+        status="Ready",
+        network_configurations=[_FakeNetworkConfiguration("public", "https://pub/")],
+    )
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient(runtime)
+    )
+    monkeypatch.setattr(
+        ve_agentkit.requests, "get", lambda url, headers=None, timeout=None: _FakeResponse(200)
+    )
+
+    result = runner.status(cfg)
+
+    assert result.status == "running"
+    assert result.health == "healthy"
+    assert result.metadata["ping_status"] is True
+
+
+def test_status_health_is_unhealthy_when_ping_returns_500(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(
+        runtime_id="rt-1",
+        runtime_auth_type="key_auth",
+        runtime_apikey="k-1",
+    )
+    runtime = _FakeRuntime(
+        status="Ready",
+        network_configurations=[_FakeNetworkConfiguration("public", "https://pub/")],
+    )
+    monkeypatch.setattr(
+        runner, "_get_runtime_client", lambda region="": _FakeRuntimeClient(runtime)
+    )
+    monkeypatch.setattr(
+        ve_agentkit.requests, "get", lambda url, headers=None, timeout=None: _FakeResponse(500)
+    )
+
+    result = runner.status(cfg)
+
+    assert result.health == "unhealthy"
+    assert result.metadata["ping_status"] is False
+
+
+def test_status_returns_not_found_when_client_raises_not_found(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    cfg = _make_config(runtime_id="rt-1", runtime_auth_type="custom_jwt")
+
+    class _RaisingClient:
+        def get_runtime(self, req):
+            raise Exception("InvalidAgentKitRuntime.NotFound: gone")
+
+    monkeypatch.setattr(runner, "_get_runtime_client", lambda region="": _RaisingClient())
+
+    result = runner.status(cfg)
+
+    assert result.success is False
+    assert result.status == "not_found"
+    assert result.error_code == ErrorCode.RESOURCE_NOT_FOUND

--- a/tests/toolkit/runners/test_ve_agentkit_lifecycle.py
+++ b/tests/toolkit/runners/test_ve_agentkit_lifecycle.py
@@ -1,0 +1,701 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+import agentkit.sdk.runtime.types as runtime_types
+from agentkit.toolkit.config import CommonConfig
+from agentkit.toolkit.errors import ErrorCode
+from agentkit.toolkit.runners.ve_agentkit import (
+    VeAgentkitRuntimeRunner,
+    VeAgentkitRunnerConfig,
+    RUNTIME_STATUS_READY,
+    RUNTIME_STATUS_ERROR,
+    RUNTIME_STATUS_UNRELEASED,
+    ARTIFACT_TYPE_DOCKER_IMAGE,
+    AUTH_TYPE_KEY_AUTH,
+    AUTH_TYPE_CUSTOM_JWT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _make_runtime(
+    *,
+    runtime_id="r-1",
+    status=RUNTIME_STATUS_READY,
+    artifact_type=ARTIFACT_TYPE_DOCKER_IMAGE,
+    artifact_url="reg/img:tag",
+    name="rt-name",
+    api_key=None,
+    public_endpoint="https://public.example/",
+    failed_log_file_url=None,
+):
+    """Build a real GetRuntimeResponse pydantic object matching the API shape."""
+    authorizer = None
+    if api_key is not None:
+        authorizer = runtime_types.AuthorizerConfigurationForGetRuntime(
+            KeyAuth=runtime_types.KeyAuthForGetRuntime(ApiKey=api_key)
+        )
+    net = []
+    if public_endpoint is not None:
+        net.append(
+            runtime_types.NetworkConfigurationsForGetRuntime(
+                NetworkType="public", Endpoint=public_endpoint
+            )
+        )
+    return runtime_types.GetRuntimeResponse(
+        RuntimeId=runtime_id,
+        Status=status,
+        ArtifactType=artifact_type,
+        ArtifactUrl=artifact_url,
+        Name=name,
+        AuthorizerConfiguration=authorizer,
+        NetworkConfigurations=net,
+        FailedLogFileUrl=failed_log_file_url,
+    )
+
+
+class _FakeRuntimeClient:
+    """Records calls; get_runtime returns a scripted sequence of statuses.
+
+    ``get_runtime_responses`` is a list of runtime objects (or exceptions) served
+    one-per-call; the last element is repeated once exhausted so polling loops
+    that call more times than scripted keep seeing the terminal state.
+    """
+
+    def __init__(
+        self,
+        *,
+        create_response=None,
+        get_runtime_responses=None,
+        get_runtime_exc=None,
+    ):
+        self._create_response = create_response
+        self._get_seq = list(get_runtime_responses or [])
+        self._get_runtime_exc = get_runtime_exc
+        self.create_calls = []
+        self.get_calls = []
+        self.update_calls = []
+        self.release_calls = []
+        self.delete_calls = []
+
+    def create_runtime(self, req):
+        self.create_calls.append(req)
+        return self._create_response
+
+    def get_runtime(self, req):
+        self.get_calls.append(req)
+        if self._get_runtime_exc is not None:
+            raise self._get_runtime_exc
+        if not self._get_seq:
+            raise AssertionError("get_runtime called with no scripted responses")
+        if len(self._get_seq) == 1:
+            return self._get_seq[0]
+        return self._get_seq.pop(0)
+
+    def update_runtime(self, req):
+        self.update_calls.append(req)
+        return runtime_types.UpdateRuntimeResponse(RuntimeId=req.runtime_id)
+
+    def release_runtime(self, req):
+        self.release_calls.append(req)
+        return runtime_types.ReleaseRuntimeResponse(RuntimeId=req.runtime_id)
+
+    def delete_runtime(self, req):
+        self.delete_calls.append(req)
+        return runtime_types.DeleteRuntimeResponse(RuntimeId=req.runtime_id)
+
+
+class _RecordingReporter:
+    """Reporter double that records confirm() prompts and show_logs() calls."""
+
+    def __init__(self, confirm_return=False):
+        self.confirm_return = confirm_return
+        self.confirm_calls = []
+        self.show_logs_calls = []
+        self.long_task_descriptions = []
+
+    def info(self, message, **kwargs):
+        pass
+
+    def success(self, message, **kwargs):
+        pass
+
+    def warning(self, message, **kwargs):
+        pass
+
+    def error(self, message, **kwargs):
+        pass
+
+    def progress(self, message, current, total=100, **kwargs):
+        pass
+
+    def confirm(self, message, default=False, **kwargs):
+        self.confirm_calls.append((message, default))
+        return self.confirm_return
+
+    def show_logs(self, title, lines, max_lines=100):
+        self.show_logs_calls.append((title, list(lines), max_lines))
+
+    class _Task:
+        def update(self, description=None, completed=None):
+            pass
+
+    from contextlib import contextmanager as _cm
+
+    @_cm
+    def long_task(self, description, total=100):
+        self.long_task_descriptions.append(description)
+        yield _RecordingReporter._Task()
+
+
+class _FakeResponse:
+    def __init__(self, content=b"log line 1\nlog line 2\n"):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_wait(monkeypatch):
+    """Neutralise all real waiting inside the ve_agentkit module."""
+    import agentkit.toolkit.runners.ve_agentkit as mod
+
+    monkeypatch.setattr(mod.time, "sleep", lambda *a, **k: None)
+    # deterministic client token so request construction is reproducible
+    monkeypatch.setattr(mod, "generate_client_token", lambda: "tok-fixed")
+
+
+def _make_config(**overrides):
+    cfg = VeAgentkitRunnerConfig(
+        common_config=CommonConfig(),
+        runtime_name="my-runtime",
+        runtime_role_name="role-x",
+        image_url="reg/img:tag",
+        region="cn-beijing",
+        runtime_auth_type=AUTH_TYPE_KEY_AUTH,
+        runtime_apikey_name="apikey-name-x",
+        min_instance=2,
+    )
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _install_client(monkeypatch, runner, client):
+    monkeypatch.setattr(runner, "_get_runtime_client", lambda region="": client)
+
+
+def _freeze_time(monkeypatch, values):
+    """Make ve_agentkit's time.time() return the given sequence, then hold last."""
+    import agentkit.toolkit.runners.ve_agentkit as mod
+
+    seq = list(values)
+
+    def _time():
+        if len(seq) == 1:
+            return seq[0]
+        return seq.pop(0)
+
+    monkeypatch.setattr(mod.time, "time", _time)
+
+
+# ---------------------------------------------------------------------------
+# _create_new_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_create_new_runtime_happy_path_builds_request_and_returns_ready_metadata(
+    monkeypatch,
+):
+    runner = VeAgentkitRuntimeRunner()
+    ready = _make_runtime(
+        runtime_id="rt-new", status=RUNTIME_STATUS_READY, api_key="secret-key"
+    )
+    client = _FakeRuntimeClient(
+        create_response=runtime_types.CreateRuntimeResponse(RuntimeId="rt-new"),
+        get_runtime_responses=[ready],
+    )
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(runtime_envs={"FOO": "bar"})
+    result = runner._create_new_runtime(cfg)
+
+    # Behaviour: a CreateRuntimeRequest was actually submitted with the mapped fields.
+    assert len(client.create_calls) == 1
+    req = client.create_calls[0]
+    assert isinstance(req, runtime_types.CreateRuntimeRequest)
+    assert req.name == "my-runtime"
+    assert req.artifact_type == ARTIFACT_TYPE_DOCKER_IMAGE
+    assert req.artifact_url == "reg/img:tag"
+    assert req.role_name == "role-x"
+    assert req.min_instance == 2
+    assert req.client_token == "tok-fixed"
+    assert req.apmplus_enable is True
+    # env mapping into EnvsItemForCreateRuntime
+    assert [(e.key, e.value) for e in req.envs] == [("FOO", "bar")]
+    # key_auth branch built a key_auth authorizer (not custom jwt)
+    assert req.authorizer_configuration.key_auth is not None
+    assert req.authorizer_configuration.custom_jwt_authorizer is None
+
+    # Runtime id is captured from create response and returned.
+    assert cfg.runtime_id == "rt-new"
+
+    # Success DeployResult with endpoint + metadata mapping.
+    assert result.success is True
+    assert result.error_code is None
+    assert result.service_id == "rt-new"
+    assert result.endpoint_url == "https://public.example/"
+    assert result.metadata["runtime_id"] == "rt-new"
+    assert result.metadata["runtime_auth_type"] == AUTH_TYPE_KEY_AUTH
+    assert result.metadata["message"] == "Runtime created successfully"
+    # key_auth mode pulls the api key off the ready runtime.
+    assert cfg.runtime_apikey == "secret-key"
+    assert result.metadata["runtime_apikey"] == "secret-key"
+
+
+def test_create_new_runtime_custom_jwt_does_not_fetch_api_key(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    ready = _make_runtime(runtime_id="rt-jwt", api_key="should-not-be-read")
+    client = _FakeRuntimeClient(
+        create_response=runtime_types.CreateRuntimeResponse(RuntimeId="rt-jwt"),
+        get_runtime_responses=[ready],
+    )
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(
+        runtime_auth_type=AUTH_TYPE_CUSTOM_JWT,
+        runtime_jwt_discovery_url="https://issuer/.well-known",
+        runtime_jwt_allowed_clients=["client-a"],
+    )
+    result = runner._create_new_runtime(cfg)
+
+    req = client.create_calls[0]
+    assert req.authorizer_configuration.custom_jwt_authorizer is not None
+    assert (
+        req.authorizer_configuration.custom_jwt_authorizer.discovery_url
+        == "https://issuer/.well-known"
+    )
+    assert result.success is True
+    # custom_jwt path leaves runtime_apikey untouched (stays default empty string)
+    assert cfg.runtime_apikey == ""
+
+
+def test_create_new_runtime_init_failure_downloads_logs_and_cleans_up_when_confirmed(
+    monkeypatch, tmp_path
+):
+    reporter = _RecordingReporter(confirm_return=True)
+    runner = VeAgentkitRuntimeRunner(reporter=reporter)
+
+    errored = _make_runtime(
+        runtime_id="rt-bad",
+        status=RUNTIME_STATUS_ERROR,
+        failed_log_file_url="https://logs.example/failed.log",
+    )
+    client = _FakeRuntimeClient(
+        create_response=runtime_types.CreateRuntimeResponse(RuntimeId="rt-bad"),
+        get_runtime_responses=[errored],
+    )
+    _install_client(monkeypatch, runner, client)
+
+    # Redirect log-file writes into tmp_path and capture the download call.
+    monkeypatch.chdir(tmp_path)
+    import agentkit.toolkit.runners.ve_agentkit as mod
+
+    get_calls = []
+
+    def _fake_get(url, timeout=None):
+        get_calls.append((url, timeout))
+        return _FakeResponse()
+
+    monkeypatch.setattr(mod.requests, "get", _fake_get)
+
+    cfg = _make_config()
+    result = runner._create_new_runtime(cfg)
+
+    # Init failure -> RUNTIME_NOT_READY with the runtime id preserved.
+    assert result.success is False
+    assert result.error_code == ErrorCode.RUNTIME_NOT_READY
+    assert result.service_id == "rt-bad"
+
+    # Failure-log download was attempted against the failed_log_file_url.
+    assert get_calls == [("https://logs.example/failed.log", 30)]
+    assert reporter.show_logs_calls  # logs were shown
+    # A cleanup confirmation was requested, defaulting to False.
+    assert reporter.confirm_calls and reporter.confirm_calls[0][1] is False
+    # Confirmed -> delete_runtime called with the failed runtime id.
+    assert len(client.delete_calls) == 1
+    assert client.delete_calls[0].runtime_id == "rt-bad"
+
+
+def test_create_new_runtime_init_failure_skips_cleanup_when_declined(monkeypatch):
+    reporter = _RecordingReporter(confirm_return=False)
+    runner = VeAgentkitRuntimeRunner(reporter=reporter)
+
+    # No failed_log_file_url -> download is short-circuited (no requests.get needed).
+    errored = _make_runtime(
+        runtime_id="rt-bad2",
+        status=RUNTIME_STATUS_ERROR,
+        failed_log_file_url=None,
+    )
+    client = _FakeRuntimeClient(
+        create_response=runtime_types.CreateRuntimeResponse(RuntimeId="rt-bad2"),
+        get_runtime_responses=[errored],
+    )
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config()
+    result = runner._create_new_runtime(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.RUNTIME_NOT_READY
+    # Declined cleanup -> no delete call.
+    assert client.delete_calls == []
+    # No log url -> show_logs never invoked.
+    assert reporter.show_logs_calls == []
+
+
+def test_create_new_runtime_exception_maps_to_runtime_create_failed(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+
+    class _BoomClient(_FakeRuntimeClient):
+        def create_runtime(self, req):
+            raise RuntimeError("boom from create")
+
+    client = _BoomClient()
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config()
+    result = runner._create_new_runtime(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.RUNTIME_CREATE_FAILED
+    assert "boom from create" in result.error
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_runtime_status / _wait_for_runtime_status_multiple
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_status_returns_success_when_target_reached(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    ready = _make_runtime(status=RUNTIME_STATUS_READY)
+    client = _FakeRuntimeClient(get_runtime_responses=[ready])
+    _install_client(monkeypatch, runner, client)
+
+    ok, runtime, err = runner._wait_for_runtime_status(
+        runtime_id="r-1",
+        target_status=RUNTIME_STATUS_READY,
+        task_description="waiting",
+        timeout=600,
+    )
+
+    assert ok is True
+    assert err is None
+    assert runtime is ready
+    # Only one poll needed since first status already matched.
+    assert len(client.get_calls) == 1
+    assert client.get_calls[0].runtime_id == "r-1"
+
+
+def test_wait_for_status_polls_until_target_reached(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    creating = _make_runtime(status="Creating")
+    ready = _make_runtime(status=RUNTIME_STATUS_READY)
+    client = _FakeRuntimeClient(get_runtime_responses=[creating, creating, ready])
+    _install_client(monkeypatch, runner, client)
+    # keep elapsed small so timeout never trips
+    _freeze_time(monkeypatch, [1000.0, 1001.0, 1002.0, 1003.0, 1004.0, 1005.0])
+
+    ok, runtime, err = runner._wait_for_runtime_status(
+        runtime_id="r-1",
+        target_status=RUNTIME_STATUS_READY,
+        task_description="waiting",
+        timeout=600,
+    )
+
+    assert ok is True
+    assert runtime.status == RUNTIME_STATUS_READY
+    assert len(client.get_calls) == 3
+
+
+def test_wait_for_status_error_status_returns_failure(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    errored = _make_runtime(status=RUNTIME_STATUS_ERROR)
+    client = _FakeRuntimeClient(get_runtime_responses=[errored])
+    _install_client(monkeypatch, runner, client)
+
+    ok, runtime, err = runner._wait_for_runtime_status(
+        runtime_id="r-1",
+        target_status=RUNTIME_STATUS_READY,
+        task_description="waiting",
+        timeout=600,
+        error_message="Initialization failed",
+    )
+
+    assert ok is False
+    assert runtime is errored
+    assert "Runtime status is Error" in err
+    assert "Initialization failed" in err
+
+
+def test_wait_for_status_timeout_returns_timeout_message(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    creating = _make_runtime(status="Creating")
+    client = _FakeRuntimeClient(get_runtime_responses=[creating])
+    _install_client(monkeypatch, runner, client)
+    # start_time=0; first elapsed read = 999 (> timeout 10) -> timeout branch.
+    _freeze_time(monkeypatch, [0.0, 999.0])
+
+    ok, runtime, err = runner._wait_for_runtime_status(
+        runtime_id="r-1",
+        target_status=RUNTIME_STATUS_READY,
+        task_description="waiting",
+        timeout=10,
+        error_message="Initialization failed",
+    )
+
+    assert ok is False
+    assert runtime is creating
+    assert "timeout after 10s" in err
+    # Non-terminal status: it polled once then timed out (no sleep loop since patched).
+    assert len(client.get_calls) == 1
+
+
+def test_wait_for_status_multiple_accepts_any_target(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    unreleased = _make_runtime(status=RUNTIME_STATUS_UNRELEASED)
+    client = _FakeRuntimeClient(get_runtime_responses=[unreleased])
+    _install_client(monkeypatch, runner, client)
+
+    ok, runtime, err = runner._wait_for_runtime_status_multiple(
+        runtime_id="r-1",
+        target_statuses=[RUNTIME_STATUS_UNRELEASED, RUNTIME_STATUS_READY],
+        task_description="waiting",
+        timeout=600,
+    )
+
+    assert ok is True
+    assert runtime.status == RUNTIME_STATUS_UNRELEASED
+
+
+# ---------------------------------------------------------------------------
+# _update_existing_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_update_existing_runtime_not_found_returns_resource_not_found(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    client = _FakeRuntimeClient(
+        get_runtime_exc=RuntimeError("InvalidAgentKitRuntime.NotFound: gone")
+    )
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(runtime_id="r-missing")
+    result = runner._update_existing_runtime(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.RESOURCE_NOT_FOUND
+    assert result.service_id == "r-missing"
+    # No update was attempted.
+    assert client.update_calls == []
+
+
+def test_update_existing_runtime_wrong_artifact_type_returns_config_invalid(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    # artifact_type is not the docker image type -> CONFIG_INVALID guard.
+    existing = _make_runtime(runtime_id="r-code", artifact_type="code")
+    client = _FakeRuntimeClient(get_runtime_responses=[existing])
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(runtime_id="r-code")
+    result = runner._update_existing_runtime(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert "code" in result.error
+    assert client.update_calls == []
+
+
+def test_update_existing_runtime_other_get_error_maps_to_deploy_failed(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    # A non-NotFound error is re-raised and caught by the outer handler.
+    client = _FakeRuntimeClient(get_runtime_exc=RuntimeError("network exploded"))
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(runtime_id="r-x")
+    result = runner._update_existing_runtime(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.DEPLOY_FAILED
+    assert "network exploded" in result.error
+
+
+def test_update_existing_runtime_direct_to_ready_submits_update_and_skips_release(
+    monkeypatch,
+):
+    runner = VeAgentkitRuntimeRunner()
+    existing = _make_runtime(runtime_id="r-up", status=RUNTIME_STATUS_READY, name="orig-name")
+    # get_runtime is called: once for the initial fetch, then by the wait loop.
+    ready_after_update = _make_runtime(
+        runtime_id="r-up", status=RUNTIME_STATUS_READY, api_key="k-updated"
+    )
+    client = _FakeRuntimeClient(
+        get_runtime_responses=[existing, ready_after_update]
+    )
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(
+        runtime_id="r-up",
+        runtime_envs={"A": "1"},
+        runtime_bindings={"memory_id": "mem-1", "knowledge_id": ""},
+    )
+    result = runner._update_existing_runtime(cfg)
+
+    # An update request was submitted with mapped fields.
+    assert len(client.update_calls) == 1
+    ureq = client.update_calls[0]
+    assert isinstance(ureq, runtime_types.UpdateRuntimeRequest)
+    assert ureq.runtime_id == "r-up"
+    assert ureq.artifact_url == "reg/img:tag"
+    assert ureq.memory_id == "mem-1"
+    # empty-string binding -> explicit clear ("")
+    assert ureq.knowledge_id == ""
+    # binding key absent -> None (not sent)
+    assert ureq.tool_id is None
+    # NOTE: latent bug -- _update_existing_runtime passes client_token= to
+    # UpdateRuntimeRequest, but that pydantic model has no client_token field and
+    # extra is "ignore", so the idempotency token is silently dropped (unlike
+    # CreateRuntimeRequest which does carry it). Pin the actual current behaviour.
+    assert not hasattr(ureq, "client_token")
+
+    # Reached Ready directly -> no release step.
+    assert client.release_calls == []
+
+    assert result.success is True
+    assert result.error_code is None
+    assert result.service_id == "r-up"
+    assert result.endpoint_url == "https://public.example/"
+    # metadata prefers the fetched runtime's name over config's runtime_name.
+    assert result.metadata["runtime_name"] == "orig-name"
+    assert result.metadata["message"] == "Runtime update completed"
+    # key_auth mode pulls apikey from the updated runtime.
+    assert cfg.runtime_apikey == "k-updated"
+
+
+def test_update_existing_runtime_unreleased_triggers_release_then_ready(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    existing = _make_runtime(runtime_id="r-rel", status=RUNTIME_STATUS_READY)
+    unreleased = _make_runtime(runtime_id="r-rel", status=RUNTIME_STATUS_UNRELEASED)
+    released_ready = _make_runtime(runtime_id="r-rel", status=RUNTIME_STATUS_READY)
+    # 1: initial get, 2: post-update wait (UnReleased), 3: post-release wait (Ready)
+    client = _FakeRuntimeClient(
+        get_runtime_responses=[existing, unreleased, released_ready]
+    )
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(runtime_id="r-rel")
+    result = runner._update_existing_runtime(cfg)
+
+    # Phase 2 release path exercised.
+    assert len(client.release_calls) == 1
+    assert client.release_calls[0].runtime_id == "r-rel"
+    assert result.success is True
+    assert result.error_code is None
+
+
+def test_update_existing_runtime_update_wait_error_returns_deploy_failed(monkeypatch):
+    reporter = _RecordingReporter()
+    runner = VeAgentkitRuntimeRunner(reporter=reporter)
+    existing = _make_runtime(runtime_id="r-fail", status=RUNTIME_STATUS_READY)
+    errored = _make_runtime(
+        runtime_id="r-fail",
+        status=RUNTIME_STATUS_ERROR,
+        failed_log_file_url=None,
+    )
+    client = _FakeRuntimeClient(get_runtime_responses=[existing, errored])
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(runtime_id="r-fail")
+    result = runner._update_existing_runtime(cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.DEPLOY_FAILED
+    assert result.service_id == "r-fail"
+    # Update was submitted, but no release happened after the failed wait.
+    assert len(client.update_calls) == 1
+    assert client.release_calls == []
+
+
+def test_update_existing_runtime_release_wait_failure_returns_deploy_failed(monkeypatch):
+    runner = VeAgentkitRuntimeRunner()
+    existing = _make_runtime(runtime_id="r-rf", status=RUNTIME_STATUS_READY)
+    unreleased = _make_runtime(runtime_id="r-rf", status=RUNTIME_STATUS_UNRELEASED)
+    # Release phase wait ends in Error -> phase-2 failure path.
+    release_error = _make_runtime(
+        runtime_id="r-rf", status=RUNTIME_STATUS_ERROR, failed_log_file_url=None
+    )
+    client = _FakeRuntimeClient(
+        get_runtime_responses=[existing, unreleased, release_error]
+    )
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(runtime_id="r-rf")
+    result = runner._update_existing_runtime(cfg)
+
+    # Release was attempted, but the subsequent wait failed.
+    assert len(client.release_calls) == 1
+    assert result.success is False
+    assert result.error_code == ErrorCode.DEPLOY_FAILED
+    assert result.service_id == "r-rf"
+
+
+def test_update_existing_runtime_warns_and_ignores_network_and_clears_none_binding(
+    monkeypatch,
+):
+    reporter = _RecordingReporter()
+    runner = VeAgentkitRuntimeRunner(reporter=reporter)
+    existing = _make_runtime(runtime_id="r-net", status=RUNTIME_STATUS_READY)
+    ready = _make_runtime(runtime_id="r-net", status=RUNTIME_STATUS_READY)
+    client = _FakeRuntimeClient(get_runtime_responses=[existing, ready])
+    _install_client(monkeypatch, runner, client)
+
+    cfg = _make_config(
+        runtime_id="r-net",
+        runtime_network={"mode": "public"},
+        # None value -> explicit clear ("")
+        runtime_bindings={"tool_id": None},
+    )
+    result = runner._update_existing_runtime(cfg)
+
+    assert result.success is True
+    ureq = client.update_calls[0]
+    # None binding -> explicit clear ("")
+    assert ureq.tool_id == ""
+    # runtime_network is ignored on update (network only applies to create),
+    # so no NetworkConfiguration is sent as part of the update request.
+    assert not hasattr(ureq, "network_configuration") or ureq.network_configuration is None

--- a/tests/toolkit/strategies/test_hybrid_strategy.py
+++ b/tests/toolkit/strategies/test_hybrid_strategy.py
@@ -1,0 +1,500 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit tests for :class:`HybridStrategy` orchestration.
+
+These tests exercise HybridStrategy as a pure orchestration layer: its CR
+predicate helpers (:func:`_should_push_to_cr`, :func:`_prepare_cr_config`,
+:func:`_validate_cr_image_url`, :func:`_report_cr_skip_reason`) and its
+build/deploy/invoke/status/destroy delegation. The lazy ``builder``/``runner``
+properties are bypassed by directly setting ``strategy._builder`` /
+``strategy._runner`` to hand-rolled fakes, so no Docker, network, or VE Runtime
+calls ever happen.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from agentkit.toolkit.config import AUTO_CREATE_VE
+from agentkit.toolkit.config.config import CommonConfig
+from agentkit.toolkit.config.strategy_configs import HybridStrategyConfig
+from agentkit.toolkit.errors import ErrorCode
+from agentkit.toolkit.models import (
+    BuildResult,
+    DeployResult,
+    ImageInfo,
+    InvokeResult,
+    StatusResult,
+)
+from agentkit.toolkit.strategies.hybrid_strategy import HybridStrategy
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fakes
+# ---------------------------------------------------------------------------
+
+
+class _SpyReporter:
+    """Records every reporter call so tests can assert which branch fired."""
+
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.successes: list[str] = []
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+
+    def info(self, message: str, **kwargs) -> None:
+        self.infos.append(message)
+
+    def success(self, message: str, **kwargs) -> None:
+        self.successes.append(message)
+
+    def warning(self, message: str, **kwargs) -> None:
+        self.warnings.append(message)
+
+    def error(self, message: str, **kwargs) -> None:
+        self.errors.append(message)
+
+
+class _FakeConfigManager:
+    """Minimal config manager returning a controlled project dir.
+
+    Pinning ``get_project_dir`` to an empty tmp dir keeps ``merge_runtime_envs``
+    deterministic (it otherwise reads .env / config.yaml from cwd).
+    """
+
+    def __init__(self, project_dir) -> None:
+        self._project_dir = project_dir
+
+    def get_project_dir(self):
+        return self._project_dir
+
+
+class _FakeBuilder:
+    """Fake builder capturing the config it was called with."""
+
+    def __init__(self, result: BuildResult) -> None:
+        self._result = result
+        self.calls: list = []
+
+    def build(self, builder_config) -> BuildResult:
+        self.calls.append(builder_config)
+        return self._result
+
+
+class _FakeRunner:
+    """Fake runner recording delegation and returning canned results verbatim."""
+
+    def __init__(
+        self,
+        deploy_result: DeployResult = None,
+        invoke_result: InvokeResult = None,
+        status_result: StatusResult = None,
+        destroy_result: bool = True,
+    ) -> None:
+        self._deploy_result = deploy_result
+        self._invoke_result = invoke_result
+        self._status_result = status_result
+        self._destroy_result = destroy_result
+        self.deploy_calls: list = []
+        self.invoke_calls: list = []
+        self.status_calls: list = []
+        self.destroy_calls: list = []
+
+    def deploy(self, runner_config) -> DeployResult:
+        self.deploy_calls.append(runner_config)
+        return self._deploy_result
+
+    def invoke(self, runner_config, payload, headers, stream) -> InvokeResult:
+        self.invoke_calls.append((runner_config, payload, headers, stream))
+        return self._invoke_result
+
+    def status(self, runner_config) -> StatusResult:
+        self.status_calls.append(runner_config)
+        return self._status_result
+
+    def destroy(self, runner_config) -> bool:
+        self.destroy_calls.append(runner_config)
+        return self._destroy_result
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def common_config() -> CommonConfig:
+    return CommonConfig(agent_name="my-agent")
+
+
+@pytest.fixture
+def strategy(tmp_path) -> HybridStrategy:
+    """A HybridStrategy wired with a spy reporter and a pinned project dir."""
+    reporter = _SpyReporter()
+    cm = _FakeConfigManager(project_dir=tmp_path)
+    strat = HybridStrategy(config_manager=cm, reporter=reporter)
+    return strat
+
+
+def _valid_hybrid_config(**overrides) -> HybridStrategyConfig:
+    """A HybridStrategyConfig with a fully valid, rendered CR configuration."""
+    cfg = HybridStrategyConfig(
+        cr_instance_name="my-cr-instance",
+        cr_namespace_name="my-namespace",
+        cr_repo_name="my-repo",
+    )
+    for key, value in overrides.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# _should_push_to_cr  (:267)
+# ---------------------------------------------------------------------------
+
+
+def test_should_push_to_cr_returns_false_when_instance_name_is_empty(strategy):
+    cfg = _valid_hybrid_config(cr_instance_name="")
+    should_push, reason = strategy._should_push_to_cr(cfg, "my-repo")
+    assert should_push is False
+    assert reason == "CR instance name is empty"
+
+
+def test_should_push_to_cr_returns_false_when_instance_name_is_auto(strategy):
+    cfg = _valid_hybrid_config(cr_instance_name=AUTO_CREATE_VE)
+    should_push, reason = strategy._should_push_to_cr(cfg, "my-repo")
+    assert should_push is False
+    assert reason == "CR instance name is 'Auto'"
+
+
+def test_should_push_to_cr_returns_false_when_instance_name_has_unrendered_template(
+    strategy,
+):
+    cfg = _valid_hybrid_config(cr_instance_name="cr-{{ account_id }}")
+    should_push, reason = strategy._should_push_to_cr(cfg, "my-repo")
+    assert should_push is False
+    assert reason == "CR instance name contains unrendered template variables"
+
+
+def test_should_push_to_cr_returns_false_when_namespace_name_is_empty(strategy):
+    cfg = _valid_hybrid_config(cr_namespace_name="")
+    should_push, reason = strategy._should_push_to_cr(cfg, "my-repo")
+    assert should_push is False
+    assert reason == "CR namespace name is empty"
+
+
+def test_should_push_to_cr_returns_false_when_namespace_name_is_auto(strategy):
+    cfg = _valid_hybrid_config(cr_namespace_name=AUTO_CREATE_VE)
+    should_push, reason = strategy._should_push_to_cr(cfg, "my-repo")
+    assert should_push is False
+    assert reason == "CR namespace name is 'Auto'"
+
+
+def test_should_push_to_cr_returns_false_when_namespace_name_has_unrendered_template(
+    strategy,
+):
+    cfg = _valid_hybrid_config(cr_namespace_name="ns-{{ foo }}")
+    should_push, reason = strategy._should_push_to_cr(cfg, "my-repo")
+    assert should_push is False
+    assert reason == "CR namespace name contains unrendered template variables"
+
+
+def test_should_push_to_cr_returns_false_when_repo_name_is_empty(strategy):
+    cfg = _valid_hybrid_config()
+    should_push, reason = strategy._should_push_to_cr(cfg, "")
+    assert should_push is False
+    assert reason == "CR repository name is empty"
+
+
+def test_should_push_to_cr_returns_true_for_fully_valid_configuration(strategy):
+    cfg = _valid_hybrid_config()
+    should_push, reason = strategy._should_push_to_cr(cfg, "my-repo")
+    assert should_push is True
+    assert reason == ""
+
+
+# ---------------------------------------------------------------------------
+# _prepare_cr_config  (:252)
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_cr_config_falls_back_to_agent_name_when_repo_empty(strategy):
+    result = strategy._prepare_cr_config("", "my-agent")
+    assert result == "my-agent"
+
+
+def test_prepare_cr_config_falls_back_to_default_when_repo_and_agent_empty(strategy):
+    result = strategy._prepare_cr_config("", "")
+    assert result == "agentkit-app"
+
+
+def test_prepare_cr_config_passes_through_non_empty_repo_name(strategy):
+    result = strategy._prepare_cr_config("explicit-repo", "my-agent")
+    assert result == "explicit-repo"
+
+
+# ---------------------------------------------------------------------------
+# _validate_cr_image_url  (:427)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_cr_image_url_succeeds_when_image_url_present(strategy):
+    cfg = _valid_hybrid_config(cr_image_full_url="registry.example.com/ns/app:v1")
+    result = strategy._validate_cr_image_url(cfg)
+    assert isinstance(result, DeployResult)
+    assert result.success is True
+    assert result.error_code is None
+
+
+def test_validate_cr_image_url_reports_config_invalid_for_unrendered_template(strategy):
+    cfg = _valid_hybrid_config(
+        cr_image_full_url="",
+        cr_instance_name="cr-{{ account_id }}",
+    )
+    result = strategy._validate_cr_image_url(cfg)
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+
+
+def test_validate_cr_image_url_reports_config_invalid_for_auto_instance(strategy):
+    cfg = _valid_hybrid_config(cr_image_full_url="", cr_instance_name=AUTO_CREATE_VE)
+    result = strategy._validate_cr_image_url(cfg)
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert "requires valid CR configuration" in result.error
+
+
+def test_validate_cr_image_url_reports_config_invalid_for_empty_instance(strategy):
+    cfg = _valid_hybrid_config(cr_image_full_url="", cr_instance_name="")
+    result = strategy._validate_cr_image_url(cfg)
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert "requires valid CR configuration" in result.error
+
+
+def test_validate_cr_image_url_reports_resource_not_found_when_config_valid_but_no_url(
+    strategy,
+):
+    # Valid instance name, no unrendered template, but no built image URL yet.
+    cfg = _valid_hybrid_config(cr_image_full_url="")
+    result = strategy._validate_cr_image_url(cfg)
+    assert result.success is False
+    assert result.error_code == ErrorCode.RESOURCE_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# _report_cr_skip_reason  (:406)
+# ---------------------------------------------------------------------------
+
+
+def test_report_cr_skip_reason_warns_about_unrendered_template(strategy):
+    cfg = _valid_hybrid_config(cr_instance_name="cr-{{ account_id }}")
+    strategy._report_cr_skip_reason("some reason", cfg)
+    warnings = strategy.reporter.warnings
+    assert any("unrendered template variables" in w for w in warnings)
+    assert any("STS can fetch account_id" in w for w in warnings)
+
+
+def test_report_cr_skip_reason_warns_about_auto_instance(strategy):
+    cfg = _valid_hybrid_config(cr_instance_name=AUTO_CREATE_VE)
+    strategy._report_cr_skip_reason("CR instance name is 'Auto'", cfg)
+    warnings = strategy.reporter.warnings
+    assert any("'Auto'" in w for w in warnings)
+    assert any("configure a valid CR instance name" in w for w in warnings)
+
+
+def test_report_cr_skip_reason_warns_generic_for_other_reasons(strategy):
+    cfg = _valid_hybrid_config()
+    strategy._report_cr_skip_reason("CR repository name is empty", cfg)
+    warnings = strategy.reporter.warnings
+    assert len(warnings) == 1
+    assert "Invalid CR configuration, skipping push to CR" in warnings[0]
+    assert "CR repository name is empty" in warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# build  (:108)
+# ---------------------------------------------------------------------------
+
+
+def test_build_happy_path_populates_config_updates_when_push_skipped(
+    strategy, common_config, monkeypatch
+):
+    ts = datetime(2026, 6, 30, 12, 0, 0)
+    image = ImageInfo(
+        repository="registry.example.com/ns/app", tag="v1", digest="sha256:deadbeef"
+    )
+    build_result = BuildResult(success=True, image=image, build_timestamp=ts)
+    strategy._builder = _FakeBuilder(build_result)
+
+    # Force the push decision so we never touch CR services.
+    monkeypatch.setattr(
+        strategy,
+        "_should_push_to_cr",
+        lambda strategy_config, cr_repo_name: (False, "skipped for test"),
+    )
+
+    # Empty repo name so _prepare_cr_config auto-fills from agent_name and the
+    # change gets recorded into config_updates.
+    cfg = _valid_hybrid_config(cr_repo_name="")
+    result = strategy.build(common_config, cfg)
+
+    assert result is build_result
+    assert result.config_updates is not None
+    updates = result.config_updates.to_dict()
+    # cr_repo_name was empty in the config -> auto-filled from agent_name.
+    assert updates["cr_repo_name"] == "my-agent"
+    assert updates["full_image_name"] == "registry.example.com/ns/app:v1"
+    assert updates["image_id"] == "sha256:deadbeef"
+    assert updates["build_timestamp"] == ts.isoformat()
+
+
+def test_build_reports_skip_reason_when_push_not_allowed(
+    strategy, common_config, monkeypatch
+):
+    image = ImageInfo(repository="registry.example.com/ns/app", tag="v1")
+    build_result = BuildResult(success=True, image=image)
+    strategy._builder = _FakeBuilder(build_result)
+
+    monkeypatch.setattr(
+        strategy,
+        "_should_push_to_cr",
+        lambda strategy_config, cr_repo_name: (False, "CR repository name is empty"),
+    )
+
+    cfg = _valid_hybrid_config()
+    strategy.build(common_config, cfg)
+
+    # The generic skip-reason warning branch should have fired.
+    assert any(
+        "Invalid CR configuration, skipping push to CR" in w
+        for w in strategy.reporter.warnings
+    )
+
+
+def test_build_short_circuits_and_returns_failed_result_without_config_updates(
+    strategy, common_config
+):
+    failed = BuildResult(
+        success=False, error="docker exploded", error_code=ErrorCode.BUILD_FAILED
+    )
+    strategy._builder = _FakeBuilder(failed)
+
+    cfg = _valid_hybrid_config()
+    result = strategy.build(common_config, cfg)
+
+    assert result is failed
+    assert result.success is False
+    assert result.config_updates is None
+
+
+# ---------------------------------------------------------------------------
+# deploy  (:155)
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_maps_runner_metadata_into_config_updates(strategy, common_config):
+    deploy_result = DeployResult(
+        success=True,
+        endpoint_url="https://runtime.example.com/app",
+        service_id="rt-123",
+        metadata={
+            "runtime_apikey": "sk-secret",
+            "runtime_name": "auto-runtime",
+            "runtime_apikey_name": "auto-key-name",
+            "runtime_role_name": "auto-role",
+        },
+    )
+    strategy._runner = _FakeRunner(deploy_result=deploy_result)
+
+    # cr_image_full_url present -> _validate_cr_image_url passes.
+    cfg = _valid_hybrid_config(cr_image_full_url="registry.example.com/ns/app:v1")
+    result = strategy.deploy(common_config, cfg)
+
+    assert result is deploy_result
+    updates = result.config_updates.to_dict()
+    assert updates["runtime_id"] == "rt-123"
+    assert updates["runtime_endpoint"] == "https://runtime.example.com/app"
+    assert updates["runtime_apikey"] == "sk-secret"
+    assert updates["runtime_name"] == "auto-runtime"
+    assert updates["runtime_apikey_name"] == "auto-key-name"
+    assert updates["runtime_role_name"] == "auto-role"
+
+
+def test_deploy_short_circuits_on_invalid_cr_image_url(strategy, common_config):
+    # Runner must never be reached when validation fails.
+    strategy._runner = _FakeRunner(deploy_result=DeployResult(success=True))
+
+    cfg = _valid_hybrid_config(cr_image_full_url="", cr_instance_name=AUTO_CREATE_VE)
+    result = strategy.deploy(common_config, cfg)
+
+    assert result.success is False
+    assert result.error_code == ErrorCode.CONFIG_INVALID
+    assert strategy._runner.deploy_calls == []
+
+
+# ---------------------------------------------------------------------------
+# invoke / status / destroy  (:202 / :221 / :235)
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_delegates_to_runner_and_returns_result_verbatim(
+    strategy, common_config
+):
+    invoke_result = InvokeResult(success=True)
+    runner = _FakeRunner(invoke_result=invoke_result)
+    strategy._runner = runner
+
+    cfg = _valid_hybrid_config()
+    payload = {"prompt": "hello"}
+    headers = {"X-Test": "1"}
+    result = strategy.invoke(common_config, cfg, payload, headers=headers, stream=True)
+
+    assert result is invoke_result
+    assert len(runner.invoke_calls) == 1
+    _, sent_payload, sent_headers, sent_stream = runner.invoke_calls[0]
+    assert sent_payload == payload
+    assert sent_headers == headers
+    assert sent_stream is True
+
+
+def test_status_delegates_to_runner_and_returns_result_verbatim(
+    strategy, common_config
+):
+    status_result = StatusResult(success=True)
+    runner = _FakeRunner(status_result=status_result)
+    strategy._runner = runner
+
+    cfg = _valid_hybrid_config()
+    result = strategy.status(common_config, cfg)
+
+    assert result is status_result
+    assert len(runner.status_calls) == 1
+
+
+def test_destroy_delegates_to_runner_and_returns_boolean_verbatim(
+    strategy, common_config
+):
+    runner = _FakeRunner(destroy_result=True)
+    strategy._runner = runner
+
+    cfg = _valid_hybrid_config()
+    result = strategy.destroy(common_config, cfg)
+
+    assert result is True
+    assert len(runner.destroy_calls) == 1

--- a/tests/utils/test_engineering_standards.py
+++ b/tests/utils/test_engineering_standards.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline unit tests for the engineering-standards refactor.
+
+Covers the three foundations applied to the inner HTTP/credential loop:
+
+* ``ve_sign._signed_request`` transient-retry + transport-error wrapping
+  (connection errors retried to the budget then wrapped as ``NetworkError``
+  with the original cause chained; read timeouts surfaced, not retried;
+  ``AGENTKIT_HTTP_RETRIES=0`` disables retries).
+* ``utils.http_defaults`` env parsing/clamping.
+* ``RedactionFilter`` scrubbing of JWT / ak-sk / opaque tokens from a
+  ``logging.LogRecord``.
+
+No network is performed: ``requests.request`` and ``time.sleep`` are
+monkeypatched.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+import requests
+
+from agentkit.auth.errors import NetworkError
+from agentkit.utils import http_defaults, ve_sign
+from agentkit.utils.logging_config import RedactionFilter
+
+
+# --------------------------------------------------------------------------- #
+# ve_sign._signed_request
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Make the retry backoff instantaneous."""
+    monkeypatch.setattr(ve_sign.time, "sleep", lambda _seconds: None)
+
+
+def _count_request(monkeypatch, exc_factory):
+    """Patch ``requests.request`` to always raise; return an attempt counter."""
+    counter = {"attempts": 0}
+
+    def _fake_request(**_kwargs):
+        counter["attempts"] += 1
+        raise exc_factory()
+
+    monkeypatch.setattr(ve_sign.requests, "request", _fake_request)
+    return counter
+
+
+def test_signed_request_retries_connection_error_to_budget_then_networkerror(
+    monkeypatch, no_sleep
+):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_RETRIES, "2")
+    counter = _count_request(
+        monkeypatch, lambda: requests.ConnectionError("connection refused")
+    )
+
+    with pytest.raises(NetworkError) as excinfo:
+        ve_sign._signed_request("POST", "https://example.invalid", {}, {}, "")
+
+    # retries=2 -> 1 initial attempt + 2 retries = 3 total attempts.
+    assert counter["attempts"] == 3
+    # Original transport error is chained, not swallowed.
+    assert isinstance(excinfo.value.__cause__, requests.ConnectionError)
+    # The domain message must not leak the underlying request/secret payload.
+    assert "connection refused" not in str(excinfo.value)
+
+
+def test_signed_request_read_timeout_not_retried(monkeypatch, no_sleep):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_RETRIES, "2")
+    counter = _count_request(
+        monkeypatch, lambda: requests.ReadTimeout("read timed out")
+    )
+
+    with pytest.raises(NetworkError) as excinfo:
+        ve_sign._signed_request("POST", "https://example.invalid", {}, {}, "")
+
+    # Read timeouts may have been processed by a non-idempotent action, so a
+    # single attempt is made and the error is surfaced, never retried.
+    assert counter["attempts"] == 1
+    assert isinstance(excinfo.value.__cause__, requests.ReadTimeout)
+
+
+def test_signed_request_retries_zero_means_single_attempt(monkeypatch, no_sleep):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_RETRIES, "0")
+    counter = _count_request(
+        monkeypatch, lambda: requests.ConnectionError("connection refused")
+    )
+
+    with pytest.raises(NetworkError):
+        ve_sign._signed_request("POST", "https://example.invalid", {}, {}, "")
+
+    assert counter["attempts"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# http_defaults env clamping
+# --------------------------------------------------------------------------- #
+
+
+def test_http_timeout_default(monkeypatch):
+    monkeypatch.delenv(http_defaults.ENV_HTTP_TIMEOUT, raising=False)
+    assert http_defaults.http_timeout() == 30.0
+
+
+def test_http_timeout_clamped_to_floor(monkeypatch):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_TIMEOUT, "0")
+    assert http_defaults.http_timeout() == 1.0
+
+
+def test_http_timeout_invalid_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_TIMEOUT, "not-a-number")
+    assert http_defaults.http_timeout() == http_defaults.DEFAULT_HTTP_TIMEOUT
+
+
+def test_http_retries_clamped_non_negative(monkeypatch):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_RETRIES, "-5")
+    assert http_defaults.http_retries() == 0
+
+
+def test_http_retries_invalid_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_RETRIES, "abc")
+    assert http_defaults.http_retries() == http_defaults.DEFAULT_HTTP_RETRIES
+
+
+def test_http_retries_honors_valid_value(monkeypatch):
+    monkeypatch.setenv(http_defaults.ENV_HTTP_RETRIES, "4")
+    assert http_defaults.http_retries() == 4
+
+
+def test_stream_timeout_default_and_clamp(monkeypatch):
+    monkeypatch.delenv(http_defaults.ENV_STREAM_TIMEOUT, raising=False)
+    assert http_defaults.stream_timeout() == 300.0
+    monkeypatch.setenv(http_defaults.ENV_STREAM_TIMEOUT, "0.1")
+    assert http_defaults.stream_timeout() == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# RedactionFilter
+# --------------------------------------------------------------------------- #
+
+
+def _record(msg, *args):
+    return logging.LogRecord(
+        name="agentkit.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=args,
+        exc_info=None,
+    )
+
+
+def test_redaction_filter_scrubs_jwt():
+    secret = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.s1gn4tur3_padding_xyz"
+    record = _record("auth header token=%s end", secret)
+
+    assert RedactionFilter().filter(record) is True
+    out = record.getMessage()
+    assert secret not in out
+    assert "***" in out
+    # Lazy %-args must be cleared so a downstream formatter cannot re-expand them.
+    assert record.args == ()
+
+
+def test_redaction_filter_scrubs_ak_sk_field():
+    record = _record('{"secret_access_key": "AKLTabcdefgh1234567890ZZ"}')
+
+    RedactionFilter().filter(record)
+    out = record.getMessage()
+    assert "AKLTabcdefgh1234567890ZZ" not in out
+    assert "***" in out
+
+
+def test_redaction_filter_scrubs_opaque_token():
+    opaque = "abcdefghijklmnopqrstuvwxyz0123456789"
+    record = _record("bearer %s", opaque)
+
+    RedactionFilter().filter(record)
+    out = record.getMessage()
+    assert opaque not in out
+    assert "***" in out


### PR DESCRIPTION
## What
Raises the core HTTP / credential / SDK inner-loop to one consistent engineering standard across three dimensions, plus the underlying transient-retry fix.

**Foundations (new leaves):** `agentkit/errors.py` (single stdlib-only root `AgentKitError`), `utils/http_defaults.py` (one source of truth for timeout/retry env+defaults), `utils/redact.py` + a `RedactionFilter` on every log handler.

- **Logging:** `get_logger(__name__)` now actually used in the scoped modules (previously 0 callers); library stays silent-by-default.
- **Exceptions:** transport errors wrapped into `NetworkError`; typed `ApiError` (with `error_code`); `from e` chaining; `raise e`→`raise`; runtime-validation asserts→raises.
- **Secret leaks closed:** API key (`identity/auth`), full response (`request.py`, `cr.py` debug, `ve_sign.check_error`). `print(1)/print(2)` removed. `request()` now re-raises instead of silently returning `None`.
- **Timeouts:** `base_service_client` reads `http_timeout()/http_retries()` instead of hardcoded 30/30; `cli_mount` `urlopen` bounded.
- **Transient retry (base commit):** OpenAPI calls get a bounded timeout + conservative retry (connection errors + 429/503 only, honors `Retry-After`, never retries read-timeouts — safe for non-idempotent `Create*`).

## Tests
+22 offline unit tests (hierarchy, `http_defaults` clamping, `RedactionFilter`, `_signed_request`/`_invoke_api` error paths). Backward-compatible: `except AuthError` still catches the same set; no code did `except AgentKitError` before.

## Stack
Base of the stack. Followed by the test PR (`test/agentkit-apps-pipeline-ut`) then the fix PR (`fix/agentkit-latent-bugs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)