### PR TITLE
fix(agentkit): six latent bugs surfaced by the new unit tests

### DIFF
--- a/agentkit/apps/mcp_app/mcp_app.py
+++ b/agentkit/apps/mcp_app/mcp_app.py
@@ -43,13 +43,14 @@ class AgentkitMCPApp(BaseAgentkitApp):
                 # with tracer.start_as_current_span("tool") as span:
                 with telemetry.tracer.start_as_current_span(name="tool") as span:
                     exception = None
+                    result = None
                     try:
                         result = await func(*args, **kwargs)
 
                     except Exception as e:
                         logger.error("Invoke tool function failed: %s", e)
                         exception = e
-                        raise e
+                        raise
                     finally:
                         # handler trace span and metrics
                         telemetry.trace_tool(
@@ -71,12 +72,13 @@ class AgentkitMCPApp(BaseAgentkitApp):
                 # with tracer.start_as_current_span("tool") as span:
                 with telemetry.tracer.start_as_current_span(name="tool") as span:
                     exception = None
+                    result = None
                     try:
                         result = func(*args, **kwargs)
                     except Exception as e:
                         logger.error("Invoke tool function failed: %s", e)
                         exception = e
-                        raise e
+                        raise
                     finally:
                         telemetry.trace_tool(
                             func,
@@ -99,12 +101,13 @@ class AgentkitMCPApp(BaseAgentkitApp):
             async def async_wrapper(*args, **kwargs) -> Any:
                 with telemetry.tracer.start_as_current_span(name="tool") as span:
                     exception = None
+                    result = None
                     try:
                         result = await func(*args, **kwargs)
                     except Exception as e:
                         logger.error("Invoke tool function failed: %s", e)
                         exception = e
-                        raise e
+                        raise
                     finally:
                         telemetry.trace_tool(
                             func,
@@ -123,12 +126,13 @@ class AgentkitMCPApp(BaseAgentkitApp):
             def sync_wrapper(*args, **kwargs) -> Any:
                 with telemetry.tracer.start_as_current_span(name="tool") as span:
                     exception = None
+                    result = None
                     try:
                         result = func(*args, **kwargs)
                     except Exception as e:
                         logger.error("Invoke tool function failed: %s", e)
                         exception = e
-                        raise e
+                        raise
                     finally:
                         telemetry.trace_tool(
                             func,

--- a/agentkit/apps/simple_app/simple_app_handlers.py
+++ b/agentkit/apps/simple_app/simple_app_handlers.py
@@ -308,8 +308,9 @@ class PingHandler(BaseHandler):
         elif isinstance(result, dict):
             return result
         else:
+            func_name = getattr(self.func, "__name__", "<unknown>")
             logger.error(
-                f"Health check function {self.func.__name__} must return `dict` or `str` type."
+                f"Health check function {func_name} must return `dict` or `str` type."
             )
             return {"status": "error", "message": "Invalid response type."}
 
@@ -322,7 +323,7 @@ class AsyncTaskHandler(BaseHandler):
         self._task_counter_lock: threading.Lock = threading.Lock()
 
     @override
-    async def handle(self) -> Response:
+    async def handle(self, request: Request | None = None) -> Response:
         return Response()
 
     def get_async_task_info(self) -> dict[str, Any]:

--- a/agentkit/sdk/runtime/types.py
+++ b/agentkit/sdk/runtime/types.py
@@ -579,6 +579,7 @@ class UpdateRuntimeRequest(RuntimeTypeBaseModel):
     apmplus_enable: Optional[bool] = Field(default=None, alias="ApmplusEnable")
     artifact_type: Optional[str] = Field(default=None, alias="ArtifactType")
     artifact_url: Optional[str] = Field(default=None, alias="ArtifactUrl")
+    client_token: Optional[str] = Field(default=None, alias="ClientToken")
     cpu_milli: Optional[int] = Field(default=None, alias="CpuMilli")
     description: Optional[str] = Field(default=None, alias="Description")
     knowledge_id: Optional[str] = Field(default=None, alias="KnowledgeId")

--- a/agentkit/toolkit/builders/local_docker.py
+++ b/agentkit/toolkit/builders/local_docker.py
@@ -393,6 +393,11 @@ class LocalDockerBuilder(Builder):
             success, build_logs, image_id = self.docker_manager.build_image(
                 **build_kwargs
             )
+            # build_image returns logs as a single string; BuildResult.build_logs
+            # is List[str] (the docker-unavailable path already splits), so
+            # normalize to a list of lines here for a consistent contract.
+            if isinstance(build_logs, str):
+                build_logs = build_logs.splitlines()
 
             if success:
                 self.reporter.success(

--- a/agentkit/toolkit/builders/ve_pipeline.py
+++ b/agentkit/toolkit/builders/ve_pipeline.py
@@ -1088,6 +1088,11 @@ class VeCPCRBuilder(Builder):
             logger.info(f"File uploaded to TOS: {tos_url} (Region: {actual_region})")
             return tos_url, actual_region
 
+        except ValueError:
+            # Config errors (e.g. an unrendered {{template}} bucket name) are
+            # surfaced as-is per the documented contract, not masked as a
+            # generic upload failure.
+            raise
         except Exception as e:
             if "AccountDisable" in str(e):
                 from agentkit.platform import (

--- a/tests/apps/test_mcp_app.py
+++ b/tests/apps/test_mcp_app.py
@@ -256,7 +256,7 @@ def test_invoking_async_tool_wrapper_returns_result_and_traces_as_mcp_tool(
     assert call["args"] == (5,)
 
 
-def test_invoking_sync_tool_wrapper_raises_unbound_local_error_when_func_fails(
+def test_invoking_sync_tool_wrapper_reraises_original_error_and_still_traces(
     app, fake_telemetry
 ):
     boom = ValueError("kaboom")
@@ -267,19 +267,22 @@ def test_invoking_sync_tool_wrapper_raises_unbound_local_error_when_func_fails(
     app.tool(failing_tool)
     wrapper = app._mcp_server.registered[0]
 
-    # NOTE: latent bug -- when the wrapped func raises, ``result`` is never
-    # assigned, so the ``finally`` block's ``telemetry.trace_tool(..., func_result=result, ...)``
-    # dereferences an unbound local. That UnboundLocalError is raised out of the
-    # ``finally`` and MASKS the original ValueError, so trace_tool is never
-    # invoked. We pin the actual current behavior: an UnboundLocalError, not the
-    # original ValueError, escapes and no telemetry call is recorded.
-    with pytest.raises(UnboundLocalError):
+    # After the fix (result initialized before the try): the wrapper re-raises
+    # the ORIGINAL exception instead of an UnboundLocalError from the finally,
+    # and telemetry.trace_tool is still invoked once with func_result=None and
+    # the captured exception.
+    with pytest.raises(ValueError) as excinfo:
         wrapper()
+    assert excinfo.value is boom
 
-    assert fake_telemetry.calls == []
+    assert len(fake_telemetry.calls) == 1
+    call = fake_telemetry.calls[0]
+    assert call["func_result"] is None
+    assert call["exception"] is boom
+    assert call["operation_type"] == "mcp_tool"
 
 
-def test_invoking_async_tool_wrapper_raises_unbound_local_error_when_func_fails(
+def test_invoking_async_tool_wrapper_reraises_original_error_and_still_traces(
     app, fake_telemetry
 ):
     boom = ValueError("kaboom")
@@ -290,13 +293,17 @@ def test_invoking_async_tool_wrapper_raises_unbound_local_error_when_func_fails(
     app.tool(failing_tool)
     wrapper = app._mcp_server.registered[0]
 
-    # NOTE: latent bug -- see sync counterpart. The async wrapper's ``finally``
-    # references the unbound ``result``, raising UnboundLocalError that masks the
-    # original ValueError; trace_tool is never reached.
-    with pytest.raises(UnboundLocalError):
+    # After the fix: the async wrapper re-raises the original ValueError (not an
+    # UnboundLocalError from the finally) and still records one trace_tool call.
+    with pytest.raises(ValueError) as excinfo:
         asyncio.run(wrapper())
+    assert excinfo.value is boom
 
-    assert fake_telemetry.calls == []
+    assert len(fake_telemetry.calls) == 1
+    call = fake_telemetry.calls[0]
+    assert call["func_result"] is None
+    assert call["exception"] is boom
+    assert call["operation_type"] == "mcp_tool"
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +387,7 @@ def test_invoking_async_agent_tool_wrapper_traces_as_agent_mcp_tool_with_args_as
     assert call["args"] == (2, 3)
 
 
-def test_invoking_async_agent_tool_wrapper_raises_unbound_local_error_when_func_fails(
+def test_invoking_async_agent_tool_wrapper_reraises_original_error_and_still_traces(
     app, fake_telemetry
 ):
     boom = RuntimeError("agent boom")
@@ -391,13 +398,18 @@ def test_invoking_async_agent_tool_wrapper_raises_unbound_local_error_when_func_
     app.agent_as_a_tool(failing_agent)
     wrapper = app._mcp_server.registered[0]
 
-    # NOTE: latent bug -- same unbound-``result`` defect as the tool() wrappers.
-    # The ``finally`` block raises UnboundLocalError, masking the original
-    # RuntimeError, and trace_tool is never called.
-    with pytest.raises(UnboundLocalError):
+    # After the fix: the agent wrapper re-raises the original RuntimeError (not
+    # an UnboundLocalError from the finally) and still records one trace_tool
+    # call tagged agent_mcp_tool.
+    with pytest.raises(RuntimeError) as excinfo:
         asyncio.run(wrapper())
+    assert excinfo.value is boom
 
-    assert fake_telemetry.calls == []
+    assert len(fake_telemetry.calls) == 1
+    call = fake_telemetry.calls[0]
+    assert call["func_result"] is None
+    assert call["exception"] is boom
+    assert call["operation_type"] == "agent_mcp_tool"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps/test_simple_app_handlers.py
+++ b/tests/apps/test_simple_app_handlers.py
@@ -492,16 +492,16 @@ def test_format_ping_status_returns_dict_result_unchanged():
     assert handler._format_ping_status(payload) == payload
 
 
-def test_format_ping_status_on_non_str_non_dict_raises_when_func_is_none():
-    # NOTE: latent bug -- the else branch logs f"... {self.func.__name__} ..."
-    # (simple_app_handlers.py:312). When no ping func has been registered,
-    # self.func is None, so attribute access raises AttributeError *before* the
-    # intended {"status": "error", ...} dict is returned. We pin the ACTUAL
-    # current behavior (AttributeError), not the intended error dict.
+def test_format_ping_status_on_non_str_non_dict_returns_error_dict_when_func_is_none():
+    # After the fix (None-safe func name via getattr): with no registered func
+    # the else branch no longer raises AttributeError -- it returns the intended
+    # error dict for an unexpected (non str/dict) result type.
     handler = PingHandler()
     assert handler.func is None
-    with pytest.raises(AttributeError):
-        handler._format_ping_status(12345)
+    assert handler._format_ping_status(12345) == {
+        "status": "error",
+        "message": "Invalid response type.",
+    }
 
 
 def test_format_ping_status_on_non_str_non_dict_returns_error_dict_when_func_present():
@@ -524,17 +524,15 @@ def test_format_ping_status_on_non_str_non_dict_returns_error_dict_when_func_pre
 # ---------------------------------------------------------------------------
 
 
-def test_async_task_handler_handle_takes_no_request_argument():
-    # NOTE: latent bug -- AsyncTaskHandler.handle is declared as `handle(self)`
-    # (simple_app_handlers.py:325), violating the abstract
-    # BaseHandler.handle(self, request) contract. It therefore cannot be used as
-    # a Starlette route endpoint (which always passes a request). We pin the
-    # ACTUAL current behavior: it accepts NO request argument and returns an
-    # empty Response; passing a request raises TypeError.
+def test_async_task_handler_handle_accepts_optional_request_argument():
+    # After the fix: handle conforms to the BaseHandler.handle(self, request)
+    # contract via an optional request param, so it works both as a no-arg call
+    # and as a Starlette route endpoint (which passes a request). Both return an
+    # empty Response.
     handler = AsyncTaskHandler()
 
     resp = asyncio.run(handler.handle())
     assert isinstance(resp, Response)
 
-    with pytest.raises(TypeError):
-        asyncio.run(handler.handle(object()))
+    resp2 = asyncio.run(handler.handle(object()))
+    assert isinstance(resp2, Response)

--- a/tests/toolkit/builders/test_local_docker_build.py
+++ b/tests/toolkit/builders/test_local_docker_build.py
@@ -167,7 +167,9 @@ def test_python_happy_path_returns_image_info_and_calls_build_image(tmp_path):
     assert result.image.tag == "v1.2"
     assert result.image.digest == "sha256:deadbeefimageid"
     assert result.image.full_name == "my-repo:v1.2"
-    # build_logs echoes the raw string returned by build_image (see note below).
+    # build_logs is normalized to a list of lines (split from build_image's
+    # single log string) for a consistent BuildResult.build_logs contract.
+    assert isinstance(result.build_logs, list)
     assert "Successfully built abc123" in result.build_logs
     assert result.build_timestamp is not None
 

--- a/tests/toolkit/builders/test_ve_pipeline_upload_tos.py
+++ b/tests/toolkit/builders/test_ve_pipeline_upload_tos.py
@@ -420,19 +420,14 @@ def test_unrendered_template_bucket_name_raises_value_error_before_service_use(
     # Inject an unrendered template AFTER construction to reach the L933 guard.
     config.tos_bucket = "{{agent_name}}-bucket"
 
-    # NOTE: latent bug -- the docstring advertises `Raises: ValueError` for an
-    # unrendered bucket name, and the guard at L933-936 does raise ValueError.
-    # But that raise happens INSIDE the outer try/except (L914/L1091), so the
-    # broad `except Exception` tail swallows the ValueError and re-raises it as
-    # a plain Exception wrapped with the generic "Failed to upload to TOS:"
-    # prefix (L1120). Callers can therefore never catch this specific failure
-    # as ValueError. We pin the ACTUAL current behavior.
-    with pytest.raises(Exception) as excinfo:
+    # After the fix: an `except ValueError: raise` clause precedes the broad
+    # `except Exception` tail, so the documented ValueError propagates unwrapped
+    # (rather than being masked as a generic "Failed to upload to TOS:"), and
+    # callers can catch this config error as ValueError per the docstring.
+    with pytest.raises(ValueError) as excinfo:
         builder._upload_to_tos(str(archive), config)
 
-    assert not isinstance(excinfo.value, ValueError)
     msg = str(excinfo.value)
-    assert msg.startswith("Failed to upload to TOS:")
     assert "unrendered template variables" in msg
     assert "{{agent_name}}-bucket" in msg
 

--- a/tests/toolkit/runners/test_ve_agentkit_lifecycle.py
+++ b/tests/toolkit/runners/test_ve_agentkit_lifecycle.py
@@ -587,11 +587,10 @@ def test_update_existing_runtime_direct_to_ready_submits_update_and_skips_releas
     assert ureq.knowledge_id == ""
     # binding key absent -> None (not sent)
     assert ureq.tool_id is None
-    # NOTE: latent bug -- _update_existing_runtime passes client_token= to
-    # UpdateRuntimeRequest, but that pydantic model has no client_token field and
-    # extra is "ignore", so the idempotency token is silently dropped (unlike
-    # CreateRuntimeRequest which does carry it). Pin the actual current behaviour.
-    assert not hasattr(ureq, "client_token")
+    # After the fix: UpdateRuntimeRequest now defines a client_token field
+    # (matching CreateRuntimeRequest), so the idempotency token supplied by
+    # _update_existing_runtime is retained instead of being silently dropped.
+    assert isinstance(ureq.client_token, str) and ureq.client_token
 
     # Reached Ready directly -> no release step.
     assert client.release_calls == []


### PR DESCRIPTION
## What
Fixes the 6 latent bugs the unit-test PR pinned, and flips those pins to assert the corrected behavior.

| Bug | Fix |
|---|---|
| mcp `tool()`/`agent_as_a_tool()` wrappers: `UnboundLocalError` in `finally` masked every tool exception + skipped telemetry | init `result = None` before `try` (4 branches); `raise e`→`raise` |
| `ve_pipeline._upload_to_tos`: documented `ValueError` for an unrendered `{{template}}` bucket name swallowed + re-wrapped generic | `except ValueError: raise` before the broad handler |
| `UpdateRuntimeRequest` silently dropped `client_token` (no field, `extra="ignore"`) | added `client_token` field (alias `ClientToken`, matching `CreateRuntimeRequest`) |
| `local_docker.build`: `build_logs` typed `List[str]` but assigned raw `str` | normalize via `splitlines()` |
| `PingHandler._format_ping_status`: `AttributeError` when no func registered | None-safe `getattr` |
| `AsyncTaskHandler.handle`: signature omitted `request`, broke `BaseHandler` contract | optional `request` param |

Full suite: 823 passed, 1 pre-existing failure (`test_cli_add_harness`), no new regressions.

## Stack
Base = `test/agentkit-apps-pipeline-ut`. Merge the standards PR, then the test PR, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)