### PR TITLE
ci: add GitHub tag release workflow for PyPI

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,155 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish, for example v0.7.5'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.tag }}"
+            git fetch --force --tags origin "refs/tags/${tag}:refs/tags/${tag}"
+            git checkout --force "refs/tags/${tag}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must use the form vX.Y.Z, got: ${tag}" >&2
+            exit 1
+          fi
+
+          version="${tag#v}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Ensure tag is on main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "Release tag ${{ steps.version.outputs.tag }} is not reachable from origin/main." >&2
+            exit 1
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install build and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Validate release source
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import re
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          expected = "${{ steps.version.outputs.version }}"
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          project_version = project["project"]["version"]
+          version_py = Path("agentkit/version.py").read_text(encoding="utf-8")
+          version_match = re.search(r'VERSION\s*=\s*["\']([^"\']+)["\']', version_py)
+          source_version = version_match.group(1) if version_match else None
+
+          checks = {
+              "pyproject.toml": project_version == expected,
+              "agentkit/version.py": source_version == expected,
+          }
+          failed = [name for name, ok in checks.items() if not ok]
+          if failed:
+              print(
+                  "Release version mismatch: "
+                  f"tag={expected}, pyproject={project_version}, "
+                  f"agentkit/version.py={source_version}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
+
+      - name: Build release artifacts
+        run: python -m build --outdir dist
+
+      - name: Verify artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m twine check dist/*
+          python - <<'PY'
+          from __future__ import annotations
+
+          import sys
+          import tarfile
+          import zipfile
+          from pathlib import Path
+
+          expected = "${{ steps.version.outputs.version }}"
+          dist = Path("dist")
+          wheel = next(dist.glob("agentkit_sdk_python-*.whl"))
+          sdist = next(dist.glob("agentkit_sdk_python-*.tar.gz"))
+
+          with zipfile.ZipFile(wheel) as archive:
+              names = archive.namelist()
+              version_py = archive.read("agentkit/version.py").decode()
+              metadata_name = next(
+                  name for name in names if name.endswith(".dist-info/METADATA")
+              )
+              metadata = archive.read(metadata_name).decode()
+
+          with tarfile.open(sdist) as archive:
+              root = archive.getnames()[0].split("/", 1)[0]
+              pyproject = archive.extractfile(f"{root}/pyproject.toml").read().decode()
+              sdist_version_py = (
+                  archive.extractfile(f"{root}/agentkit/version.py").read().decode()
+              )
+
+          checks = {
+              "wheel metadata": f"Version: {expected}" in metadata,
+              "wheel version.py": f'VERSION = "{expected}"' in version_py,
+              "sdist pyproject": f'version = "{expected}"' in pyproject,
+              "sdist version.py": f'VERSION = "{expected}"' in sdist_version_py,
+          }
+          failed = [name for name, ok in checks.items() if not ok]
+          if failed:
+              print(f"Artifact version verification failed: {failed}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
@@ -153,3 +152,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -111,10 +111,13 @@ When the tag reaches GitHub, `.github/workflows/release-pypi.yml` will:
 - verify that `pyproject.toml` and `agentkit/version.py` match the tag version
 - build the wheel and source distribution from the tagged commit
 - verify the built artifacts contain the expected version metadata
-- publish the release to PyPI through GitHub OIDC Trusted Publishing
+- publish the release to PyPI using the GitHub Actions secret `PYPI_API_TOKEN`
 
 The internal `local_build.py` helper is a separate local-only workflow and is
 not used by the GitHub tag release.
+
+Before using the GitHub tag release workflow, configure a project-scoped PyPI
+API token in the repository's GitHub Actions secrets as `PYPI_API_TOKEN`.
 
 ## Security and privacy
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,37 @@ pip install agentkit-sdk-python==1.0.0.dev1
 
 **Note**: Development versions may contain bugs and are not recommended for production use.
 
+## Release Process
+
+Stable releases are published from GitHub tags. The source tree keeps the
+release version in `pyproject.toml` and `agentkit/version.py`, and the GitHub
+workflow verifies that the pushed tag matches those files before building and
+publishing the package.
+
+The release workflow must already exist on `main` before you push the release
+tag. For `0.7.5`, merge the tag-release automation change first, then create
+and push `v0.7.5`.
+
+Use the following workflow for a stable release:
+
+```bash
+git checkout main
+git pull github main
+git tag v0.7.5
+git push github v0.7.5
+```
+
+When the tag reaches GitHub, `.github/workflows/release-pypi.yml` will:
+
+- verify the tag is reachable from `main`
+- verify that `pyproject.toml` and `agentkit/version.py` match the tag version
+- build the wheel and source distribution from the tagged commit
+- verify the built artifacts contain the expected version metadata
+- publish the release to PyPI through GitHub OIDC Trusted Publishing
+
+The internal `local_build.py` helper is a separate local-only workflow and is
+not used by the GitHub tag release.
+
 ## Security and privacy
 
 This project takes security seriously.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "agentkit-sdk-python"
 version = "0.7.5"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that publishes to PyPI when a `vX.Y.Z` tag is pushed
- verify the pushed tag is reachable from `main` and matches `pyproject.toml` / `agentkit/version.py`
- build wheel and sdist with standard `python -m build`, run `twine check`, and verify artifact version metadata

## Validation
- parsed `.github/workflows/release-pypi.yml` successfully
- verified source version consistency for `0.7.5`
- ran `python -m build --outdir dist-release-final`
- ran `python -m twine check dist-release-final/*`
- verified wheel/sdist metadata contains `0.7.5`

## Release note
Merge this PR before pushing `v0.7.5`, otherwise the tag-triggered workflow will not exist on `main` yet.