### PR TITLE
feat: use sandbox build config for create defaults

### DIFF
--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, NoReturn, Optional
 
 import typer
+import yaml
 
 from agentkit.platform import VolcConfiguration
 from agentkit.sdk.tools.client import AgentkitToolsClient
@@ -48,6 +49,7 @@ from agentkit.toolkit.cli.sandbox.tos_config import (
     build_create_tool_tos_mount_config,
 )
 from agentkit.toolkit.cli.sandbox.sandbox_client import error
+from agentkit.toolkit.cli.sandbox.sandbox_client import SANDBOX_YAML_PATH
 from agentkit.toolkit.volcengine.services.tos_service import (
     TOSService,
     TOSServiceConfig,
@@ -72,6 +74,55 @@ NETWORK_CONFIG_FIELDS = (
     "subnet_ids",
     "enable_shared_internet_access",
 )
+
+
+def _get_sandbox_yaml_path() -> Path:
+    return Path.cwd() / SANDBOX_YAML_PATH
+
+
+def _load_sandbox_yaml_defaults() -> tuple[str, str] | None:
+    path = _get_sandbox_yaml_path()
+    if not path.exists():
+        return None
+
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        error(f"Invalid {SANDBOX_YAML_PATH}: {exc}")
+    except OSError as exc:
+        error(f"Failed to read {SANDBOX_YAML_PATH}: {exc}")
+
+    if not isinstance(payload, dict):
+        error(f"Invalid {SANDBOX_YAML_PATH}: expected a YAML mapping")
+
+    raw_tool_type = payload.get("tool_type")
+    raw_image_url = payload.get("image_url")
+    if not isinstance(raw_tool_type, str) or not raw_tool_type.strip():
+        error(f"Invalid {SANDBOX_YAML_PATH}: tool_type must be a non-empty string")
+    if not isinstance(raw_image_url, str) or not raw_image_url.strip():
+        error(f"Invalid {SANDBOX_YAML_PATH}: image_url must be a non-empty string")
+
+    tool_type = _validate_tool_type(raw_tool_type)
+    image_url = raw_image_url.strip()
+    if tool_type == PRIVATE_TOOL_TYPE and not image_url:
+        error(f"Invalid {SANDBOX_YAML_PATH}: image_url is required for Private tools")
+
+    return tool_type, image_url
+
+
+def _resolve_create_tool_image_defaults(
+    *,
+    tool_type: Optional[str],
+    image_url: Optional[str],
+) -> tuple[str, Optional[str]]:
+    if tool_type is not None or image_url is not None:
+        return tool_type or DEFAULT_CREATE_TOOL_TYPE, image_url
+
+    defaults = _load_sandbox_yaml_defaults()
+    if defaults is None:
+        return DEFAULT_CREATE_TOOL_TYPE, image_url
+
+    return defaults
 
 
 def _resolve_region(env_var_name: str, service_key: str) -> str:
@@ -573,8 +624,8 @@ def create_tool(
 
 def create_command(
     ctx: typer.Context,
-    tool_type: str = typer.Option(
-        DEFAULT_CREATE_TOOL_TYPE,
+    tool_type: Optional[str] = typer.Option(
+        None,
         "--tool-type",
         help="Tool type. Defaults to CodeEnv.",
     ),
@@ -664,6 +715,10 @@ def create_command(
     result = None
     try:
         skill_role_name, skill_role_name_provided = _resolve_create_extra_args(ctx)
+        tool_type, image_url = _resolve_create_tool_image_defaults(
+            tool_type=tool_type,
+            image_url=image_url,
+        )
         if tos_mount is not None and not (tos_bucket or "").strip():
             error("--tos-mount requires --tos-bucket")
         result = create_tool(

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -627,7 +627,7 @@ def create_command(
     tool_type: Optional[str] = typer.Option(
         None,
         "--tool-type",
-        help="Tool type. Defaults to sandbox.yaml (from sandbox build) or CodeEnv.",
+        help="Tool type. Defaults to Private if sandbox.yaml exists (from sandbox build) or CodeEnv.",
     ),
     tool_name: Optional[str] = typer.Option(
         None,

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -627,7 +627,7 @@ def create_command(
     tool_type: Optional[str] = typer.Option(
         None,
         "--tool-type",
-        help="Tool type. Defaults to CodeEnv.",
+        help="Tool type. Defaults to sandbox.yaml (from sandbox build) or CodeEnv.",
     ),
     tool_name: Optional[str] = typer.Option(
         None,
@@ -694,7 +694,7 @@ def create_command(
     image_url: Optional[str] = typer.Option(
         None,
         "--image-url",
-        help="Custom image URL. Required when --tool-type Private.",
+        help="Custom image URL. Defaults to sandbox.yaml (from sandbox build). Required for Private tools.",
     ),
     network_config: Optional[str] = typer.Option(
         None,

--- a/tests/toolkit/cli/test_cli_create_tool.py
+++ b/tests/toolkit/cli/test_cli_create_tool.py
@@ -177,11 +177,16 @@ def _reset_fake_tools_client():
 
 
 @pytest.fixture(autouse=True)
-def _use_platform_config(monkeypatch):
+def _use_platform_config(monkeypatch, tmp_path):
     from agentkit.toolkit.cli.sandbox import cli_create
 
     _reset_fake_tools_client()
     monkeypatch.setattr(cli_create, "VolcConfiguration", _FakePlatformConfig)
+    monkeypatch.setattr(
+        cli_create,
+        "_get_sandbox_yaml_path",
+        lambda: tmp_path / ".agentkit" / "sandbox" / "sandbox.yaml",
+    )
 
 
 def test_create_command_skips_tos_mount_by_default(
@@ -850,6 +855,109 @@ def test_create_command_adds_private_defaults_and_caches_private_type(
         "ToolType": "Private",
         "ModelProvider": "model_square",
     }
+
+
+def test_create_command_uses_sandbox_yaml_when_image_options_are_omitted(
+    monkeypatch,
+):
+    from agentkit.toolkit.cli.cli import app
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+    monkeypatch.setattr(
+        cli_create,
+        "_wait_for_tool_ready",
+        lambda _client, _tool_id: SimpleNamespace(
+            tool_type="Private",
+            name="demo-tool",
+            status="Ready",
+        ),
+    )
+    sandbox_yaml_path = cli_create._get_sandbox_yaml_path()
+    sandbox_yaml_path.parent.mkdir(parents=True, exist_ok=True)
+    sandbox_yaml_path.write_text(
+        "tool_type: Private\n"
+        "image_url: registry.example.com/custom-image:from-yaml\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["sandbox", "create", "--tool-name", "demo-tool"])
+
+    assert result.exit_code == 0
+    request = _FakeToolsClient.last_request
+    assert request.tool_type == "Private"
+    assert request.image_url == "registry.example.com/custom-image:from-yaml"
+    assert request.command == "/opt/gem/run.sh"
+    assert request.port == 8080
+
+
+def test_create_command_cli_tool_type_disables_sandbox_yaml_defaults(
+    monkeypatch,
+):
+    from agentkit.toolkit.cli.cli import app
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+    sandbox_yaml_path = cli_create._get_sandbox_yaml_path()
+    sandbox_yaml_path.parent.mkdir(parents=True, exist_ok=True)
+    sandbox_yaml_path.write_text(
+        "tool_type: Private\n"
+        "image_url: registry.example.com/custom-image:from-yaml\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["sandbox", "create", "--tool-name", "demo-tool", "--tool-type", "CodeEnv"],
+    )
+
+    assert result.exit_code == 0
+    request = _FakeToolsClient.last_request
+    assert request.tool_type == "CodeEnv"
+    assert request.image_url is None
+    assert request.command is None
+    assert request.port is None
+
+
+def test_create_command_cli_image_url_disables_sandbox_yaml_defaults(
+    monkeypatch,
+):
+    from agentkit.toolkit.cli.cli import app
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+    sandbox_yaml_path = cli_create._get_sandbox_yaml_path()
+    sandbox_yaml_path.parent.mkdir(parents=True, exist_ok=True)
+    sandbox_yaml_path.write_text(
+        "tool_type: Private\n"
+        "image_url: registry.example.com/custom-image:from-yaml\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "--tool-name",
+            "demo-tool",
+            "--image-url",
+            "registry.example.com/custom-image:from-cli",
+        ],
+    )
+
+    assert result.exit_code == 0
+    request = _FakeToolsClient.last_request
+    assert request.tool_type == "CodeEnv"
+    assert request.image_url == "registry.example.com/custom-image:from-cli"
+    assert request.command is None
+    assert request.port is None
 
 
 def test_build_create_tool_request_adds_model_envs(monkeypatch):


### PR DESCRIPTION
Use .agentkit/sandbox/sandbox.yaml as default input for sandbox create when
    --tool-type and --image-url are omitted.