### PR TITLE
feat(harness-deploy): add backward-compatible Runtime VPC config

### DIFF
--- a/agentkit/toolkit/cli/cli_deploy.py
+++ b/agentkit/toolkit/cli/cli_deploy.py
@@ -15,7 +15,7 @@
 """AgentKit CLI - Deploy command implementation."""
 
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, List, Optional
 
 import typer
 from rich.console import Console
@@ -63,6 +63,27 @@ def deploy_command(
         "--allowed-id",
         help="Comma-separated allowed client IDs for OAuth2/JWT auth (harness deploy).",
     ),
+    runtime_network_mode: Optional[str] = typer.Option(
+        None,
+        "--runtime-network-mode",
+        help="Harness Runtime network mode: public, private, or both.",
+    ),
+    runtime_vpc_id: Optional[str] = typer.Option(
+        None,
+        "--runtime-vpc-id",
+        help="Harness Runtime VPC ID (required for private/both).",
+    ),
+    runtime_subnet_ids: Optional[List[str]] = typer.Option(
+        None,
+        "--runtime-subnet-id",
+        "--runtime-subnet-ids",
+        help="Harness Runtime subnet ID. Repeat for multiple subnets.",
+    ),
+    runtime_enable_shared_internet_access: Optional[bool] = typer.Option(
+        None,
+        "--runtime-enable-shared-internet-access/--no-runtime-enable-shared-internet-access",
+        help="Enable shared internet egress for a private Harness Runtime.",
+    ),
     yes: bool = typer.Option(
         False,
         "--yes",
@@ -83,6 +104,10 @@ def deploy_command(
             secret_key=volcengine_secret_key,
             discovery_url=discovery_url,
             allowed_id=allowed_id,
+            runtime_network_mode=runtime_network_mode,
+            runtime_vpc_id=runtime_vpc_id,
+            runtime_subnet_ids=runtime_subnet_ids,
+            runtime_enable_shared_internet_access=runtime_enable_shared_internet_access,
             assume_yes=yes,
         )
         return
@@ -126,6 +151,11 @@ def _deploy_harness(
     discovery_url,
     allowed_id,
     assume_yes: bool = False,
+    *,
+    runtime_network_mode=None,
+    runtime_vpc_id=None,
+    runtime_subnet_ids=None,
+    runtime_enable_shared_internet_access=None,
 ):
     """Deploy a harness spec <name>.harness.json from the current directory."""
     import sys
@@ -159,6 +189,10 @@ def _deploy_harness(
             secret_key=secret_key,
             discovery_url=discovery_url,
             allowed_id=allowed_id,
+            runtime_network_mode=runtime_network_mode,
+            runtime_vpc_id=runtime_vpc_id,
+            runtime_subnet_ids=runtime_subnet_ids,
+            runtime_enable_shared_internet_access=runtime_enable_shared_internet_access,
             reporter=reporter,
             on_conflict=on_conflict,
         )
@@ -185,6 +219,4 @@ def _deploy_harness(
     if meta.get("runtime_apikey"):
         console.print(f"[green]API key: {meta['runtime_apikey']}[/green]")
     if endpoint:
-        console.print(
-            f"[green]Recorded in {(Path.cwd() / 'harness.json')}[/green]"
-        )
+        console.print(f"[green]Recorded in {(Path.cwd() / 'harness.json')}[/green]")

--- a/agentkit/toolkit/harness/config_builder.py
+++ b/agentkit/toolkit/harness/config_builder.py
@@ -23,6 +23,7 @@ def build_agentkit_config(
     envs: Dict[str, str],
     auth: Optional[Dict[str, Any]] = None,
     runtime_id: str = "Auto",
+    runtime_network: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build the cloud AgentKit launch config dict (auto-provision).
 
@@ -64,6 +65,9 @@ def build_agentkit_config(
         cloud["runtime_apikey_name"] = "Auto"
         cloud["runtime_apikey"] = "Auto"
         cloud["runtime_jwt_allowed_clients"] = []
+    if runtime_network:
+        # Forwarded to the cloud runner for CreateRuntime (public/private/both).
+        cloud["runtime_network"] = runtime_network
     return {
         "common": {
             "agent_name": runtime_name,

--- a/agentkit/toolkit/harness/deploy.py
+++ b/agentkit/toolkit/harness/deploy.py
@@ -198,6 +198,10 @@ def deploy_harness(
     secret_key: Optional[str] = None,
     discovery_url: Optional[str] = None,
     allowed_id: Optional[str] = None,
+    runtime_network_mode: Optional[str] = None,
+    runtime_vpc_id: Optional[str] = None,
+    runtime_subnet_ids: Optional[list] = None,
+    runtime_enable_shared_internet_access: Optional[bool] = None,
     reporter: Optional[Reporter] = None,
     on_conflict: Optional[Callable[[Dict[str, Any]], bool]] = None,
 ) -> LifecycleResult:
@@ -228,6 +232,10 @@ def deploy_harness(
         region: AgentKit region (default ``cn-beijing`` or ``VOLCENGINE_REGION``).
         access_key / secret_key: Volcengine credentials (default: ``VOLCENGINE_*`` env).
         discovery_url / allowed_id: OAuth2/JWT overrides for the spec ``auth`` block.
+        runtime_network_mode / runtime_vpc_id / runtime_subnet_ids /
+            runtime_enable_shared_internet_access: Optional Runtime networking
+            overrides. When omitted, the generated config is identical to the
+            legacy public-network deploy config.
         reporter: Progress reporter forwarded to the launch (default: silent).
         on_conflict: Callback consulted when a single same-name harness exists;
             returns True to update it, False to abort.
@@ -279,6 +287,22 @@ def deploy_harness(
 
     resolved_region = region or os.getenv("VOLCENGINE_REGION") or "cn-beijing"
 
+    # Runtime VPC network (CreateRuntime only); forwarded to the cloud runner.
+    runtime_network = {}
+    if runtime_network_mode is not None:
+        runtime_network["mode"] = runtime_network_mode
+    if runtime_vpc_id is not None:
+        runtime_network["vpc_id"] = runtime_vpc_id
+    # Typer and programmatic callers may represent an omitted repeated option as
+    # either None or an empty list. Treat both as "not configured" so an old
+    # deploy command keeps producing the exact legacy public-network config.
+    if runtime_subnet_ids:
+        runtime_network["subnet_ids"] = runtime_subnet_ids
+    if runtime_enable_shared_internet_access is not None:
+        runtime_network["enable_shared_internet_access"] = (
+            runtime_enable_shared_internet_access
+        )
+
     # Resolve a name collision into a deploy mode. The harness config defaults to
     # `runtime_id: Auto` (create new); an existing same-name harness can instead
     # be updated in place (new version) after confirmation.
@@ -328,6 +352,7 @@ def deploy_harness(
         runtime_envs,
         auth,
         runtime_id=update_runtime_id or "Auto",
+        runtime_network=runtime_network,
     )
 
     # AgentKit's launch path exposes no hook for runtime tags, so tag the runtime

--- a/tests/toolkit/test_harness_deploy_compat.py
+++ b/tests/toolkit/test_harness_deploy_compat.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward-compatibility contracts for Harness Runtime network options."""
+
+from inspect import Parameter, signature
+
+from typer.testing import CliRunner
+
+from agentkit.toolkit.cli.cli import app
+from agentkit.toolkit.harness.config_builder import build_agentkit_config
+from agentkit.toolkit.harness.deploy import deploy_harness
+
+
+def test_legacy_config_builder_call_does_not_add_runtime_network():
+    config = build_agentkit_config(
+        "legacy-harness",
+        "cn-beijing",
+        {"EXISTING_ENV": "value"},
+        None,
+        "Auto",
+    )
+
+    cloud = config["launch_types"]["cloud"]
+    assert "runtime_network" not in cloud
+    assert cloud["runtime_id"] == "Auto"
+
+
+def test_runtime_network_is_opt_in():
+    runtime_network = {
+        "mode": "private",
+        "vpc_id": "vpc-example",
+        "subnet_ids": ["subnet-example"],
+    }
+
+    config = build_agentkit_config(
+        "private-harness",
+        "cn-beijing",
+        {},
+        runtime_network=runtime_network,
+    )
+
+    assert config["launch_types"]["cloud"]["runtime_network"] == runtime_network
+
+
+def test_public_deploy_network_options_are_optional_keyword_only_parameters():
+    parameters = signature(deploy_harness).parameters
+
+    for name in (
+        "runtime_network_mode",
+        "runtime_vpc_id",
+        "runtime_subnet_ids",
+        "runtime_enable_shared_internet_access",
+    ):
+        assert parameters[name].kind is Parameter.KEYWORD_ONLY
+        assert parameters[name].default is None
+
+
+def test_cli_helper_preserves_legacy_assume_yes_positional_parameter():
+    from agentkit.toolkit.cli.cli_deploy import _deploy_harness
+
+    parameters = list(signature(_deploy_harness).parameters.values())
+
+    assert [parameter.name for parameter in parameters[:7]] == [
+        "name",
+        "region",
+        "access_key",
+        "secret_key",
+        "discovery_url",
+        "allowed_id",
+        "assume_yes",
+    ]
+    assert parameters[6].default is False
+    assert all(parameter.kind is Parameter.KEYWORD_ONLY for parameter in parameters[7:])
+
+
+def test_legacy_cli_invocation_keeps_network_options_unset(monkeypatch):
+    import agentkit.toolkit.cli.cli_deploy as cli_deploy
+
+    captured = {}
+
+    def fake_deploy_harness(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli_deploy, "_deploy_harness", fake_deploy_harness)
+
+    result = CliRunner().invoke(app, ["deploy", "--harness", "legacy-harness"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["runtime_network_mode"] is None
+    assert captured["runtime_vpc_id"] is None
+    assert not captured["runtime_subnet_ids"]
+    assert captured["runtime_enable_shared_internet_access"] is None


### PR DESCRIPTION
## Summary
- Add optional Runtime network flags to `agentkit deploy --harness` and the public `deploy_harness` API.
- Forward opt-in network configuration to the existing cloud runner for Runtime creation.
- Preserve legacy deploy output and the existing positional helper calling convention when options are omitted.

## Backward compatibility
- New `deploy_harness` network parameters are keyword-only and default to `None`.
- The config builder appends one optional parameter without changing existing positional arguments.
- Legacy callers emit no `runtime_network`; an empty repeated subnet option is also treated as unset.
- Compatibility contract tests cover the old builder call, CLI invocation, and helper signature.

## Validation
- `13 passed` for Harness/network compatibility tests.
- Ruff check, Ruff format, and gitleaks hooks passed on all changed files.