### PR TITLE
feat(agent-server): capture inbound auth credentials

### DIFF
--- a/agentkit/apps/agent_server_app/agent_server_app.py
+++ b/agentkit/apps/agent_server_app/agent_server_app.py
@@ -61,6 +61,15 @@ except ImportError:  # pragma: no cover - default migration path avoids veadk.
 from agentkit.apps.agent_server_app.middleware import (
     AgentkitTelemetryHTTPMiddleware,
 )
+from agentkit.apps.agent_server_app.credential_service import (
+    AgentkitCredentialService,
+)
+from agentkit.apps.agent_server_app.inbound_auth_adapter import (
+    InboundAuthCaptureMiddleware,
+    build_a2a_inbound_auth_executor_factory,
+    save_inbound_auth,
+)
+from agentkit.apps.auth.inbound import redact_inbound_auth_headers
 from agentkit.apps.agent_server_app.origin import (
     add_cors_compat_middleware,
     adk_supports_regex_origins,
@@ -131,6 +140,10 @@ def _create_a2a_runner(
             short_term_memory=short_term_memory
             if _is_veadk_short_term_memory(short_term_memory)
             else None,
+            app_name=root_agent.name,
+            session_service=session_service,
+            memory_service=memory_service,
+            credential_service=credential_service,
         )
     return Runner(
         agent=root_agent,
@@ -233,10 +246,12 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
         app: App | None = None,
         allow_origins: list[str] | None = None,
         allow_origin_regex: str | list[str] | None = None,
+        enable_auth: bool = False,
         identity: IdentityRuntimeConfig | RuntimeIdentity | None = None,
         identity_health_routes: tuple[str, ...] = (),
     ) -> None:
         super().__init__()
+        self._enable_auth_enabled = enable_auth
 
         if app is not None and agent is not None:
             raise TypeError("Only one of 'agent' or 'app' can be provided.")
@@ -250,7 +265,9 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
         memory_service = _resolve_memory_service(root_agent)
 
         _artifact_service = InMemoryArtifactService()
-        _credential_service = InMemoryCredentialService()
+        _credential_service = (
+            AgentkitCredentialService() if enable_auth else InMemoryCredentialService()
+        )
 
         _eval_sets_manager = LocalEvalSetsManager(agents_dir=".")
         _eval_set_results_manager = LocalEvalSetResultsManager(agents_dir=".")
@@ -274,14 +291,21 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
             artifact_service=_artifact_service,
             credential_service=_credential_service,
         )
-        _a2a_server_app = to_a2a(agent=root_agent, runner=runner)
+        to_a2a_kwargs: dict[str, Any] = {"agent": root_agent, "runner": runner}
+        if enable_auth:
+            to_a2a_kwargs["agent_executor_factory"] = (
+                build_a2a_inbound_auth_executor_factory(
+                    runner=runner,
+                    app_name=root_agent.name,
+                    credential_service=_credential_service,
+                )
+            )
+        _a2a_server_app = to_a2a(**to_a2a_kwargs)
 
         @asynccontextmanager
         async def lifespan(app: FastAPI):
             # trigger A2A server app startup
-            logger.info(
-                "Triggering A2A server app lifespan within API server..."
-            )
+            logger.info("Triggering A2A server app lifespan within API server...")
             async with _run_a2a_app_lifespan(_a2a_server_app):
                 yield
 
@@ -344,12 +368,21 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
             add_cors_compat_middleware(self.app, resolved_allow_origins)
 
         @self.app.post("/run_sse")
-        async def run_agent_sse(req: RunAgentRequest) -> StreamingResponse:
+        async def run_agent_sse(
+            req: RunAgentRequest, request: Request
+        ) -> StreamingResponse:
             logger.info("Overriding run_agent_sse endpoint...")
             identity_context = AgentkitAgentServerApp._request_identity_context(self)
             effective_user_id = (
                 identity_context.user_sub if identity_context else req.user_id
             )
+            if getattr(self, "_enable_auth_enabled", False):
+                await save_inbound_auth(
+                    request=request,
+                    app_name=req.app_name,
+                    user_id=effective_user_id,
+                    credential_service=self.server.credential_service,
+                )
             # SSE endpoint
             session = await self.server.session_service.get_session(
                 app_name=req.app_name,
@@ -423,9 +456,7 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
                         telemetry.trace_agent_server_finish(
                             path="/run_sse", func_result="", exception=e
                         )
-                        error_payload = (
-                            f"data: {json.dumps({'error': str(e)})}\n\n"
-                        )
+                        error_payload = f"data: {json.dumps({'error': str(e)})}\n\n"
                 if error_payload is not None:
                     # Yield only after the caught exception variable and its
                     # traceback have left scope in identity mode.
@@ -462,6 +493,8 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
                 identity=self.runtime_identity,
                 public_health_routes=identity_health_routes,
             )
+        if enable_auth:
+            self.app.add_middleware(InboundAuthCaptureMiddleware)
 
         async def _invoke_compat(request: Request):
             # Use current request span from middleware for telemetry
@@ -469,11 +502,7 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
 
             # Extract headers (fallback keys supported)
             headers = request.headers
-            telemetry_headers = {
-                k: v
-                for k, v in dict(headers).items()
-                if k.lower() not in {"authorization", "token"}
-            }
+            telemetry_headers = redact_inbound_auth_headers(dict(headers))
             # trace request attributes on current span
             telemetry.trace_agent_server(
                 func_name="_invoke_compat",
@@ -501,6 +530,13 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
                 )
                 raise exception
             app_name = app_names[0]
+            if getattr(self, "_enable_auth_enabled", False):
+                await save_inbound_auth(
+                    request=request,
+                    app_name=app_name,
+                    user_id=user_id,
+                    credential_service=self.server.credential_service,
+                )
 
             # Parse payload and convert to ADK Content
             try:
@@ -541,9 +577,7 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
                             user_id=user_id,
                             session_id=session_id,
                             new_message=content,
-                            run_config=RunConfig(
-                                streaming_mode=StreamingMode.SSE
-                            ),
+                            run_config=RunConfig(streaming_mode=StreamingMode.SSE),
                         )
                     ) as agen:
                         async for event in agen:

--- a/agentkit/apps/agent_server_app/credential_service.py
+++ b/agentkit/apps/agent_server_app/credential_service.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.auth.auth_credential import AuthCredential
+from google.adk.auth.credential_service.base_credential_service import (
+    BaseCredentialService,
+)
+
+
+class AgentkitCredentialService(BaseCredentialService):
+    """AgentKit-owned ADK credential service with a direct write API."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._credentials: dict[str, dict[str, dict[str, AuthCredential]]] = {}
+
+    async def load_credential(
+        self,
+        auth_config: Any,
+        callback_context: Any,
+    ) -> AuthCredential | None:
+        app_name, user_id = self._resolve_context(callback_context)
+        credential_key = self._resolve_credential_key(auth_config)
+        if credential_key is None:
+            return None
+        return await self.get_credential(
+            app_name=app_name,
+            user_id=user_id,
+            credential_key=credential_key,
+        )
+
+    async def save_credential(
+        self,
+        auth_config: Any,
+        callback_context: Any,
+    ) -> None:
+        app_name, user_id = self._resolve_context(callback_context)
+        credential_key = self._resolve_credential_key(auth_config)
+        credential = getattr(auth_config, "exchanged_auth_credential", None)
+        if credential_key and credential is not None:
+            await self.set_credential(
+                app_name=app_name,
+                user_id=user_id,
+                credential_key=credential_key,
+                credential=credential,
+            )
+
+    async def set_credential(
+        self,
+        app_name: str,
+        user_id: str,
+        credential_key: str,
+        credential: AuthCredential,
+    ) -> None:
+        self._credentials.setdefault(app_name, {})
+        self._credentials[app_name].setdefault(user_id, {})
+        self._credentials[app_name][user_id][credential_key] = credential
+
+    async def get_credential(
+        self,
+        app_name: str,
+        user_id: str,
+        credential_key: str,
+    ) -> AuthCredential | None:
+        return self._credentials.get(app_name, {}).get(user_id, {}).get(credential_key)
+
+    def _resolve_context(self, callback_context: Any) -> tuple[str, str]:
+        invocation_context = getattr(callback_context, "_invocation_context", None)
+        if invocation_context is None:
+            invocation_context = getattr(callback_context, "invocation_context", None)
+        return invocation_context.app_name, invocation_context.user_id
+
+    def _resolve_credential_key(self, auth_config: Any) -> str | None:
+        credential_key = getattr(auth_config, "credential_key", None)
+        if credential_key is None and hasattr(auth_config, "get_credential_key"):
+            credential_key = auth_config.get_credential_key()
+        return credential_key

--- a/agentkit/apps/agent_server_app/inbound_auth.py
+++ b/agentkit/apps/agent_server_app/inbound_auth.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility imports for AgentServer inbound-auth helpers."""
+
+from agentkit.apps.agent_server_app.inbound_auth_adapter import (
+    inbound_tokens_to_adk_credentials,
+    save_inbound_auth,
+)
+from agentkit.apps.auth.inbound import (
+    AUTHORIZATION_HEADER,
+    INBOUND_AUTH_CREDENTIAL_KEY,
+    TIP_TOKEN_CREDENTIAL_KEY,
+    TIP_TOKEN_HEADER,
+    InboundAuthTokens,
+    extract_inbound_auth,
+    redact_inbound_auth_headers,
+    strip_bearer,
+)
+
+__all__ = [
+    "AUTHORIZATION_HEADER",
+    "INBOUND_AUTH_CREDENTIAL_KEY",
+    "TIP_TOKEN_CREDENTIAL_KEY",
+    "TIP_TOKEN_HEADER",
+    "InboundAuthTokens",
+    "extract_inbound_auth",
+    "inbound_tokens_to_adk_credentials",
+    "redact_inbound_auth_headers",
+    "save_inbound_auth",
+    "strip_bearer",
+]

--- a/agentkit/apps/agent_server_app/inbound_auth_adapter.py
+++ b/agentkit/apps/agent_server_app/inbound_auth_adapter.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
+from google.adk.a2a.executor.config import A2aAgentExecutorConfig, ExecuteInterceptor
+from google.adk.auth.auth_credential import (
+    AuthCredential,
+    AuthCredentialTypes,
+    HttpAuth,
+    HttpCredentials,
+)
+
+from agentkit.apps.auth.inbound import (
+    INBOUND_AUTH_CREDENTIAL_KEY,
+    TIP_TOKEN_CREDENTIAL_KEY,
+    InboundAuthTokens,
+    extract_inbound_auth,
+)
+
+logger = logging.getLogger(__name__)
+INBOUND_AUTH_TOKENS_SCOPE_KEY = "agentkit.inbound_auth_tokens"
+
+
+class InboundAuthCaptureMiddleware:
+    """Capture inbound auth before identity middleware scrubs Authorization."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") == "http":
+            headers = {
+                key.decode("latin-1"): value.decode("latin-1")
+                for key, value in scope.get("headers", [])
+            }
+            tokens = extract_inbound_auth(headers)
+            if tokens:
+                scope = dict(scope)
+                scope[INBOUND_AUTH_TOKENS_SCOPE_KEY] = tokens
+        await self.app(scope, receive, send)
+
+
+def inbound_tokens_to_adk_credentials(
+    tokens: InboundAuthTokens,
+) -> dict[str, AuthCredential]:
+    credentials: dict[str, AuthCredential] = {}
+    if tokens.authorization_token:
+        credentials[INBOUND_AUTH_CREDENTIAL_KEY] = AuthCredential(
+            auth_type=AuthCredentialTypes.HTTP,
+            http=HttpAuth(
+                scheme=tokens.authorization_scheme or "header",
+                credentials=HttpCredentials(token=tokens.authorization_token),
+            ),
+        )
+    if tokens.tip_token:
+        credentials[TIP_TOKEN_CREDENTIAL_KEY] = AuthCredential(
+            auth_type=AuthCredentialTypes.API_KEY,
+            api_key=tokens.tip_token,
+        )
+    return credentials
+
+
+def _request_inbound_auth_tokens(request: Any) -> InboundAuthTokens:
+    scope = getattr(request, "scope", None)
+    if isinstance(scope, dict):
+        captured = scope.get(INBOUND_AUTH_TOKENS_SCOPE_KEY)
+        if isinstance(captured, InboundAuthTokens):
+            return captured
+    return extract_inbound_auth(request.headers)
+
+
+async def save_inbound_auth(
+    *,
+    request: Any,
+    app_name: str,
+    user_id: str,
+    credential_service: Any,
+) -> None:
+    try:
+        set_credential = getattr(credential_service, "set_credential", None)
+        if not callable(set_credential):
+            logger.warning("Credential service cannot store inbound auth credentials")
+            return
+
+        tokens = _request_inbound_auth_tokens(request)
+        for credential_key, credential in inbound_tokens_to_adk_credentials(
+            tokens
+        ).items():
+            await set_credential(
+                app_name=app_name,
+                user_id=user_id,
+                credential_key=credential_key,
+                credential=credential,
+            )
+    except Exception:
+        logger.warning("Failed to save inbound auth credentials", exc_info=True)
+
+
+def _resolve_a2a_user_id(context: Any) -> str:
+    call_context = getattr(context, "call_context", None)
+    user = getattr(call_context, "user", None)
+    user_name = getattr(user, "user_name", None)
+    if user_name:
+        return user_name
+
+    context_id = getattr(context, "context_id", None)
+    return f"A2A_USER_{context_id}"
+
+
+def _ensure_a2a_runner_credential_service(
+    runner: Any,
+    credential_service: Any,
+) -> Any:
+    runner_credential_service = getattr(runner, "credential_service", None)
+    if runner_credential_service is not None:
+        return runner_credential_service
+
+    try:
+        runner.credential_service = credential_service
+    except Exception:
+        return credential_service
+    return getattr(runner, "credential_service", None) or credential_service
+
+
+def _build_a2a_inbound_auth_interceptor(
+    *,
+    app_name: str,
+    credential_service: Any,
+) -> ExecuteInterceptor:
+    async def before_agent(context: Any) -> Any:
+        call_context = getattr(context, "call_context", None)
+        state = getattr(call_context, "state", {}) if call_context else {}
+        headers = state.get("headers", {}) if isinstance(state, dict) else {}
+        if not headers:
+            return context
+
+        await save_inbound_auth(
+            request=SimpleNamespace(headers=headers, scope={}),
+            app_name=app_name,
+            user_id=_resolve_a2a_user_id(context),
+            credential_service=credential_service,
+        )
+        return context
+
+    return ExecuteInterceptor(before_agent=before_agent)
+
+
+def build_a2a_inbound_auth_executor_factory(
+    *,
+    runner: Any,
+    app_name: str,
+    credential_service: Any,
+) -> Any:
+    a2a_credential_service = _ensure_a2a_runner_credential_service(
+        runner,
+        credential_service,
+    )
+    a2a_config = A2aAgentExecutorConfig(
+        execute_interceptors=[
+            _build_a2a_inbound_auth_interceptor(
+                app_name=app_name,
+                credential_service=a2a_credential_service,
+            )
+        ]
+    )
+
+    def a2a_agent_executor_factory(runner: Any) -> A2aAgentExecutor:
+        return A2aAgentExecutor(runner=runner, config=a2a_config)
+
+    return a2a_agent_executor_factory

--- a/agentkit/apps/agent_server_app/middleware.py
+++ b/agentkit/apps/agent_server_app/middleware.py
@@ -14,12 +14,11 @@
 
 from typing import Callable
 
-from opentelemetry import trace
 from opentelemetry import context as context_api
+from opentelemetry import trace
 
 from agentkit.apps.agent_server_app.telemetry import telemetry
-
-_EXCLUDED_HEADERS = {"authorization", "token"}
+from agentkit.apps.auth.inbound import redact_inbound_auth_headers
 
 
 class AgentkitTelemetryHTTPMiddleware:
@@ -37,9 +36,7 @@ class AgentkitTelemetryHTTPMiddleware:
         span = telemetry.tracer.start_span(name="agent_server_request")
         ctx = trace.set_span_in_context(span)
         token = context_api.attach(ctx)
-        headers = {
-            k: v for k, v in headers.items() if k.lower() not in _EXCLUDED_HEADERS
-        }
+        headers = redact_inbound_auth_headers(headers)
 
         # Currently unable to retrieve user_id and session_id from headers; keep logic for future use
         user_id = headers.get("user_id")

--- a/agentkit/apps/auth/__init__.py
+++ b/agentkit/apps/auth/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from agentkit.apps.auth.inbound import (
+    AUTHORIZATION_HEADER,
+    INBOUND_AUTH_CREDENTIAL_KEY,
+    TIP_TOKEN_CREDENTIAL_KEY,
+    TIP_TOKEN_HEADER,
+    InboundAuthTokens,
+    extract_inbound_auth,
+    redact_inbound_auth_headers,
+    strip_bearer,
+)
+
+__all__ = [
+    "AUTHORIZATION_HEADER",
+    "INBOUND_AUTH_CREDENTIAL_KEY",
+    "TIP_TOKEN_CREDENTIAL_KEY",
+    "TIP_TOKEN_HEADER",
+    "InboundAuthTokens",
+    "extract_inbound_auth",
+    "redact_inbound_auth_headers",
+    "strip_bearer",
+]

--- a/agentkit/apps/auth/inbound.py
+++ b/agentkit/apps/auth/inbound.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+INBOUND_AUTH_CREDENTIAL_KEY = "inbound_auth"
+TIP_TOKEN_CREDENTIAL_KEY = "ve_tip_token"
+AUTHORIZATION_HEADER = "Authorization"
+TIP_TOKEN_HEADER = "X-Ve-TIP-Token"
+
+
+@dataclass(frozen=True, repr=False)
+class InboundAuthTokens:
+    authorization_token: str | None = None
+    authorization_scheme: str | None = None
+    tip_token: str | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self.authorization_token or self.tip_token)
+
+
+def strip_bearer(value: str) -> tuple[str, bool]:
+    value = (value or "").strip()
+    if value.lower().startswith("bearer "):
+        return value[7:].strip(), True
+    return value, False
+
+
+def _get_header(headers: Any, name: str) -> str | None:
+    expected = name.lower()
+    if hasattr(headers, "items"):
+        for key, value in headers.items():
+            if isinstance(key, bytes):
+                key_text = key.decode("latin-1")
+            else:
+                key_text = str(key)
+            if key_text.lower() == expected:
+                return value
+    return headers.get(name) or headers.get(name.lower()) or headers.get(name.upper())
+
+
+def extract_inbound_auth(
+    headers: Any,
+) -> InboundAuthTokens:
+    authorization_token = None
+    authorization_scheme = None
+    tip_token = None
+
+    auth_header = _get_header(headers, AUTHORIZATION_HEADER)
+    if auth_header:
+        token, has_bearer = strip_bearer(auth_header)
+        if token:
+            authorization_token = token
+            authorization_scheme = "bearer" if has_bearer else "header"
+
+    raw_tip_token = _get_header(headers, TIP_TOKEN_HEADER)
+    if raw_tip_token and raw_tip_token.strip():
+        tip_token = raw_tip_token.strip()
+
+    return InboundAuthTokens(
+        authorization_token=authorization_token,
+        authorization_scheme=authorization_scheme,
+        tip_token=tip_token,
+    )
+
+
+def redact_inbound_auth_headers(headers: dict[str, str]) -> dict[str, str]:
+    sensitive_names = {
+        AUTHORIZATION_HEADER.lower(),
+        "token",
+        TIP_TOKEN_HEADER.lower(),
+    }
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in sensitive_names
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ authors = [
     {name = "Guodong Li", email = "cu.eric.lee@gmail.com"},
 ]
 dependencies = [
-    "a2a-sdk>=0.3.7,<1.0.0",
+    "a2a-sdk>=0.3.15,<1.0.0",
     "fastapi>=0.117.1",
     "fastmcp>=2.12.3",
     "opentelemetry-api>=1.32.1, <=1.37.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core dependencies
-a2a-sdk>=0.3.7
+a2a-sdk>=0.3.15
 fastapi>=0.117.1
 fastmcp>=2.12.3
 opentelemetry-api>=1.32.1, <=1.37.0

--- a/tests/apps/test_agent_server_identity_integration.py
+++ b/tests/apps/test_agent_server_identity_integration.py
@@ -65,10 +65,11 @@ def _runtime_identity():
     )
 
 
-def _server_with_recording_runner():
+def _server_with_recording_runner(*, enable_auth=False):
     server = AgentkitAgentServerApp(
         agent=BaseAgent(name="identity_integration_agent"),
         identity=_runtime_identity(),
+        enable_auth=enable_auth,
     )
     calls = []
     runner = _RecordingRunner(calls)
@@ -146,6 +147,155 @@ def test_run_sse_uses_verified_subject_for_existing_session():
         )
     assert response.status_code == 200
     assert calls == [{"user_id": "alice", "identity_sub": "alice"}]
+
+
+def test_run_sse_inbound_auth_uses_body_user_id_without_identity():
+    server = AgentkitAgentServerApp(
+        agent=BaseAgent(name="run_sse_inbound_auth_agent"),
+        enable_auth=True,
+    )
+    asyncio.run(
+        server.server.session_service.create_session(
+            app_name="run_sse_inbound_auth_agent",
+            user_id="body-user",
+            session_id="sse-session",
+        )
+    )
+
+    class _Runner:
+        def run_async(self, **kwargs):
+            async def events():
+                if False:
+                    yield None
+
+            return events()
+
+    async def get_runner_async(app_name):
+        return _Runner()
+
+    server.server.get_runner_async = get_runner_async
+
+    with TestClient(server.app) as client:
+        response = client.post(
+            "/run_sse",
+            headers={
+                "user_id": "header-user",
+                "X-Ve-TIP-Token": "tip-secret",
+            },
+            json={
+                "appName": "run_sse_inbound_auth_agent",
+                "userId": "body-user",
+                "sessionId": "sse-session",
+                "newMessage": {"role": "user", "parts": [{"text": "hello"}]},
+                "streaming": True,
+            },
+        )
+
+    assert response.status_code == 200
+    credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="run_sse_inbound_auth_agent",
+            user_id="body-user",
+            credential_key="ve_tip_token",
+        )
+    )
+    assert credential.api_key == "tip-secret"
+    header_credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="run_sse_inbound_auth_agent",
+            user_id="header-user",
+            credential_key="ve_tip_token",
+        )
+    )
+    assert header_credential is None
+
+
+def test_run_sse_inbound_auth_uses_verified_subject_for_credentials():
+    server, calls = _server_with_recording_runner(enable_auth=True)
+    asyncio.run(
+        server.server.session_service.create_session(
+            app_name="identity_integration_agent",
+            user_id="alice",
+            session_id="sse-session",
+        )
+    )
+    with TestClient(server.app) as client:
+        response = client.post(
+            "/run_sse",
+            headers={
+                "Authorization": "Bearer valid.jwt.value",
+                "X-Ve-TIP-Token": "tip-secret",
+            },
+            json={
+                "appName": "identity_integration_agent",
+                "userId": "mallory",
+                "sessionId": "sse-session",
+                "newMessage": {"role": "user", "parts": [{"text": "hello"}]},
+                "streaming": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert calls == [{"user_id": "alice", "identity_sub": "alice"}]
+    credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="identity_integration_agent",
+            user_id="alice",
+            credential_key="ve_tip_token",
+        )
+    )
+    assert credential.api_key == "tip-secret"
+    auth_credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="identity_integration_agent",
+            user_id="alice",
+            credential_key="inbound_auth",
+        )
+    )
+    assert auth_credential.http.scheme == "bearer"
+    assert auth_credential.http.credentials.token == "valid.jwt.value"
+    mallory_credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="identity_integration_agent",
+            user_id="mallory",
+            credential_key="ve_tip_token",
+        )
+    )
+    assert mallory_credential is None
+
+
+def test_invoke_inbound_auth_captures_authorization_before_identity_scrub():
+    server, calls = _server_with_recording_runner(enable_auth=True)
+    with TestClient(server.app) as client:
+        response = client.post(
+            "/invoke",
+            headers={
+                "Authorization": "Bearer valid.jwt.value",
+                "user_id": "mallory",
+                "session_id": "invoke-session",
+            },
+            json={"prompt": "hello"},
+        )
+
+    assert response.status_code == 200
+    assert calls == [{"user_id": "alice", "identity_sub": "alice"}]
+    credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="identity_integration_agent",
+            user_id="alice",
+            credential_key="inbound_auth",
+        )
+    )
+    assert credential.http.scheme == "bearer"
+    assert credential.http.credentials.token == "valid.jwt.value"
+    mallory_credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="identity_integration_agent",
+            user_id="mallory",
+            credential_key="inbound_auth",
+        )
+    )
+    assert mallory_credential is None
 
 
 def test_identity_none_preserves_the_existing_unauthenticated_app_surface():

--- a/tests/apps/test_agent_server_inbound_auth.py
+++ b/tests/apps/test_agent_server_inbound_auth.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+from a2a.extensions.common import HTTP_EXTENSION_HEADER
+from google.adk.a2a.agent.interceptors.new_integration_extension import (
+    _NEW_A2A_ADK_INTEGRATION_EXTENSION,
+)
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.auth.auth_credential import (
+    AuthCredential,
+    AuthCredentialTypes,
+    HttpAuth,
+    HttpCredentials,
+)
+from google.adk.auth.credential_service.base_credential_service import (
+    BaseCredentialService,
+)
+from starlette.testclient import TestClient
+
+import agentkit.apps.auth.inbound as shared_inbound_auth
+from agentkit.apps.agent_server_app.agent_server_app import AgentkitAgentServerApp
+from agentkit.apps.agent_server_app.credential_service import (
+    AgentkitCredentialService,
+)
+from agentkit.apps.agent_server_app.inbound_auth import (
+    INBOUND_AUTH_CREDENTIAL_KEY,
+    TIP_TOKEN_CREDENTIAL_KEY,
+    extract_inbound_auth,
+    redact_inbound_auth_headers,
+    save_inbound_auth,
+    strip_bearer,
+)
+
+
+class _InvocationContext:
+    app_name = "app_1"
+    user_id = "user_1"
+
+
+class _CallbackContext:
+    _invocation_context = _InvocationContext()
+
+
+class _AuthConfig:
+    credential_key = "credential_1"
+    exchanged_auth_credential = AuthCredential(
+        auth_type=AuthCredentialTypes.API_KEY,
+        api_key="saved",
+    )
+
+
+class _FallbackAuthConfig:
+    exchanged_auth_credential = AuthCredential(
+        auth_type=AuthCredentialTypes.API_KEY,
+        api_key="fallback",
+    )
+
+    def get_credential_key(self):
+        return "fallback_key"
+
+
+class _Headers:
+    def __init__(self, data: dict[str, str]) -> None:
+        self._data = data
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
+class _Request:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = _Headers(headers)
+
+
+def test_strip_bearer_handles_bearer_and_non_bearer_values():
+    assert strip_bearer("Bearer abc") == ("abc", True)
+    assert strip_bearer(" bearer   abc  ") == ("abc", True)
+    assert strip_bearer("abc") == ("abc", False)
+    assert strip_bearer("   ") == ("", False)
+
+
+def test_agentkit_credential_service_direct_and_adk_protocol_access():
+    service = AgentkitCredentialService()
+    credential = AuthCredential(
+        auth_type=AuthCredentialTypes.HTTP,
+        http=HttpAuth(
+            scheme="bearer",
+            credentials=HttpCredentials(token="token_1"),
+        ),
+    )
+
+    assert isinstance(service, BaseCredentialService)
+    asyncio.run(
+        service.set_credential(
+            app_name="app_1",
+            user_id="user_1",
+            credential_key="credential_1",
+            credential=credential,
+        )
+    )
+    asyncio.run(
+        service.set_credential(
+            "app_1",
+            "user_1",
+            "positional_key",
+            AuthCredential(
+                auth_type=AuthCredentialTypes.API_KEY,
+                api_key="positional",
+            ),
+        )
+    )
+
+    loaded = asyncio.run(service.load_credential(_AuthConfig(), _CallbackContext()))
+    assert loaded is credential
+    positional = asyncio.run(
+        service.get_credential("app_1", "user_1", "positional_key")
+    )
+    assert positional.api_key == "positional"
+
+    asyncio.run(service.save_credential(_FallbackAuthConfig(), _CallbackContext()))
+    fallback = asyncio.run(
+        service.get_credential(
+            app_name="app_1",
+            user_id="user_1",
+            credential_key="fallback_key",
+        )
+    )
+    assert fallback.api_key == "fallback"
+
+
+def test_save_inbound_auth_stores_compatible_authorization_and_tip_credentials():
+    service = AgentkitCredentialService()
+    request = _Request(
+        {
+            "authorization": "Bearer user-token",
+            "X-Ve-TIP-Token": "tip-token",
+        }
+    )
+
+    asyncio.run(
+        save_inbound_auth(
+            request=request,
+            app_name="app_1",
+            user_id="user_1",
+            credential_service=service,
+        )
+    )
+
+    auth_credential = asyncio.run(
+        service.get_credential(
+            app_name="app_1",
+            user_id="user_1",
+            credential_key=INBOUND_AUTH_CREDENTIAL_KEY,
+        )
+    )
+    tip_credential = asyncio.run(
+        service.get_credential(
+            app_name="app_1",
+            user_id="user_1",
+            credential_key=TIP_TOKEN_CREDENTIAL_KEY,
+        )
+    )
+    assert isinstance(auth_credential, AuthCredential)
+    assert auth_credential.auth_type == AuthCredentialTypes.HTTP
+    assert auth_credential.http.scheme == "bearer"
+    assert auth_credential.http.credentials.token == "user-token"
+    assert isinstance(tip_credential, AuthCredential)
+    assert tip_credential.auth_type == AuthCredentialTypes.API_KEY
+    assert tip_credential.api_key == "tip-token"
+
+
+def test_save_inbound_auth_fails_open_without_set_credential(caplog):
+    request = _Request({"Authorization": "Bearer user-token"})
+
+    asyncio.run(
+        save_inbound_auth(
+            request=request,
+            app_name="app_1",
+            user_id="user_1",
+            credential_service=object(),
+        )
+    )
+
+    assert "cannot store inbound auth credentials" in caplog.text
+    assert "user-token" not in caplog.text
+
+
+def test_shared_inbound_auth_module_does_not_import_adk_or_veadk():
+    source = inspect.getsource(shared_inbound_auth)
+
+    assert "google.adk" not in source
+    assert "veadk" not in source
+
+
+def test_extract_inbound_auth_and_redaction_are_framework_neutral():
+    headers = {
+        "AuthoriZation": "Bearer user-token",
+        "X-Ve-Tip-Token": "tip-token",
+        "content-type": "application/json",
+    }
+
+    tokens = extract_inbound_auth(headers)
+
+    assert tokens.authorization_token == "user-token"
+    assert tokens.authorization_scheme == "bearer"
+    assert tokens.tip_token == "tip-token"
+    assert redact_inbound_auth_headers(headers) == {"content-type": "application/json"}
+
+
+@pytest.mark.parametrize("use_adk_extension", [False, True])
+def test_a2a_request_saves_authorization_and_tip_headers(use_adk_extension):
+    server = AgentkitAgentServerApp(
+        agent=BaseAgent(name="a2a_inbound_auth_agent"),
+        enable_auth=True,
+    )
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "kind": "message",
+                "messageId": "msg-1",
+                "role": "user",
+                "contextId": "ctx-1",
+                "parts": [{"kind": "text", "text": "hello"}],
+            }
+        },
+    }
+    headers = {
+        "Authorization": "Bearer user-token",
+        "X-Ve-TIP-Token": "tip-token",
+    }
+    if use_adk_extension:
+        headers[HTTP_EXTENSION_HEADER] = _NEW_A2A_ADK_INTEGRATION_EXTENSION
+
+    with TestClient(server.app) as client:
+        response = client.post(
+            "/",
+            json=payload,
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    auth_credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="a2a_inbound_auth_agent",
+            user_id="A2A_USER_ctx-1",
+            credential_key=INBOUND_AUTH_CREDENTIAL_KEY,
+        )
+    )
+    tip_credential = asyncio.run(
+        server.server.credential_service.get_credential(
+            app_name="a2a_inbound_auth_agent",
+            user_id="A2A_USER_ctx-1",
+            credential_key=TIP_TOKEN_CREDENTIAL_KEY,
+        )
+    )
+    assert auth_credential.http.scheme == "bearer"
+    assert auth_credential.http.credentials.token == "user-token"
+    assert tip_credential.api_key == "tip-token"

--- a/tests/apps/test_agent_server_invoke.py
+++ b/tests/apps/test_agent_server_invoke.py
@@ -50,7 +50,6 @@ from google.genai import types as genai_types
 
 import agentkit.apps.agent_server_app.agent_server_app as mod
 
-
 # ---------------------------------------------------------------------------
 # Extract the real _invoke_compat code object from __init__ and rebuild it.
 # ---------------------------------------------------------------------------
@@ -216,6 +215,14 @@ class _FakeSessionService:
         return object()
 
 
+class _FakeCredentialService:
+    def __init__(self) -> None:
+        self.set_calls: list[dict] = []
+
+    async def set_credential(self, **kwargs):
+        self.set_calls.append(kwargs)
+
+
 class _FakeAgentLoader:
     def __init__(self, agents) -> None:
         self._agents = list(agents)
@@ -227,9 +234,12 @@ class _FakeAgentLoader:
 
 
 class _FakeServer:
-    def __init__(self, agent_loader, session_service, runner) -> None:
+    def __init__(
+        self, agent_loader, session_service, runner, credential_service
+    ) -> None:
         self.agent_loader = agent_loader
         self.session_service = session_service
+        self.credential_service = credential_service
         self._runner = runner
         self.get_runner_calls: list = []
 
@@ -243,6 +253,7 @@ class _FakeSelf:
 
     def __init__(self, server) -> None:
         self.server = server
+        self._enable_auth_enabled = False
 
 
 # Records of telemetry calls so tests can assert wiring without touching a
@@ -282,12 +293,8 @@ def _isolate_telemetry_and_span(monkeypatch):
             {"path": path, "func_result": func_result, "exception": exception}
         )
 
-    monkeypatch.setattr(
-        mod.telemetry, "trace_agent_server", _fake_trace_agent_server
-    )
-    monkeypatch.setattr(
-        mod.telemetry, "trace_agent_server_finish", _fake_trace_finish
-    )
+    monkeypatch.setattr(mod.telemetry, "trace_agent_server", _fake_trace_agent_server)
+    monkeypatch.setattr(mod.telemetry, "trace_agent_server_finish", _fake_trace_finish)
     monkeypatch.setattr(mod.trace, "get_current_span", lambda: _FakeSpan())
     yield
 
@@ -303,12 +310,15 @@ def _build(
     existing_session=None,
     events=None,
     run_exc: Exception | None = None,
+    enable_auth: bool = False,
 ):
     runner = _FakeRunner(events if events is not None else [], raise_exc=run_exc)
     session_service = _FakeSessionService(existing_session=existing_session)
     agent_loader = _FakeAgentLoader(agents)
-    server = _FakeServer(agent_loader, session_service, runner)
+    credential_service = _FakeCredentialService()
+    server = _FakeServer(agent_loader, session_service, runner, credential_service)
     fake_self = _FakeSelf(server)
+    fake_self._enable_auth_enabled = enable_auth
     invoke = _bind_invoke_compat(fake_self)
     return invoke, fake_self, server, session_service, runner
 
@@ -365,6 +375,7 @@ def test_invoke_entry_traces_request_with_authorization_and_token_redacted():
         headers={
             "Authorization": "Bearer secret",
             "Token": "abc",
+            "X-Ve-TIP-Token": "tip-secret",
             "user_id": "u1",
             "content-type": "application/json",
         },
@@ -379,8 +390,37 @@ def test_invoke_entry_traces_request_with_authorization_and_token_redacted():
     # Authorization/token (case-insensitively) are stripped from telemetry.
     assert "Authorization" not in entry["headers"]
     assert "Token" not in entry["headers"]
+    assert "X-Ve-TIP-Token" not in entry["headers"]
     assert entry["headers"]["user_id"] == "u1"
     assert entry["headers"]["content-type"] == "application/json"
+
+
+def test_invoke_saves_inbound_auth_for_selected_app_and_effective_user():
+    invoke, _self, server, _ss, _runner = _build(
+        agents=("my_app",), existing_session=object(), enable_auth=True
+    )
+    request = _FakeRequest(
+        headers={
+            "Authorization": "Bearer user-secret",
+            "X-Ve-TIP-Token": "tip-secret",
+            "user_id": "alice",
+        },
+        json_payload={"prompt": "hi"},
+    )
+
+    asyncio.run(invoke(request))
+
+    assert len(server.credential_service.set_calls) == 2
+    auth_call, tip_call = server.credential_service.set_calls
+    assert auth_call["app_name"] == "my_app"
+    assert auth_call["user_id"] == "alice"
+    assert auth_call["credential_key"] == "inbound_auth"
+    assert auth_call["credential"].http.scheme == "bearer"
+    assert auth_call["credential"].http.credentials.token == "user-secret"
+    assert tip_call["app_name"] == "my_app"
+    assert tip_call["user_id"] == "alice"
+    assert tip_call["credential_key"] == "ve_tip_token"
+    assert tip_call["credential"].api_key == "tip-secret"
 
 
 # ===========================================================================

--- a/tests/apps/test_agent_server_loader.py
+++ b/tests/apps/test_agent_server_loader.py
@@ -278,18 +278,30 @@ def test_create_a2a_runner_preserves_veadk_runner_for_veadk_agent_with_session_s
 
     root_agent = BaseAgent(name="legacy_session_agent")
     session_service = InMemorySessionService()
+    memory_service = object()
+    artifact_service = object()
+    credential_service = object()
 
     runner = _create_a2a_runner(
         root_agent=root_agent,
         short_term_memory=session_service,
         session_service=session_service,
-        memory_service=object(),
-        artifact_service=object(),
-        credential_service=object(),
+        memory_service=memory_service,
+        artifact_service=artifact_service,
+        credential_service=credential_service,
     )
 
     assert isinstance(runner, _FakeVeadkRunner)
-    assert calls == [{"agent": root_agent, "short_term_memory": None}]
+    assert calls == [
+        {
+            "agent": root_agent,
+            "short_term_memory": None,
+            "app_name": "legacy_session_agent",
+            "session_service": session_service,
+            "memory_service": memory_service,
+            "credential_service": credential_service,
+        }
+    ]
 
 
 def test_create_a2a_runner_uses_adk_runner_for_plain_adk_agent_with_session_service(
@@ -353,18 +365,30 @@ def test_create_a2a_runner_preserves_veadk_runner_for_veadk_agent_without_memory
 
     root_agent = BaseAgent(name="veadk_agent_without_memory")
     session_service = InMemorySessionService()
+    memory_service = object()
+    artifact_service = object()
+    credential_service = object()
 
     runner = _create_a2a_runner(
         root_agent=root_agent,
         short_term_memory=None,
         session_service=session_service,
-        memory_service=object(),
-        artifact_service=object(),
-        credential_service=object(),
+        memory_service=memory_service,
+        artifact_service=artifact_service,
+        credential_service=credential_service,
     )
 
     assert isinstance(runner, _FakeVeadkRunner)
-    assert calls == [{"agent": root_agent, "short_term_memory": None}]
+    assert calls == [
+        {
+            "agent": root_agent,
+            "short_term_memory": None,
+            "app_name": "veadk_agent_without_memory",
+            "session_service": session_service,
+            "memory_service": memory_service,
+            "credential_service": credential_service,
+        }
+    ]
 
 
 def test_create_a2a_runner_uses_adk_runner_for_new_default_adk_agent(monkeypatch):

--- a/tests/apps/test_agent_server_middleware.py
+++ b/tests/apps/test_agent_server_middleware.py
@@ -103,7 +103,9 @@ def test_http_scope_starts_span_and_calls_trace_agent_server(fake_telemetry):
 
     asyncio.run(mw(scope, _noop_receive, send))
 
-    fake_telemetry.tracer.start_span.assert_called_once_with(name="agent_server_request")
+    fake_telemetry.tracer.start_span.assert_called_once_with(
+        name="agent_server_request"
+    )
     fake_telemetry.trace_agent_server.assert_called_once()
     kwargs = fake_telemetry.trace_agent_server.call_args.kwargs
     assert kwargs["func_name"] == "GET /hello"
@@ -151,6 +153,7 @@ def test_header_exclusion_is_case_insensitive(fake_telemetry):
         "headers": [
             (b"Authorization", b"Bearer x"),
             (b"TOKEN", b"y"),
+            (b"X-Ve-Tip-Token", b"tip"),
             (b"X-Custom", b"keep"),
         ],
     }
@@ -162,10 +165,13 @@ def test_header_exclusion_is_case_insensitive(fake_telemetry):
     # Keys are preserved verbatim; only the lowercased comparison decides exclusion.
     assert "Authorization" not in headers
     assert "TOKEN" not in headers
+    assert "X-Ve-Tip-Token" not in headers
     assert headers == {"X-Custom": "keep"}
 
 
-def test_finish_is_called_only_on_final_body_message_not_on_response_start(fake_telemetry):
+def test_finish_is_called_only_on_final_body_message_not_on_response_start(
+    fake_telemetry,
+):
     async def _app(scope, receive, send):
         # A realistic send sequence: start, then a final body chunk.
         await send({"type": "http.response.start", "status": 200, "headers": []})
@@ -227,7 +233,9 @@ def test_body_message_without_more_body_key_defaults_to_finished(fake_telemetry)
     )
 
 
-def test_wrapped_app_exception_records_finish_with_exception_and_reraises(fake_telemetry):
+def test_wrapped_app_exception_records_finish_with_exception_and_reraises(
+    fake_telemetry,
+):
     boom = RuntimeError("downstream failure")
 
     async def _app(scope, receive, send):


### PR DESCRIPTION
Add opt-in inbound auth capture for Agent Server.

When enable_auth is set, AgentServer now captures inbound Authorization and
X-Ve-TIP-Token headers, converts them into ADK-compatible credentials, and stores
them by app/user credential key for /invoke, /run_sse, and A2A requests.

This also adds an AgentKit credential service with direct write support, shared
framework-neutral inbound auth helpers, telemetry redaction for TIP tokens, and
coverage for identity-aware request handling so credentials are stored under the
effective verified user.
Validation:
- Ran targeted Agent Server inbound auth tests with a2a-sdk==0.3.15.
- 70 passed.