### PR TITLE
fix(test): support tomli on Python 3.10

### DIFF
--- a/packages/agentkit-harness-sidecar-integration/tests/harness_sidecar/test_sidecar_config.py
+++ b/packages/agentkit-harness-sidecar-integration/tests/harness_sidecar/test_sidecar_config.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from secrets import token_urlsafe
 
 import pytest
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
 
 from agentkit.extensions.harness_sidecar.deploy import to_runtime_env
 from agentkit.extensions.harness_sidecar.runtime_components import (


### PR DESCRIPTION
## Summary

Make the Harness Sidecar config tests use the standard-library `tomllib` on Python 3.11+ and fall back to the SDKs already-declared `tomli` dependency on Python 3.10.

This changes test compatibility only. It does not change runtime dependencies, SDK behavior, wheel contents, tags, or publication state.

## Failure fixed

The `v0.8.2` Release to PyPI run failed during Python 3.10 test collection with `ModuleNotFoundError: No module named tomllib`; Python 3.12 passed.

## Verification

Target config tests passed: 39/39.

The complete Harness Sidecar release subset passed on Python 3.12: 85/85.

Ruff check, Ruff format check, and `git diff --check` passed. The PR matrix is expected to provide the exact Python 3.10 proof.

## Release note

The existing failed `v0.8.2` tag is not changed by this PR. After merge, maintainers must explicitly choose whether to move that unpublished failed tag or release SDK 0.8.3.