### PR TITLE
fix(config): scope global config cache by path

### DIFF
--- a/agentkit/utils/global_config_io.py
+++ b/agentkit/utils/global_config_io.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Optional, Tuple
 
 
-_cache: Tuple[Optional[float], dict] = (None, {})
+_cache: Tuple[Optional[Path], Optional[float], dict] = (None, None, {})
 
 
 def get_default_global_config_path() -> Path:
@@ -38,13 +38,13 @@ def read_global_config_dict(
         mtime = path.stat().st_mtime
     except FileNotFoundError:
         if force_reload:
-            _cache = (None, {})
+            _cache = (None, None, {})
         return {}
     except Exception:
         return {}
 
-    cached_mtime, cached_data = _cache
-    if not force_reload and cached_mtime == mtime:
+    cached_path, cached_mtime, cached_data = _cache
+    if not force_reload and cached_path == path and cached_mtime == mtime:
         return cached_data
 
     try:
@@ -53,7 +53,7 @@ def read_global_config_dict(
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         parsed = data if isinstance(data, dict) else {}
-        _cache = (mtime, parsed)
+        _cache = (path, mtime, parsed)
         return parsed
     except Exception:
         return {}
@@ -86,7 +86,7 @@ def write_global_config_dict(
 
     try:
         mtime = path.stat().st_mtime
-        _cache = (mtime, data)
+        _cache = (path, mtime, data)
     except Exception:
         pass
 

--- a/tests/platform/test_global_config_compat.py
+++ b/tests/platform/test_global_config_compat.py
@@ -12,8 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 from agentkit.toolkit.config.global_config import GlobalConfig
+from agentkit.utils.global_config_io import read_global_config_dict
+
+
+def test_global_config_cache_is_scoped_to_path(tmp_path):
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    first.write_text("region: cn-beijing\n", encoding="utf-8")
+    second.write_text("region: ap-southeast-1\n", encoding="utf-8")
+    shared_mtime_ns = 1_700_000_000_000_000_000
+    os.utime(first, ns=(shared_mtime_ns, shared_mtime_ns))
+    os.utime(second, ns=(shared_mtime_ns, shared_mtime_ns))
+
+    assert read_global_config_dict(first, force_reload=True)["region"] == "cn-beijing"
+    assert read_global_config_dict(second)["region"] == "ap-southeast-1"
 
 
 class TestGlobalConfigCompatibility:


### PR DESCRIPTION
## Summary

Scope the global configuration cache by both file path and modification time.

`read_global_config_dict()` previously cached only `(mtime, data)`. If a process read two different configuration files with the same modification timestamp, the second read returned data from the first file. This can happen in tests, generated configurations, copied files, or filesystems with coarse timestamp resolution.

This change stores `(path, mtime, data)` and requires both the path and timestamp to match before returning cached data. Writes update the same cache tuple.

The regression test creates two files with distinct regions, forces them to share an identical nanosecond timestamp, and verifies that reading the second path returns its own content.

## Validation

- `pytest tests/platform/test_global_config_compat.py -q` — 5 passed
- Ruff 0.11.12 check on both changed files
- Ruff 0.11.12 format check on both changed files
- `git diff --check`

## AI assistance

This change was developed with AI assistance. I reviewed the cache lifecycle, reproduced the old failure deterministically, and ran the checks above.
