### PR TITLE
fix(auth): make admin sso-setup cloud-provider aware (BytePlus)

### DIFF
--- a/agentkit/auth/_openapi.py
+++ b/agentkit/auth/_openapi.py
@@ -12,18 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal signed Volcengine OpenAPI client for the auth ADMIN commands.
+"""Minimal signed OpenAPI client for the auth ADMIN commands.
 
 Stdlib-only SigV4 (reusing :mod:`agentkit.auth._sigv4`) so the admin path that
 provisions the UserPool client / IAM OIDC provider / STS role carries no
 third-party dependency. Used only by ``agentkit auth admin`` — the end-user login
 path never touches it. A mandatory ``GetCallerIdentity`` guard runs before any write.
+
+Credentials and the OpenAPI gateway host are resolved through the SDK's unified,
+Cloud-Provider-aware chain (:class:`agentkit.platform.configuration.VolcConfiguration`),
+so ``CLOUD_PROVIDER=byteplus`` uses ``BYTEPLUS_ACCESS_KEY`` / ``BYTEPLUS_SECRET_KEY``
+and ``open.byteplusapi.com`` instead of the Volcengine equivalents.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -31,8 +35,9 @@ import urllib.request
 from agentkit.auth._sigv4 import sign_headers
 from agentkit.auth.errors import AuthError
 from agentkit.auth.ssl_trust import harden_default_ssl_context
+from agentkit.platform.configuration import VolcConfiguration
+from agentkit.platform.provider import CloudProvider
 
-_HOST = "open.volcengineapi.com"
 # Services whose OpenAPI reads parameters from the query string, not a JSON body.
 _QUERY_PARAM_SERVICES = {"iam"}
 
@@ -85,21 +90,51 @@ class OpenApiClient:
         access_key: str | None = None,
         secret_key: str | None = None,
         session_token: str | None = None,
-        region: str = "cn-beijing",
+        region: str | None = None,
         expect_account: str | None = None,
         harden_ssl: bool = True,
     ) -> None:
         if harden_ssl:
             harden_default_ssl_context()
-        self.ak = access_key or os.getenv("VOLCENGINE_ACCESS_KEY") or os.getenv("VOLC_ACCESSKEY")
-        self.sk = secret_key or os.getenv("VOLCENGINE_SECRET_KEY") or os.getenv("VOLC_SECRETKEY")
-        self.token = session_token or os.getenv("VOLCENGINE_SESSION_TOKEN")
-        if not (self.ak and self.sk):
+        # Credentials/region come from the SDK's unified provider-aware chain
+        # (CLOUD_PROVIDER=volcengine|byteplus), so the admin path accepts the same
+        # sources as the runtime clients: BYTEPLUS_* on BytePlus, VOLCENGINE_* /
+        # VOLC_* on Volcengine, plus ~/.agentkit/config.yaml.
+        cfg = VolcConfiguration(
+            region=region,
+            access_key=access_key,
+            secret_key=secret_key,
+            session_token=session_token,
+        )
+        self.provider = cfg.provider
+        if self.provider == CloudProvider.BYTEPLUS:
+            provider_label = "BytePlus"
+            self.cred_env_hint = "BYTEPLUS_ACCESS_KEY / BYTEPLUS_SECRET_KEY"
+        else:
+            provider_label = "Volcengine"
+            self.cred_env_hint = "VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY"
+        try:
+            creds = cfg.get_service_credentials("iam")
+        except ValueError as exc:
             raise AuthError(
-                "admin provisioning needs Volcengine credentials.",
-                hint="export VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY for the account that owns the UserPool.",
+                f"admin provisioning needs {provider_label} credentials.",
+                hint=f"export {self.cred_env_hint} for the account that owns the UserPool.",
+            ) from exc
+        if creds.source == "sso-sts":
+            # `agentkit login` stores the END-USER sandbox STS role; provisioning
+            # UserPool/IAM resources needs the account's long-lived admin AK/SK.
+            raise AuthError(
+                "admin provisioning cannot use the SSO login session (it carries the "
+                "end-user sandbox role, not account admin rights).",
+                hint=f"export {self.cred_env_hint} for the account that owns the UserPool.",
             )
-        self.region = region
+        self.ak = creds.access_key
+        self.sk = creds.secret_key
+        self.token = session_token or creds.session_token
+        # Every admin control-plane call signs against the provider's top OpenAPI
+        # gateway — the same host that serves the provider's IAM service.
+        self._host = cfg.get_service_endpoint("iam").host
+        self.region = cfg.region
         ident = self.call("sts", "GetCallerIdentity", "2018-01-01", {})
         self.account_id = str(ident.get("AccountId") or "")
         if expect_account and self.account_id != expect_account:
@@ -121,11 +156,11 @@ class OpenApiClient:
             query = {"Action": action, "Version": version}
             payload = json.dumps(body).encode()
         headers = sign_headers(
-            "POST", _HOST, query, payload,
+            "POST", self._host, query, payload,
             access_key=self.ak, secret_key=self.sk, service=service, region=self.region,
             session_token=self.token,
         )
-        url = f"https://{_HOST}/?{urllib.parse.urlencode(query)}"
+        url = f"https://{self._host}/?{urllib.parse.urlencode(query)}"
         req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
         try:
             raw = urllib.request.urlopen(req, timeout=30).read()
@@ -147,11 +182,11 @@ class OpenApiClient:
             else:
                 query[k] = str(v)
         headers = sign_headers(
-            "GET", _HOST, query, b"",
+            "GET", self._host, query, b"",
             access_key=self.ak, secret_key=self.sk, service=service, region=self.region,
             session_token=self.token,
         )
-        url = f"https://{_HOST}/?{urllib.parse.urlencode(query)}"
+        url = f"https://{self._host}/?{urllib.parse.urlencode(query)}"
         req = urllib.request.Request(url, headers=headers, method="GET")
         try:
             raw = urllib.request.urlopen(req, timeout=30).read()

--- a/agentkit/auth/admin.py
+++ b/agentkit/auth/admin.py
@@ -86,7 +86,21 @@ class CliAccessCoords:
         }
 
 
+def tos_public_host(region: str) -> str:
+    """Provider-aware public host of the TOS static-site endpoint for *region*.
+
+    ``tos-<region>.volces.com`` on Volcengine, ``tos-<region>.bytepluses.com`` on
+    BytePlus — resolved from the platform service registry, not hardcoded here.
+    """
+    from agentkit.platform.configuration import VolcConfiguration
+
+    return VolcConfiguration(region=region).get_service_endpoint("tos").host
+
+
 def _issuer(user_pool_uid: str, region: str) -> str:
+    # NOTE: this is the Volcengine UserPool issuer domain. Whether/where the
+    # UserPool (id) service is exposed on BytePlus is a platform question; the
+    # CreateUserPool call itself fails first on accounts without the service.
     return f"https://userpool-{user_pool_uid}.userpool.auth.id.{region}.volces.com"
 
 
@@ -349,7 +363,7 @@ def sso_setup(
     if custom_domain:
         manual.append(
             f"把自定义域名指向该 bucket:CNAME {custom_domain} -> "
-            f"{bucket}.tos-{region}.volces.com,并配置 https 证书(TOS/CDN)。"
+            f"{bucket}.{tos_public_host(region)},并配置 https 证书(TOS/CDN)。"
         )
     return SsoSetupResult(login_address=url, coords=coords, manual_steps=manual)
 
@@ -371,18 +385,28 @@ def publish_discovery(
     The returned URL is what the end user types: ``agentkit login <url>``.
     """
     try:
-        import os as _os
-
         import tos  # type: ignore
     except Exception as exc:  # pragma: no cover - optional dep
         raise AuthError(
             "publishing needs the `tos` package (`pip install tos`), or host the "
             "discovery doc yourself.",
         ) from exc
-    ak = access_key or _os.getenv("VOLCENGINE_ACCESS_KEY")
-    sk = secret_key or _os.getenv("VOLCENGINE_SECRET_KEY")
-    token = session_token or _os.getenv("VOLCENGINE_SESSION_TOKEN")
-    endpoint = f"tos-{coords.region}.volces.com"
+    from agentkit.platform.configuration import VolcConfiguration
+
+    cfg = VolcConfiguration(
+        region=coords.region, access_key=access_key, secret_key=secret_key,
+        session_token=session_token,
+    )
+    try:
+        creds = cfg.get_service_credentials("tos")
+    except ValueError as exc:
+        raise AuthError(
+            "publishing the discovery doc needs cloud credentials for TOS.",
+            hint=str(exc).split("\n")[0],
+        ) from exc
+    ak, sk = creds.access_key, creds.secret_key
+    token = session_token or creds.session_token
+    endpoint = cfg.get_service_endpoint("tos").host
     client = tos.TosClientV2(ak, sk, endpoint, coords.region, security_token=token)
     try:
         client.create_bucket(bucket, acl=tos.ACLType.ACL_Public_Read)
@@ -453,7 +477,7 @@ def preflight(api: OpenApiClient, *, credential_hosting: bool = True) -> list[di
             checks.append({"name": name, "status": "warn", "detail": str(exc)[:80], "fix": fix})
 
     probe("caller identity (STS)", lambda: f"account {api.account_id}",
-          "export a valid admin VOLCENGINE_ACCESS_KEY / _SECRET_KEY")
+          f"export a valid admin {api.cred_env_hint}")
     def _pools():
         r = api.call("id", "ListUserPools", "2025-10-30", {"PageNumber": 1, "PageSize": 1})
         return f"reachable ({r.get('TotalCount') or r.get('Total') or len(r.get('Items') or r.get('Data') or [])}+ pools)"

--- a/agentkit/auth/admin.py
+++ b/agentkit/auth/admin.py
@@ -157,16 +157,47 @@ def identity_console_url(region: str = "cn-beijing", *, user_pool_uid: str | Non
 
 
 def create_user_pool(name: str, *, region: str = "cn-beijing", api: OpenApiClient | None = None) -> tuple[str, str]:
-    """Create a UserPool; return ``(uid, issuer)``."""
+    """Create (or, on a re-run, reuse) the UserPool named ``name``; return ``(uid, issuer)``.
+
+    A same-name pool left by an earlier run is reused instead of failing with
+    ``Duplicated`` — sso-setup must stay idempotent to re-run.
+    """
     api = api or OpenApiClient(region=region)
-    res = api.call("id", "CreateUserPool", "2025-10-30", {
-        "Name": name, "Description": "AgentKit CLI login pool",
-        "PasswordSignInEnabled": True, "SelfSignUpEnabled": False,
-    })
+    try:
+        res = api.call("id", "CreateUserPool", "2025-10-30", {
+            "Name": name, "Description": "AgentKit CLI login pool",
+            "PasswordSignInEnabled": True, "SelfSignUpEnabled": False,
+        })
+    except ApiError as exc:
+        if not any(k in exc.code for k in ("Duplicat", "Exist", "Conflict")):
+            raise
+        existing = _find_pool_by_name(api, name)
+        if not existing:
+            raise
+        return existing, resolve_issuer(api, existing, region)
     uid = str(res.get("Uid") or res.get("uid") or "")
     if not uid:
         raise AuthError(f"CreateUserPool returned no uid: {json.dumps(res)[:200]}")
     return uid, resolve_issuer(api, uid, region)
+
+
+def _find_pool_by_name(api: OpenApiClient, name: str) -> str | None:
+    """Uid of the pool named ``name``, or None. Raises if the name is ambiguous."""
+    matches: list[str] = []
+    page = 1
+    while page <= 10:  # 500 pools is far beyond any real account
+        r = api.call("id", "ListUserPools", "2025-10-30", {"PageNumber": page, "PageSize": 50})
+        data = r.get("Data") or []
+        matches += [str(p.get("Uid")) for p in data if p.get("Name") == name and p.get("Uid")]
+        if len(data) < 50:
+            break
+        page += 1
+    if len(matches) > 1:
+        raise AuthError(
+            f"{len(matches)} user pools are named {name!r}; pass the intended one "
+            "explicitly with --user-pool <uid>."
+        )
+    return matches[0] if matches else None
 
 
 def _ensure_cli_client(api: OpenApiClient, user_pool_uid: str, client_name: str = CLI_CLIENT_NAME) -> str:
@@ -239,18 +270,33 @@ def _ensure_role(
 ) -> None:
     trust = {"Statement": [{"Effect": "Allow", "Principal": {"Federated": [provider_trn]},
                             "Action": ["sts:AssumeRoleWithOIDC"]}]}
+    # Probe existence BEFORE CreateRole: an account at its RolesPerAccount quota
+    # returns LimitExceeded before the duplicate-name check, which would wrongly
+    # kill re-runs (and --role-name reuse) even though the role is already there.
+    role_exists = True
     try:
-        api.call("iam", "CreateRole", "2018-01-01", {
-            "RoleName": role_name, "DisplayName": role_name,
-            "TrustPolicyDocument": json.dumps(trust), "MaxSessionDuration": 3600,
-            "Description": "STS role for AgentKit CLI (UserPool federated)",
-        })
+        api.call("iam", "GetRole", "2018-01-01", {"RoleName": role_name})
     except ApiError as exc:
-        if "Exist" not in exc.code and "Conflict" not in exc.code:
+        if not any(k in exc.code for k in ("NotExist", "NoSuchEntity", "NotFound")):
             raise
+        role_exists = False
+    if role_exists:
         api.call("iam", "UpdateRole", "2018-01-01",
                  {"RoleName": role_name, "TrustPolicyDocument": json.dumps(trust),
                   "MaxSessionDuration": 3600})
+    else:
+        try:
+            api.call("iam", "CreateRole", "2018-01-01", {
+                "RoleName": role_name, "DisplayName": role_name,
+                "TrustPolicyDocument": json.dumps(trust), "MaxSessionDuration": 3600,
+                "Description": "STS role for AgentKit CLI (UserPool federated)",
+            })
+        except ApiError as exc:
+            if "Exist" not in exc.code and "Conflict" not in exc.code:
+                raise
+            api.call("iam", "UpdateRole", "2018-01-01",
+                     {"RoleName": role_name, "TrustPolicyDocument": json.dumps(trust),
+                      "MaxSessionDuration": 3600})
     doc = {"Statement": [{"Effect": "Allow", "Action": list(ROLE_ACTIONS), "Resource": ["*"]}]}
     api.call_ok("iam", "CreatePolicy", "2018-01-01",
                 {"PolicyName": policy_name, "PolicyDocument": json.dumps(doc),

--- a/agentkit/auth/admin.py
+++ b/agentkit/auth/admin.py
@@ -98,10 +98,37 @@ def tos_public_host(region: str) -> str:
 
 
 def _issuer(user_pool_uid: str, region: str) -> str:
-    # NOTE: this is the Volcengine UserPool issuer domain. Whether/where the
-    # UserPool (id) service is exposed on BytePlus is a platform question; the
-    # CreateUserPool call itself fails first on accounts without the service.
+    # Volcengine UserPool issuer domain template — LAST-RESORT fallback only.
+    # The real issuer is read from the platform (GetUserPool.IssuerUrl), which is
+    # provider-correct by construction; this template is wrong on BytePlus.
     return f"https://userpool-{user_pool_uid}.userpool.auth.id.{region}.volces.com"
+
+
+def _pool_info(api: OpenApiClient, user_pool_uid: str) -> dict:
+    """Best-effort GetUserPool detail; {} when the call fails."""
+    try:
+        return api.call("id", "GetUserPool", "2025-10-30", {"UserPoolUid": user_pool_uid})
+    except (ApiError, AuthError):
+        return {}
+
+
+def resolve_issuer(api: OpenApiClient, user_pool_uid: str, region: str) -> str:
+    """The pool's real issuer URL, read from the platform.
+
+    ``GetUserPool`` returns ``IssuerUrl`` (and ``Domain`` / ``CustomDomain``), so the
+    issuer is whatever domain the current cloud provider actually serves — no
+    hardcoded domain. IAM's ``CreateOIDCProvider`` validates the issuer's OIDC
+    discovery endpoint, so a template-guessed domain fails on BytePlus.
+    Falls back to the Volcengine template only if the platform returns nothing.
+    """
+    info = _pool_info(api, user_pool_uid)
+    issuer = str(info.get("IssuerUrl") or "").rstrip("/")
+    if issuer:
+        return issuer
+    domain = str(info.get("CustomDomain") or info.get("Domain") or "").strip()
+    if domain:
+        return f"https://{domain}"
+    return _issuer(user_pool_uid, region)
 
 
 def identity_console_url(region: str = "cn-beijing", *, user_pool_uid: str | None = None) -> str:
@@ -123,7 +150,7 @@ def create_user_pool(name: str, *, region: str = "cn-beijing", api: OpenApiClien
     uid = str(res.get("Uid") or res.get("uid") or "")
     if not uid:
         raise AuthError(f"CreateUserPool returned no uid: {json.dumps(res)[:200]}")
-    return uid, _issuer(uid, region)
+    return uid, resolve_issuer(api, uid, region)
 
 
 def _ensure_cli_client(api: OpenApiClient, user_pool_uid: str, client_name: str = CLI_CLIENT_NAME) -> str:
@@ -247,7 +274,7 @@ def provision_cli_access(
     """
     api = api or OpenApiClient(region=region, expect_account=account_id)
     acct = account_id or api.account_id
-    issuer = _issuer(user_pool_uid, region)
+    issuer = resolve_issuer(api, user_pool_uid, region)
     client_id = _ensure_cli_client(api, user_pool_uid, client_name)
     if not client_id:
         raise AuthError("could not create or find the public CLI client")
@@ -291,7 +318,12 @@ def ensure_federation(
     preset = _IDP_PRESETS.get(idp)
     if not preset:
         raise AuthError(f"unknown idp {idp!r}; supported: {', '.join(_IDP_PRESETS)}")
-    callback = f"{_issuer(user_pool_uid, region)}/login/generic_oauth/callback"
+    # The platform publishes the pool's exact OAuth callback; derive it from the
+    # resolved issuer only when the field is absent.
+    info = _pool_info(api, user_pool_uid)
+    callback = str(info.get("OauthLoginCallbackUrl") or "") or (
+        f"{resolve_issuer(api, user_pool_uid, region)}/login/generic_oauth/callback"
+    )
     lst = api.call("id", "ListIdentityProviders", "2025-10-30",
                    {"UserPoolUID": user_pool_uid, "PageNumber": 1, "PageSize": 50})
     for it in (lst.get("Data") or lst.get("data") or []):

--- a/agentkit/auth/admin.py
+++ b/agentkit/auth/admin.py
@@ -73,9 +73,10 @@ class CliAccessCoords:
     client_id: str
     role_trn: str
     provider_trn: str
+    sts_host: str | None = None  # provider STS endpoint (None = Volcengine default)
 
     def discovery_doc(self) -> dict:
-        return {
+        doc = {
             "issuer": self.issuer,
             "client_id": self.client_id,
             "role_trn": self.role_trn,
@@ -84,6 +85,9 @@ class CliAccessCoords:
             "transport": "sts",
             "scope": "openid profile email offline_access",
         }
+        if self.sts_host:
+            doc["sts_host"] = self.sts_host
+        return doc
 
 
 def tos_public_host(region: str) -> str:
@@ -95,6 +99,18 @@ def tos_public_host(region: str) -> str:
     from agentkit.platform.configuration import VolcConfiguration
 
     return VolcConfiguration(region=region).get_service_endpoint("tos").host
+
+
+def sts_public_host(region: str) -> str:
+    """Provider-aware STS endpoint for *region*, from the platform service registry.
+
+    Published in the discovery doc as ``sts_host`` so the end-user login exchanges
+    the id_token against the pool's own cloud (BytePlus pools must not call the
+    Volcengine STS).
+    """
+    from agentkit.platform.configuration import VolcConfiguration
+
+    return VolcConfiguration(region=region).get_service_endpoint("sts").host
 
 
 def _issuer(user_pool_uid: str, region: str) -> str:
@@ -284,6 +300,7 @@ def provision_cli_access(
     return CliAccessCoords(
         account_id=acct, region=region, user_pool_uid=user_pool_uid, issuer=issuer,
         client_id=client_id, role_trn=f"trn:iam::{acct}:role/{role_name}", provider_trn=provider_trn,
+        sts_host=sts_public_host(region),
     )
 
 

--- a/agentkit/auth/profile.py
+++ b/agentkit/auth/profile.py
@@ -35,7 +35,7 @@ from agentkit.auth.errors import AuthError
 
 _PROFILE_FIELDS = {
     "name", "issuer", "client_id", "role_trn", "provider_trn",
-    "region", "scope", "transport", "address",
+    "region", "scope", "transport", "address", "sts_host",
 }
 
 
@@ -52,6 +52,7 @@ class AuthProfile:
     scope: str = "openid profile email offline_access"
     transport: str = "sts"  # "sts" (sandbox) | reserved for future transports
     address: str | None = None  # the login address this profile was resolved from
+    sts_host: str | None = None  # provider STS endpoint from the discovery doc (None = Volcengine default)
 
     def validate(self) -> "AuthProfile":
         missing = [k for k in ("name", "issuer", "client_id", "role_trn") if not getattr(self, k)]

--- a/agentkit/auth/resolve.py
+++ b/agentkit/auth/resolve.py
@@ -55,6 +55,7 @@ _ALIASES = {
     "region": ("region",),
     "transport": ("transport",),
     "scope": ("scope",),
+    "sts_host": ("sts_host", "stsHost"),
 }
 
 
@@ -175,7 +176,7 @@ def resolve_profile(address: str, *, timeout: float = _TIMEOUT, harden_ssl: bool
     return AuthProfile(
         name=name, issuer=str(issuer), client_id=str(client_id), role_trn=str(role_trn),
         provider_trn=provider_trn, region=region, scope=scope, transport=transport,
-        address=base,
+        address=base, sts_host=disc.get("sts_host"),
     ).validate()
 
 

--- a/agentkit/auth/session.py
+++ b/agentkit/auth/session.py
@@ -304,6 +304,7 @@ class AuthSession:
             self.profile.role_trn,
             self.profile.provider_trn,
             duration_seconds=self._duration,
+            host=self.profile.sts_host,
         )
         self._sts = StsCredentials(
             access_key=assumed.access_key_id,

--- a/agentkit/auth/sso.py
+++ b/agentkit/auth/sso.py
@@ -80,13 +80,14 @@ def login(
     refresh_token = token.get("refresh_token")
 
     assumed = assume_role_with_oidc(
-        id_token, prof.role_trn, prof.provider_trn, duration_seconds=duration_seconds
+        id_token, prof.role_trn, prof.provider_trn, duration_seconds=duration_seconds,
+        host=prof.sts_host,
     )
     account = None
     try:
         ident = get_caller_identity(
             assumed.access_key_id, assumed.secret_access_key, assumed.session_token,
-            region=prof.region,
+            region=prof.region, host=prof.sts_host,
         )
         account = ident.get("AccountId")
     except Exception:
@@ -154,7 +155,8 @@ def whoami(profile: str | None = None, *, harden_ssl: bool = True) -> dict:
         raise AuthError("not logged in.", hint="run `agentkit login` first.")
     creds = session.credentials()
     ident = get_caller_identity(
-        creds.access_key, creds.secret_key, creds.session_token, region=session.profile.region
+        creds.access_key, creds.secret_key, creds.session_token,
+        region=session.profile.region, host=session.profile.sts_host,
     )
     ident["_profile"] = session.profile.name
     ident["_expires_at"] = creds.expires_at.isoformat() if creds.expires_at else None

--- a/agentkit/auth/sts.py
+++ b/agentkit/auth/sts.py
@@ -73,13 +73,16 @@ def assume_role_with_oidc(
     role_session_name: str = "agentkit-cli",
     duration_seconds: int = 3600,
     timeout: float = _TIMEOUT,
+    host: str | None = None,
 ) -> AssumedRole:
     """Exchange an OIDC ``id_token`` for temporary STS credentials.
 
-    Anonymous call — the token is the credential. ``host`` MUST be
-    ``sts.volcengineapi.com``; the token is too long for the query string so it
-    travels in the POST body.
+    Anonymous call — the token is the credential; it is too long for the query
+    string so it travels in the POST body. ``host`` is the STS endpoint from the
+    login profile (the discovery doc's ``sts_host``, so BytePlus pools use the
+    BytePlus STS); it defaults to the Volcengine endpoint for older docs.
     """
+    sts_host = host or STS_HOST
     params = {
         "RoleTrn": role_trn,
         "OIDCToken": id_token,
@@ -89,7 +92,7 @@ def assume_role_with_oidc(
     if provider_trn:
         params["OIDCProviderTrn"] = provider_trn
     body = urllib.parse.urlencode(params).encode("utf-8")
-    url = f"https://{STS_HOST}/?Action=AssumeRoleWithOIDC&Version={STS_VERSION}"
+    url = f"https://{sts_host}/?Action=AssumeRoleWithOIDC&Version={STS_VERSION}"
     req = urllib.request.Request(
         url, data=body, headers={"Content-Type": "application/x-www-form-urlencoded"}, method="POST"
     )
@@ -103,7 +106,7 @@ def assume_role_with_oidc(
             "id_token's aud is in the provider's client-id allow-list.",
         ) from exc
     except urllib.error.URLError as exc:
-        raise NetworkError(f"cannot reach STS endpoint ({STS_HOST}): {exc.reason}") from exc
+        raise NetworkError(f"cannot reach STS endpoint ({sts_host}): {exc.reason}") from exc
 
     try:
         creds = json.loads(raw)["Result"]["Credentials"]
@@ -121,15 +124,17 @@ def get_caller_identity(
     *,
     region: str = "cn-beijing",
     timeout: float = _TIMEOUT,
+    host: str | None = None,
 ) -> dict:
     """Return the verified identity (``AccountId`` / ``IdentityType`` / ``UserId``)."""
+    sts_host = host or STS_HOST
     query = {"Action": "GetCallerIdentity", "Version": STS_VERSION}
     headers = sign_headers(
-        "POST", STS_HOST, query, b"",
+        "POST", sts_host, query, b"",
         access_key=access_key, secret_key=secret_key, service="sts", region=region,
         session_token=session_token,
     )
-    url = f"https://{STS_HOST}/?" + urllib.parse.urlencode(query)
+    url = f"https://{sts_host}/?" + urllib.parse.urlencode(query)
     req = urllib.request.Request(url, data=b"", headers=headers, method="POST")
     try:
         raw = urllib.request.urlopen(req, timeout=timeout).read()
@@ -137,5 +142,5 @@ def get_caller_identity(
         detail = redact(exc.read().decode("utf-8", "replace"))[:200]
         raise SsoError(f"GetCallerIdentity failed: {detail}") from exc
     except urllib.error.URLError as exc:
-        raise NetworkError(f"cannot reach STS endpoint ({STS_HOST}): {exc.reason}") from exc
+        raise NetworkError(f"cannot reach STS endpoint ({sts_host}): {exc.reason}") from exc
     return json.loads(raw).get("Result") or {}

--- a/agentkit/toolkit/cli/cli_auth.py
+++ b/agentkit/toolkit/cli/cli_auth.py
@@ -161,16 +161,24 @@ def _profile_app() -> typer.Typer:
     return app
 
 
+def _default_region() -> str:
+    """Provider-aware default region (CLOUD_PROVIDER + env/config), for --region."""
+    from agentkit.platform.configuration import VolcConfiguration
+
+    return VolcConfiguration().region
+
+
 def _admin_app() -> typer.Typer:
     app = typer.Typer(
         help="Admin: provision UserPool CLI login and publish its discovery doc. "
-        "Needs Volcengine AK/SK for the account that owns the UserPool.",
+        "Needs the cloud account's AK/SK (Volcengine or BytePlus, per CLOUD_PROVIDER) "
+        "for the account that owns the UserPool.",
     )
 
     @app.command("doctor")
     def doctor(
         account: Optional[str] = typer.Option(None, "--account", help="Expected account id (guard)."),
-        region: str = typer.Option("cn-beijing", "--region"),
+        region: Optional[str] = typer.Option(None, "--region", help="Region (default: the provider's default region)."),
         data_plane: bool = typer.Option(
             True, "--data-plane/--no-data-plane",
             help="Also check credential-hosting prerequisites (APIG / VPC / VeFaaS / KMS)."),
@@ -184,6 +192,7 @@ def _admin_app() -> typer.Typer:
         from agentkit.auth.admin import preflight
         from agentkit.auth.errors import AuthError
 
+        region = region or _default_region()
         try:
             api = OpenApiClient(region=region, expect_account=account)
         except AuthError as exc:
@@ -217,12 +226,13 @@ def _admin_app() -> typer.Typer:
     @app.command("create-userpool")
     def create_userpool(
         name: str = typer.Option(..., "--name", help="UserPool name."),
-        region: str = typer.Option("cn-beijing", "--region"),
+        region: Optional[str] = typer.Option(None, "--region", help="Region (default: the provider's default region)."),
     ) -> None:
         """Create a UserPool (the IdP). Federate it to Feishu/ByteDance-SSO in the console."""
         from agentkit.auth.admin import create_user_pool
         from agentkit.auth.errors import AuthError
 
+        region = region or _default_region()
         try:
             uid, issuer = create_user_pool(name, region=region)
         except AuthError as exc:
@@ -234,12 +244,13 @@ def _admin_app() -> typer.Typer:
     def provision(
         user_pool: str = typer.Option(..., "--user-pool", help="UserPool uid."),
         account: Optional[str] = typer.Option(None, "--account", help="Account id (default: caller)."),
-        region: str = typer.Option("cn-beijing", "--region"),
+        region: Optional[str] = typer.Option(None, "--region", help="Region (default: the provider's default region)."),
     ) -> None:
         """Ensure the public CLI client + IAM OIDC provider + STS role (idempotent)."""
         from agentkit.auth.admin import provision_cli_access
         from agentkit.auth.errors import AuthError
 
+        region = region or _default_region()
         try:
             coords = provision_cli_access(user_pool, region=region, account_id=account)
         except AuthError as exc:
@@ -253,7 +264,7 @@ def _admin_app() -> typer.Typer:
         user_pool: Optional[str] = typer.Option(None, "--user-pool", help="Reuse an existing UserPool uid."),
         create_pool: Optional[str] = typer.Option(None, "--create-pool", help="Create a new UserPool with this name."),
         account: Optional[str] = typer.Option(None, "--account", help="Account id (default: caller)."),
-        region: str = typer.Option("cn-beijing", "--region"),
+        region: Optional[str] = typer.Option(None, "--region", help="Region (default: the provider's default region)."),
         idp: Optional[str] = typer.Option(None, "--idp", help="Federate an upstream IdP: bytedance | feishu."),
         idp_client_id: Optional[str] = typer.Option(None, "--idp-client-id"),
         idp_secret: Optional[str] = typer.Option(None, "--idp-secret"),
@@ -270,9 +281,10 @@ def _admin_app() -> typer.Typer:
         override. ``--yes`` (or passing flags) runs it non-interactively.
         """
         from agentkit.auth._openapi import OpenApiClient
-        from agentkit.auth.admin import CLI_CLIENT_NAME, OIDC_PROVIDER_NAME, ROLE_NAME, sso_setup
+        from agentkit.auth.admin import CLI_CLIENT_NAME, OIDC_PROVIDER_NAME, ROLE_NAME, sso_setup, tos_public_host
         from agentkit.auth.errors import AuthError
 
+        region = region or _default_region()
         try:
             api = OpenApiClient(region=region, expect_account=account)
         except AuthError as exc:
@@ -317,7 +329,7 @@ def _admin_app() -> typer.Typer:
 
         # 5. 列出将要做的改动,确认后执行
         if interactive:
-            host = dom or f"{bk}.tos-{region}.volces.com"
+            host = dom or f"{bk}.{tos_public_host(region)}"
             typer.secho("  将要执行以下配置:", fg=typer.colors.CYAN, bold=True, err=True)
             typer.secho(f"    • UserPool      {'复用 ' + user_pool if user_pool else '新建 (agentkit-cli-pool)'}", err=True)
             typer.secho(f"    • 上游联邦      {idp + ' 联邦登录' if idp else '不配置(用 UserPool 本地/已有登录)'}", err=True)
@@ -385,12 +397,13 @@ def _admin_app() -> typer.Typer:
         user_pool: str = typer.Option(..., "--user-pool", help="UserPool uid."),
         bucket: str = typer.Option(..., "--bucket", help="TOS bucket to host the discovery doc."),
         account: Optional[str] = typer.Option(None, "--account"),
-        region: str = typer.Option("cn-beijing", "--region"),
+        region: Optional[str] = typer.Option(None, "--region", help="Region (default: the provider's default region)."),
     ) -> None:
         """Provision (if needed) and publish /.well-known/agentkit-cli; print the login address."""
         from agentkit.auth.admin import provision_cli_access, publish_discovery
         from agentkit.auth.errors import AuthError
 
+        region = region or _default_region()
         try:
             coords = provision_cli_access(user_pool, region=region, account_id=account)
             url = publish_discovery(coords, bucket=bucket)

--- a/tests/auth/test_admin_provider.py
+++ b/tests/auth/test_admin_provider.py
@@ -165,6 +165,51 @@ class TestOpenApiClientProviderAware:
         assert "VOLCENGINE_ACCESS_KEY" in (exc.value.hint or "")
 
 
+class TestResolveIssuer:
+    """The issuer must come from the platform (GetUserPool), not a domain template —
+    IAM CreateOIDCProvider validates the issuer's discovery endpoint, and the
+    Volcengine template is wrong on BytePlus."""
+
+    class _FakeApi:
+        def __init__(self, result=None, exc=None):
+            self._result = result
+            self._exc = exc
+
+        def call(self, service, action, version, body):
+            assert (service, action) == ("id", "GetUserPool")
+            assert body == {"UserPoolUid": "uid-1"}
+            if self._exc:
+                raise self._exc
+            return self._result
+
+    def test_platform_issuer_url_wins(self):
+        from agentkit.auth.admin import resolve_issuer
+
+        api = self._FakeApi(
+            {"IssuerUrl": "https://userpool-uid-1.userpool.auth.id.ap-southeast-1.byteplus.example/"}
+        )
+        assert (
+            resolve_issuer(api, "uid-1", "ap-southeast-1")
+            == "https://userpool-uid-1.userpool.auth.id.ap-southeast-1.byteplus.example"
+        )
+
+    def test_domain_fallback(self):
+        from agentkit.auth.admin import resolve_issuer
+
+        api = self._FakeApi({"IssuerUrl": "", "Domain": "pool.example.com"})
+        assert resolve_issuer(api, "uid-1", "cn-beijing") == "https://pool.example.com"
+
+    def test_template_fallback_on_api_error(self):
+        from agentkit.auth._openapi import ApiError
+        from agentkit.auth.admin import resolve_issuer
+
+        api = self._FakeApi(exc=ApiError("GetUserPool", "InternalError", "boom"))
+        assert (
+            resolve_issuer(api, "uid-1", "cn-beijing")
+            == "https://userpool-uid-1.userpool.auth.id.cn-beijing.volces.com"
+        )
+
+
 class TestTosPublicHost:
     def test_volcengine(self, isolated_env):
         from agentkit.auth.admin import tos_public_host

--- a/tests/auth/test_admin_provider.py
+++ b/tests/auth/test_admin_provider.py
@@ -210,6 +210,95 @@ class TestResolveIssuer:
         )
 
 
+class _ScriptedApi:
+    """Fake OpenApiClient: canned responses/errors keyed by (service, action)."""
+
+    def __init__(self, script):
+        self.script = script  # {(service, action): result | Exception | callable(body)}
+        self.calls = []
+
+    def call(self, service, action, version, body):
+        self.calls.append((service, action, body))
+        entry = self.script[(service, action)]
+        if callable(entry) and not isinstance(entry, Exception):
+            entry = entry(body)
+        if isinstance(entry, Exception):
+            raise entry
+        return entry
+
+    call_ok = call
+
+
+class TestIdempotentReruns:
+    """Re-running sso-setup must reuse what earlier runs left behind."""
+
+    def test_create_user_pool_reuses_same_name_pool(self):
+        from agentkit.auth._openapi import ApiError
+        from agentkit.auth.admin import create_user_pool
+
+        api = _ScriptedApi({
+            ("id", "CreateUserPool"): ApiError("CreateUserPool", "Duplicated", "already exists"),
+            ("id", "ListUserPools"): {"Data": [
+                {"Name": "other", "Uid": "u-other"},
+                {"Name": "agentkit-cli-pool", "Uid": "u-reused"},
+            ]},
+            ("id", "GetUserPool"): {"IssuerUrl": "https://pool.example"},
+        })
+        uid, issuer = create_user_pool("agentkit-cli-pool", region="ap-southeast-1", api=api)
+        assert (uid, issuer) == ("u-reused", "https://pool.example")
+
+    def test_create_user_pool_other_errors_propagate(self):
+        from agentkit.auth._openapi import ApiError
+        from agentkit.auth.admin import create_user_pool
+
+        api = _ScriptedApi({
+            ("id", "CreateUserPool"): ApiError("CreateUserPool", "AccessDenied", "no"),
+        })
+        with pytest.raises(ApiError):
+            create_user_pool("p", region="cn-beijing", api=api)
+
+    def test_ensure_role_updates_existing_without_create(self):
+        """Quota-full accounts return LimitExceeded before the duplicate-name check,
+        so an existing role must be detected via GetRole, never via CreateRole."""
+        from agentkit.auth.admin import _ensure_role
+
+        api = _ScriptedApi({
+            ("iam", "GetRole"): {"RoleName": "r"},
+            ("iam", "UpdateRole"): {},
+            ("iam", "CreatePolicy"): {},
+            ("iam", "AttachRolePolicy"): {},
+        })
+        _ensure_role(api, "trn:iam::1:oidc-provider/p", role_name="r")
+        actions = [a for _, a, _ in api.calls]
+        assert "CreateRole" not in actions
+        assert "UpdateRole" in actions
+
+    def test_ensure_role_creates_when_missing(self):
+        from agentkit.auth._openapi import ApiError
+        from agentkit.auth.admin import _ensure_role
+
+        api = _ScriptedApi({
+            ("iam", "GetRole"): ApiError("GetRole", "RoleNotExist", "missing"),
+            ("iam", "CreateRole"): {},
+            ("iam", "CreatePolicy"): {},
+            ("iam", "AttachRolePolicy"): {},
+        })
+        _ensure_role(api, "trn:iam::1:oidc-provider/p", role_name="r")
+        assert "CreateRole" in [a for _, a, _ in api.calls]
+
+    def test_ensure_role_quota_error_propagates_when_truly_missing(self):
+        from agentkit.auth._openapi import ApiError
+        from agentkit.auth.admin import _ensure_role
+
+        api = _ScriptedApi({
+            ("iam", "GetRole"): ApiError("GetRole", "RoleNotExist", "missing"),
+            ("iam", "CreateRole"): ApiError("CreateRole", "LimitExceeded", "RolesPerAccount"),
+        })
+        with pytest.raises(ApiError) as exc:
+            _ensure_role(api, "trn:iam::1:oidc-provider/p", role_name="r")
+        assert exc.value.code == "LimitExceeded"
+
+
 class TestTosPublicHost:
     def test_volcengine(self, isolated_env):
         from agentkit.auth.admin import tos_public_host

--- a/tests/auth/test_admin_provider.py
+++ b/tests/auth/test_admin_provider.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud-Provider awareness of the auth ADMIN path (`agentkit auth admin sso-setup`).
+
+Regression tests for Meego #7363652733: with CLOUD_PROVIDER=byteplus the admin
+OpenApiClient must resolve BYTEPLUS_ACCESS_KEY / BYTEPLUS_SECRET_KEY (via the
+SDK's unified credential chain) and sign against the BytePlus OpenAPI gateway,
+instead of hardcoding the Volcengine env vars and host.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agentkit.auth._openapi import OpenApiClient
+from agentkit.auth.errors import AuthError
+from agentkit.platform.provider import CloudProvider
+
+
+@pytest.fixture
+def isolated_env(monkeypatch, tmp_path):
+    """No ambient creds/provider/config: only what each test sets is visible."""
+    for key in list(os.environ):
+        if key.startswith(("VOLC", "BYTEPLUS")) or key in {
+            "CLOUD_PROVIDER",
+            "AGENTKIT_CLOUD_PROVIDER",
+            "AGENTKIT_AUTH_PROFILE",
+        }:
+            monkeypatch.delenv(key)
+    # Keep the cwd `.env` fallback out of the chain.
+    monkeypatch.chdir(tmp_path)
+    # Neutralize ~/.agentkit/config.yaml.
+    monkeypatch.setattr(
+        "agentkit.platform.configuration.read_global_config_dict", dict
+    )
+    monkeypatch.setattr(
+        "agentkit.platform.configuration.get_global_config_str", lambda *k: None
+    )
+    monkeypatch.setattr(
+        "agentkit.platform.configuration.get_global_config_value", lambda *k: None
+    )
+    # Never touch the real SSO session store (Keychain) from tests.
+    from agentkit.auth import providers as auth_providers
+
+    monkeypatch.setattr(
+        auth_providers.SsoStsCredentialProvider, "resolve", lambda self: None
+    )
+    return monkeypatch
+
+
+@pytest.fixture
+def stub_caller_identity(monkeypatch):
+    """Stub the network so the constructor's GetCallerIdentity guard is offline."""
+    calls: list[tuple[str, str]] = []
+
+    def _fake_call(self, service, action, version, body):
+        calls.append((service, action))
+        return {"AccountId": "2100000000"}
+
+    monkeypatch.setattr(OpenApiClient, "call", _fake_call)
+    return calls
+
+
+class TestOpenApiClientProviderAware:
+    def test_byteplus_env_credentials(self, isolated_env, stub_caller_identity):
+        isolated_env.setenv("CLOUD_PROVIDER", "byteplus")
+        isolated_env.setenv("BYTEPLUS_ACCESS_KEY", "BP_AK")
+        isolated_env.setenv("BYTEPLUS_SECRET_KEY", "BP_SK")
+        isolated_env.setenv("BYTEPLUS_SESSION_TOKEN", "BP_TOKEN")
+
+        api = OpenApiClient()
+
+        assert api.provider == CloudProvider.BYTEPLUS
+        assert (api.ak, api.sk, api.token) == ("BP_AK", "BP_SK", "BP_TOKEN")
+        assert api._host == "open.byteplusapi.com"
+        assert api.region == "ap-southeast-1"  # BytePlus default region
+        assert ("sts", "GetCallerIdentity") in stub_caller_identity
+
+    def test_byteplus_region_sources(self, isolated_env, stub_caller_identity):
+        isolated_env.setenv("CLOUD_PROVIDER", "byteplus")
+        isolated_env.setenv("BYTEPLUS_ACCESS_KEY", "BP_AK")
+        isolated_env.setenv("BYTEPLUS_SECRET_KEY", "BP_SK")
+        isolated_env.setenv("BYTEPLUS_REGION", "ap-southeast-3")
+
+        assert OpenApiClient().region == "ap-southeast-3"
+        # An explicit --region always wins over the env.
+        assert OpenApiClient(region="ap-southeast-1").region == "ap-southeast-1"
+
+    def test_volcengine_env_credentials(self, isolated_env, stub_caller_identity):
+        isolated_env.setenv("VOLCENGINE_ACCESS_KEY", "VE_AK")
+        isolated_env.setenv("VOLCENGINE_SECRET_KEY", "VE_SK")
+
+        api = OpenApiClient()
+
+        assert api.provider == CloudProvider.VOLCENGINE
+        assert (api.ak, api.sk) == ("VE_AK", "VE_SK")
+        assert api._host == "open.volcengineapi.com"
+        assert api.region == "cn-beijing"
+
+    def test_volcengine_legacy_env_credentials(
+        self, isolated_env, stub_caller_identity
+    ):
+        isolated_env.setenv("VOLC_ACCESSKEY", "LEGACY_AK")
+        isolated_env.setenv("VOLC_SECRETKEY", "LEGACY_SK")
+
+        api = OpenApiClient()
+        assert (api.ak, api.sk) == ("LEGACY_AK", "LEGACY_SK")
+
+    def test_explicit_args_win_over_env(self, isolated_env, stub_caller_identity):
+        isolated_env.setenv("CLOUD_PROVIDER", "byteplus")
+        isolated_env.setenv("BYTEPLUS_ACCESS_KEY", "ENV_AK")
+        isolated_env.setenv("BYTEPLUS_SECRET_KEY", "ENV_SK")
+
+        api = OpenApiClient(access_key="ARG_AK", secret_key="ARG_SK")
+        assert (api.ak, api.sk) == ("ARG_AK", "ARG_SK")
+
+    def test_missing_byteplus_credentials(self, isolated_env, stub_caller_identity):
+        isolated_env.setenv("CLOUD_PROVIDER", "byteplus")
+        # Volcengine creds present must NOT satisfy a BytePlus deploy.
+        isolated_env.setenv("VOLCENGINE_ACCESS_KEY", "VE_AK")
+        isolated_env.setenv("VOLCENGINE_SECRET_KEY", "VE_SK")
+
+        with pytest.raises(AuthError) as exc:
+            OpenApiClient()
+        assert "BytePlus" in str(exc.value)
+        assert "BYTEPLUS_ACCESS_KEY" in (exc.value.hint or "")
+
+    def test_missing_volcengine_credentials(self, isolated_env, stub_caller_identity):
+        with pytest.raises(AuthError) as exc:
+            OpenApiClient()
+        assert "Volcengine" in str(exc.value)
+        assert "VOLCENGINE_ACCESS_KEY" in (exc.value.hint or "")
+
+    def test_sso_session_rejected_for_admin(
+        self, isolated_env, stub_caller_identity
+    ):
+        """`agentkit login` (end-user sandbox STS role) must not silently become
+        the admin provisioning identity."""
+        from agentkit.auth import providers as auth_providers
+
+        isolated_env.setattr(
+            auth_providers.SsoStsCredentialProvider,
+            "resolve",
+            lambda self: auth_providers.ResolvedCredentials(
+                "SSO_AK", "SSO_SK", "SSO_TOKEN", "sso-sts"
+            ),
+        )
+        with pytest.raises(AuthError) as exc:
+            OpenApiClient()
+        assert "sandbox role" in str(exc.value)
+        assert "VOLCENGINE_ACCESS_KEY" in (exc.value.hint or "")
+
+
+class TestTosPublicHost:
+    def test_volcengine(self, isolated_env):
+        from agentkit.auth.admin import tos_public_host
+
+        assert tos_public_host("cn-beijing") == "tos-cn-beijing.volces.com"
+
+    def test_byteplus(self, isolated_env):
+        from agentkit.auth.admin import tos_public_host
+
+        isolated_env.setenv("CLOUD_PROVIDER", "byteplus")
+        assert tos_public_host("ap-southeast-1") == "tos-ap-southeast-1.bytepluses.com"

--- a/tests/auth/test_admin_provider.py
+++ b/tests/auth/test_admin_provider.py
@@ -221,3 +221,71 @@ class TestTosPublicHost:
 
         isolated_env.setenv("CLOUD_PROVIDER", "byteplus")
         assert tos_public_host("ap-southeast-1") == "tos-ap-southeast-1.bytepluses.com"
+
+
+class TestStsHostPlumbing:
+    """The discovery doc carries the provider's STS endpoint (`sts_host`) and the
+    end-user login honors it — a BytePlus pool must not call the Volcengine STS."""
+
+    def test_sts_public_host_by_provider(self, isolated_env):
+        from agentkit.auth.admin import sts_public_host
+
+        assert sts_public_host("cn-beijing") == "sts.volcengineapi.com"
+        isolated_env.setenv("CLOUD_PROVIDER", "byteplus")
+        assert sts_public_host("ap-southeast-1") == "sts.ap-southeast-1.byteplusapi.com"
+
+    def test_discovery_doc_carries_sts_host(self):
+        from agentkit.auth.admin import CliAccessCoords
+
+        kwargs = dict(
+            account_id="1", region="ap-southeast-1", user_pool_uid="u", issuer="https://i",
+            client_id="c", role_trn="trn:iam::1:role/r", provider_trn="trn:iam::1:oidc-provider/p",
+        )
+        doc = CliAccessCoords(**kwargs, sts_host="sts.ap-southeast-1.byteplusapi.com").discovery_doc()
+        assert doc["sts_host"] == "sts.ap-southeast-1.byteplusapi.com"
+        # Back-compat: no sts_host -> field omitted, older docs keep their shape.
+        assert "sts_host" not in CliAccessCoords(**kwargs).discovery_doc()
+
+    def test_resolve_profile_parses_sts_host(self, isolated_env, tmp_path):
+        import json
+
+        from agentkit.auth.resolve import resolve_profile
+
+        doc = {
+            "issuer": "https://userpool-u.userpool.auth.id.ap-southeast-1.example",
+            "client_id": "c",
+            "role_trn": "trn:iam::1:role/r",
+            "provider_trn": "trn:iam::1:oidc-provider/p",
+            "region": "ap-southeast-1",
+            "sts_host": "sts.ap-southeast-1.byteplusapi.com",
+        }
+        path = tmp_path / "agentkit-cli.json"
+        path.write_text(json.dumps(doc))
+        prof = resolve_profile(str(path), harden_ssl=False)
+        assert prof.sts_host == "sts.ap-southeast-1.byteplusapi.com"
+
+        path.write_text(json.dumps({k: v for k, v in doc.items() if k != "sts_host"}))
+        assert resolve_profile(str(path), harden_ssl=False).sts_host is None
+
+    def test_assume_role_honors_host(self, monkeypatch):
+        import io
+        import json
+
+        from agentkit.auth import sts as sts_mod
+
+        seen = []
+
+        def fake_urlopen(req, timeout=None):
+            seen.append(req.full_url)
+            return io.BytesIO(json.dumps({"Result": {"Credentials": {
+                "AccessKeyId": "AK", "SecretAccessKey": "SK", "SessionToken": "TOK",
+                "ExpiredTime": "2026-08-18T00:00:00+00:00",
+            }}}).encode())
+
+        monkeypatch.setattr(sts_mod.urllib.request, "urlopen", fake_urlopen)
+
+        sts_mod.assume_role_with_oidc("tok", "trn:iam::1:role/r", host="sts.ap-southeast-1.byteplusapi.com")
+        assert seen[-1].startswith("https://sts.ap-southeast-1.byteplusapi.com/")
+        # Default (older discovery docs without sts_host) is unchanged.
+        sts_mod.assume_role_with_oidc("tok", "trn:iam::1:role/r")
+        assert seen[-1].startswith("https://sts.volcengineapi.com/")


### PR DESCRIPTION
## Summary

Under `CLOUD_PROVIDER=byteplus`, `agentkit auth admin sso-setup` (and the other `auth admin` commands) rejected valid `BYTEPLUS_ACCESS_KEY` / `BYTEPLUS_SECRET_KEY` with:

```
Error: admin provisioning needs Volcengine credentials.
hint: export VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY for the account that owns the UserPool.
```

Root cause: the admin `OpenApiClient` hardcoded the `VOLCENGINE_*` / `VOLC_*` env reads and the `open.volcengineapi.com` host instead of reusing the SDK's provider-aware resolution (`VolcConfiguration` / `resolve_credentials`), so `CLOUD_PROVIDER=byteplus` had no effect on the admin path. (Internal issue: 7363652733)

## Changes

- `agentkit/auth/_openapi.py`: resolve credentials, region and the OpenAPI gateway host through the unified provider-aware chain (`VolcConfiguration`). On BytePlus this uses `BYTEPLUS_ACCESS_KEY` / `BYTEPLUS_SECRET_KEY` and signs against `open.byteplusapi.com`; error hints name the provider's env vars. Also explicitly reject `sso-sts` credentials for admin provisioning — the `agentkit login` session carries the end-user sandbox role, not account admin rights.
- `agentkit/auth/admin.py`: discovery-doc publishing resolves TOS credentials and endpoint through the same chain (`tos-<region>.bytepluses.com` on BytePlus); new `tos_public_host()` helper; the doctor's remediation hint is provider-aware.
- `agentkit/toolkit/cli/cli_auth.py`: the admin subcommands' `--region` now defaults to the provider's default region (`ap-southeast-1` on BytePlus, `cn-beijing` on Volcengine, honoring `BYTEPLUS_REGION` / `VOLCENGINE_REGION`) instead of a hardcoded `cn-beijing`.

## Known boundary

The UserPool issuer domain (`userpool.auth.id.<region>.volces.com`), the Identity console URL and the end-user login STS host are still Volcengine-specific; whether/where the UserPool (`id`) service is exposed on BytePlus is a platform-side question and is out of scope here.

## Testing

- New `tests/auth/test_admin_provider.py` (10 tests, offline — the `GetCallerIdentity` guard is stubbed; the SSO store is never touched).
- Broad regression: 899 passed / 1 failed; the single failure is a pre-existing cross-file env-leak flake (`tests/platform/test_configuration_endpoints.py` writes `os.environ` directly and leaks `VOLCENGINE_REGION` into later tests), reproduced identically on unmodified `main`.
- Live check with fake keys: `CLOUD_PROVIDER=byteplus agentkit auth admin doctor --region ap-southeast-1` now reaches `open.byteplusapi.com` and receives a server-side `InvalidAccessKey` (credential selection + endpoint + SigV4 signing all provider-aware). Volcengine paths (`VOLCENGINE_*`, legacy `VOLC_*`, and `~/.agentkit/config.yaml`) verified working.