### PR TITLE
fix: support BytePlus credentials for harness deployment

### DIFF
--- a/agentkit/toolkit/executors/init_executor.py
+++ b/agentkit/toolkit/executors/init_executor.py
@@ -131,13 +131,19 @@ TEMPLATES = {
 }
 
 
-# `.env.example` written into a harness directory. Carries only the Volcengine
-# deploy credentials; copy to `.env` and fill in the AK/SK before deploying.
+# `.env.example` written into a harness directory. Copy it to `.env` and fill in
+# the credential pair for the selected cloud provider before deploying.
 _HARNESS_ENV_EXAMPLE = """\
 # Volcengine credentials for harness deploy. Copy this file to `.env` and fill in.
 VOLCENGINE_ACCESS_KEY=
 VOLCENGINE_SECRET_KEY=
 # VOLCENGINE_REGION=cn-beijing
+
+# BytePlus credentials (uncomment these lines and set CLOUD_PROVIDER=byteplus).
+# CLOUD_PROVIDER=byteplus
+# BYTEPLUS_ACCESS_KEY=
+# BYTEPLUS_SECRET_KEY=
+# BYTEPLUS_REGION=ap-southeast-1
 """
 
 # Container image for the harness server. The base image's apt mirror is an

--- a/agentkit/toolkit/harness/config_builder.py
+++ b/agentkit/toolkit/harness/config_builder.py
@@ -23,6 +23,7 @@ def build_agentkit_config(
     envs: Dict[str, str],
     auth: Optional[Dict[str, Any]] = None,
     runtime_id: str = "Auto",
+    cloud_provider: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the cloud AgentKit launch config dict (auto-provision).
 
@@ -37,7 +38,8 @@ def build_agentkit_config(
 
     When ``auth`` (a normalized ``{discovery_url, allowed_ids}`` block) is given,
     the runtime is gated by OAuth2/JWT (``custom_jwt``); otherwise it keeps the
-    default API-key auth (``key_auth``).
+    default API-key auth (``key_auth``). ``cloud_provider`` pins the generated
+    launch config to the same provider used to resolve credentials and region.
     """
     cloud: Dict[str, Any] = {
         "region": region,
@@ -64,16 +66,20 @@ def build_agentkit_config(
         cloud["runtime_apikey_name"] = "Auto"
         cloud["runtime_apikey"] = "Auto"
         cloud["runtime_jwt_allowed_clients"] = []
+    common: Dict[str, Any] = {
+        "agent_name": runtime_name,
+        "entry_point": "app.py",
+        "description": "Harness Server - VeADK",
+        "language": "Python",
+        "language_version": "3.12",
+        "runtime_envs": envs,
+        "launch_type": "cloud",
+    }
+    if cloud_provider:
+        common["cloud_provider"] = cloud_provider
+
     return {
-        "common": {
-            "agent_name": runtime_name,
-            "entry_point": "app.py",
-            "description": "Harness Server - VeADK",
-            "language": "Python",
-            "language_version": "3.12",
-            "runtime_envs": envs,
-            "launch_type": "cloud",
-        },
+        "common": common,
         "launch_types": {"cloud": cloud},
         "docker_build": {},
     }

--- a/agentkit/toolkit/harness/deploy.py
+++ b/agentkit/toolkit/harness/deploy.py
@@ -28,7 +28,6 @@ from typing import Any, Callable, Dict, Optional, Union
 
 from ..models import LifecycleResult
 from ..reporter import Reporter
-
 from .config_builder import build_agentkit_config
 from .env_mapping import to_runtime_env
 
@@ -43,9 +42,9 @@ _DEFAULT_HARNESS_NAME = "default"
 HARNESS_TAG_KEY = "agentkit:agenttype"
 HARNESS_TAG_VALUE = "harness"
 
-# Volcengine deploy credentials: needed locally to authenticate the build/deploy,
+# Cloud deploy credentials: needed locally to authenticate the build/deploy,
 # but must never be uploaded into the cloud runtime's environment (the runtime
-# gets its Volcengine access from its IAM role). A harness's own `.env` carries
+# gets its cloud access from its IAM role). A harness's own `.env` carries
 # these for deploy; they are excluded from the runtime env upload (see
 # COMPAT_ENV_EXCLUDE). Credentials a harness genuinely needs at runtime come from
 # its spec instead, so they are not affected.
@@ -56,6 +55,9 @@ _DEPLOY_CREDENTIAL_ENV_KEYS = {
     "VOLC_ACCESSKEY",
     "VOLC_SECRETKEY",
     "VOLC_SESSIONTOKEN",
+    "BYTEPLUS_ACCESS_KEY",
+    "BYTEPLUS_SECRET_KEY",
+    "BYTEPLUS_SESSION_TOKEN",
 }
 
 
@@ -217,16 +219,17 @@ def deploy_harness(
       (``HarnessDeployAborted``); if ``on_conflict`` is ``None`` (e.g. a
       programmatic caller or a non-interactive CLI), it fast-fails.
 
-    Credentials note: a local ``.env`` is loaded for deploy auth, but the
-    Volcengine deploy credentials in it are NOT uploaded into the runtime
+    Credentials note: a local ``.env`` is loaded for deploy auth, but the cloud
+    deploy credentials in it are NOT uploaded into the runtime
     environment (the runtime authenticates via its IAM role); other ``.env`` keys
     are still merged in.
 
     Args:
         name: Harness name; locates ``<name>.harness.json`` and names the runtime.
         path: Directory containing the spec and Dockerfile (default: cwd).
-        region: AgentKit region (default ``cn-beijing`` or ``VOLCENGINE_REGION``).
-        access_key / secret_key: Volcengine credentials (default: ``VOLCENGINE_*`` env).
+        region: AgentKit region (default resolved for the active cloud provider).
+        access_key / secret_key: Explicit cloud credentials (default: resolved from
+            provider-specific environment variables or global configuration).
         discovery_url / allowed_id: OAuth2/JWT overrides for the spec ``auth`` block.
         reporter: Progress reporter forwarded to the launch (default: silent).
         on_conflict: Callback consulted when a single same-name harness exists;
@@ -242,12 +245,13 @@ def deploy_harness(
     """
     # Heavy imports are lazy: this module is imported by `agentkit.toolkit.sdk`
     # at package init, and these pull in the runtime client / executors.
-    from agentkit.toolkit.sdk.lifecycle import launch
-    from agentkit.toolkit.models import PreflightMode
-    from agentkit.toolkit.config import utils as cfg_utils
-    from agentkit.toolkit.config.utils import load_dotenv_file
+    from agentkit.platform import VolcConfiguration, resolve_credentials
     from agentkit.sdk.runtime import types as rt_types
     from agentkit.sdk.runtime.client import AgentkitRuntimeClient
+    from agentkit.toolkit.config import utils as cfg_utils
+    from agentkit.toolkit.config.utils import load_dotenv_file
+    from agentkit.toolkit.models import PreflightMode
+    from agentkit.toolkit.sdk.lifecycle import launch
 
     proj_dir = Path(path).resolve()
     if not proj_dir.is_dir():
@@ -263,26 +267,27 @@ def deploy_harness(
     runtime_name = name
     auth = _resolve_auth(spec.get("auth"), discovery_url, allowed_id)
 
-    # AgentKit authenticates via the Volcengine SDK, which reads VOLC_ACCESSKEY /
-    # VOLC_SECRETKEY from the environment. Mirror whatever AK/SK was passed (or
-    # already set as VOLCENGINE_*) into those names.
-    ak = access_key or os.getenv("VOLCENGINE_ACCESS_KEY", "")
-    sk = secret_key or os.getenv("VOLCENGINE_SECRET_KEY", "")
-    if ak and sk:
-        os.environ["VOLC_ACCESSKEY"] = ak
-        os.environ["VOLC_SECRETKEY"] = sk
-    if not os.getenv("VOLC_ACCESSKEY") or not os.getenv("VOLC_SECRETKEY"):
-        raise ValueError(
-            "Volcengine credentials are required. Pass access_key / secret_key, "
-            "or set VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY."
-        )
-
-    resolved_region = region or os.getenv("VOLCENGINE_REGION") or "cn-beijing"
+    # Use the shared platform abstraction so credentials and region follow the
+    # active provider (Volcengine or BytePlus) consistently with other clients.
+    platform_config = VolcConfiguration(region=region or None)
+    credentials = resolve_credentials(
+        "agentkit",
+        explicit_access_key=access_key,
+        explicit_secret_key=secret_key,
+        platform_config=platform_config,
+    )
+    resolved_region = platform_config.region
+    cloud_provider = platform_config.provider.value
 
     # Resolve a name collision into a deploy mode. The harness config defaults to
     # `runtime_id: Auto` (create new); an existing same-name harness can instead
     # be updated in place (new version) after confirmation.
-    client = AgentkitRuntimeClient(region=resolved_region)
+    client = AgentkitRuntimeClient(
+        access_key=credentials.access_key,
+        secret_key=credentials.secret_key,
+        region=resolved_region,
+        session_token=credentials.session_token or "",
+    )
     matches = _find_runtimes_by_name(client, runtime_name)
     update_runtime_id = None
     if len(matches) > 1:
@@ -328,6 +333,7 @@ def deploy_harness(
         runtime_envs,
         auth,
         runtime_id=update_runtime_id or "Auto",
+        cloud_provider=cloud_provider,
     )
 
     # AgentKit's launch path exposes no hook for runtime tags, so tag the runtime
@@ -349,11 +355,26 @@ def deploy_harness(
     cwd = os.getcwd()
     os.chdir(proj_dir)
     AgentkitRuntimeClient.create_runtime = _create_runtime_with_harness_tag
-    # Keep deploy-only Volcengine credentials in the local .env out of the
+    # Keep deploy-only cloud credentials in the local .env out of the
     # uploaded runtime environment (the compat layer auto-loads .env). Scoped to
     # this launch and restored afterwards.
     prev_exclude = cfg_utils.COMPAT_ENV_EXCLUDE
     cfg_utils.COMPAT_ENV_EXCLUDE = set(prev_exclude) | _DEPLOY_CREDENTIAL_ENV_KEYS
+    provider_prefix = "BYTEPLUS" if cloud_provider == "byteplus" else "VOLCENGINE"
+    deploy_env = {
+        "VOLC_ACCESSKEY": credentials.access_key,
+        "VOLC_SECRETKEY": credentials.secret_key,
+        "VOLC_SESSIONTOKEN": credentials.session_token,
+        f"{provider_prefix}_ACCESS_KEY": credentials.access_key,
+        f"{provider_prefix}_SECRET_KEY": credentials.secret_key,
+        f"{provider_prefix}_SESSION_TOKEN": credentials.session_token,
+    }
+    previous_deploy_env = {key: os.environ.get(key) for key in deploy_env}
+    for key, value in deploy_env.items():
+        if value:
+            os.environ[key] = value
+        else:
+            os.environ.pop(key, None)
     try:
         result = launch(
             config_dict=cfg,
@@ -363,6 +384,11 @@ def deploy_harness(
     finally:
         AgentkitRuntimeClient.create_runtime = orig_create_runtime
         cfg_utils.COMPAT_ENV_EXCLUDE = prev_exclude
+        for key, value in previous_deploy_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
         os.chdir(cwd)
 
     if not result.success:

--- a/docs/content/2.agentkit-cli/2.commands.md
+++ b/docs/content/2.agentkit-cli/2.commands.md
@@ -1377,10 +1377,10 @@ agentkit deploy [选项]
 - Runtime 名称即为该 `<name>`
 
 `--region` AgentKit 区域（harness 部署）
-- 默认：`cn-beijing` 或环境变量 `VOLCENGINE_REGION`
+- 默认：根据 Cloud Provider 从 `VOLCENGINE_REGION` 或 `BYTEPLUS_REGION` 解析
 
-`--volcengine-access-key` / `--volcengine-secret-key` 火山引擎凭证（harness 部署）
-- 默认：环境变量 `VOLCENGINE_ACCESS_KEY` / `VOLCENGINE_SECRET_KEY`
+`--volcengine-access-key` / `--volcengine-secret-key` 显式部署凭证（harness 部署，兼容旧参数名）
+- 默认：根据 `CLOUD_PROVIDER` 读取 `VOLCENGINE_ACCESS_KEY` / `VOLCENGINE_SECRET_KEY` 或 `BYTEPLUS_ACCESS_KEY` / `BYTEPLUS_SECRET_KEY`
 
 `--discovery-url` / `--allowed-id` OAuth2/JWT 鉴权（harness 部署，可选）
 - 设置后 Runtime 改用 `custom_jwt` 网关鉴权；`--allowed-id` 为逗号分隔的客户端 ID

--- a/docs/content/2.agentkit-cli/5.harness.md
+++ b/docs/content/2.agentkit-cli/5.harness.md
@@ -37,14 +37,14 @@ agentkit list harness                       # 5. 列出已部署的 harness 运�
 ```bash
 agentkit init my-harness --template harness
 cd my-harness
-cp .env.example .env          # 填入火山引擎 AK/SK
+cp .env.example .env          # 填入当前 Cloud Provider 对应的 AK/SK
 ```
 
 生成的目录结构：
 
 ```plaintext
 my-harness/
-├── .env.example   # 复制为 .env，填入 VOLCENGINE_ACCESS_KEY / VOLCENGINE_SECRET_KEY
+├── .env.example   # 复制为 .env，填入 Volcengine 或 BytePlus AK/SK
 └── Dockerfile     # 云端构建 veadk.cloud.harness_app 服务
 ```
 
@@ -286,14 +286,14 @@ agentkit add harness --name my-harness \
 | 参数 | 说明 | 默认值 |
 | :--- | :--- | :--- |
 | `--harness` | **（必填）** 要部署的 Harness 名称，对应 `<name>.harness.json`。 | — |
-| `--region` | AgentKit 区域。 | `cn-beijing` 或 `VOLCENGINE_REGION` |
-| `--volcengine-access-key` | 火山引擎 Access Key。 | 环境变量 `VOLCENGINE_ACCESS_KEY` |
-| `--volcengine-secret-key` | 火山引擎 Secret Key。 | 环境变量 `VOLCENGINE_SECRET_KEY` |
+| `--region` | AgentKit 区域。 | 根据 Cloud Provider 从 `VOLCENGINE_REGION` 或 `BYTEPLUS_REGION` 解析 |
+| `--volcengine-access-key` | 显式指定部署 Access Key（兼容旧参数名）。 | 当前 Cloud Provider 对应的环境变量 |
+| `--volcengine-secret-key` | 显式指定部署 Secret Key（兼容旧参数名）。 | 当前 Cloud Provider 对应的环境变量 |
 | `--discovery-url` | OIDC discovery URL；设置后运行时改用 `custom_jwt` 网关鉴权。 | 见「7. 鉴权」 |
 | `--allowed-id` | 允许的客户端 ID，逗号分隔（custom_jwt）。 | 见「7. 鉴权」 |
 | `--yes`, `-y` | 同名运行时已存在时直接更新为新版本，不交互询问。 | `false` |
 
-凭证安全：`.env` 中的火山 AK/SK 仅用于本地发起部署，不会写入镜像或运行时明文。
+凭证解析遵循 `CLOUD_PROVIDER`：`volcengine` 使用 `VOLCENGINE_ACCESS_KEY` / `VOLCENGINE_SECRET_KEY`，`byteplus` 使用 `BYTEPLUS_ACCESS_KEY` / `BYTEPLUS_SECRET_KEY`。这些 `.env` 中的部署凭证仅用于本地发起部署，不会写入镜像或运行时明文。
 
 `harness.json` 注册表条目（按鉴权类型）：
 
@@ -435,7 +435,7 @@ agentkit invoke harness my-harness "你好" -ak "<user-oauth-jwt>"
 
 ## 6. memory / knowledgebase 配置
 
-知识库与记忆在 `add harness` 时声明、`deploy` 时绑定到**基础 Agent**。部署时各组件的 `type` 映射为选择器环境变量，连接参数映射为 VeADK 的 `DATABASE_*` 环境变量，火山凭证复用 `.env` 的 `VOLCENGINE_*`。
+知识库与记忆在 `add harness` 时声明、`deploy` 时绑定到**基础 Agent**。部署时各组件的 `type` 映射为选择器环境变量，连接参数映射为 VeADK 的 `DATABASE_*` 环境变量，云凭证根据 `CLOUD_PROVIDER` 复用 `.env` 中的 `VOLCENGINE_*` 或 `BYTEPLUS_*`。
 
 | 组件 | 选择器 env | 支持后端 | 连接参数 env 前缀 |
 | :--- | :--- | :--- | :--- |

--- a/tests/toolkit/executors/test_init_executor.py
+++ b/tests/toolkit/executors/test_init_executor.py
@@ -290,6 +290,9 @@ def test_init_harness_env_example_ships_empty_credential_placeholders(
     }
     assert lines["VOLCENGINE_ACCESS_KEY"] == ""
     assert lines["VOLCENGINE_SECRET_KEY"] == ""
+    assert "# CLOUD_PROVIDER=byteplus" in env_text
+    assert "# BYTEPLUS_ACCESS_KEY=" in env_text
+    assert "# BYTEPLUS_SECRET_KEY=" in env_text
 
 
 def test_init_harness_is_idempotent_and_skips_existing_files(tmp_path: Path) -> None:

--- a/tests/toolkit/test_harness_deploy_credentials.py
+++ b/tests/toolkit/test_harness_deploy_credentials.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+import os
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def harness_deploy_spy(monkeypatch):
+    deploy_module = importlib.import_module("agentkit.toolkit.harness.deploy")
+    lifecycle_module = importlib.import_module("agentkit.toolkit.sdk.lifecycle")
+    runtime_client_module = importlib.import_module("agentkit.sdk.runtime.client")
+    config_utils = importlib.import_module("agentkit.toolkit.config.utils")
+
+    captured = {}
+
+    class FakeRuntimeClient:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        def create_runtime(self, request):
+            raise AssertionError("create_runtime should be handled by the fake launch")
+
+    def fake_launch(**kwargs):
+        captured["config_dict"] = kwargs["config_dict"]
+        captured["excluded_env"] = set(config_utils.COMPAT_ENV_EXCLUDE)
+        provider = kwargs["config_dict"]["common"]["cloud_provider"]
+        provider_prefix = "BYTEPLUS" if provider == "byteplus" else "VOLCENGINE"
+        captured["deploy_env"] = {
+            key: os.getenv(key)
+            for key in (
+                "VOLC_ACCESSKEY",
+                "VOLC_SECRETKEY",
+                "VOLC_SESSIONTOKEN",
+                f"{provider_prefix}_ACCESS_KEY",
+                f"{provider_prefix}_SECRET_KEY",
+                f"{provider_prefix}_SESSION_TOKEN",
+            )
+        }
+        return SimpleNamespace(success=False)
+
+    monkeypatch.setattr(
+        runtime_client_module, "AgentkitRuntimeClient", FakeRuntimeClient
+    )
+    monkeypatch.setattr(deploy_module, "_find_runtimes_by_name", lambda *_args: [])
+    monkeypatch.setattr(lifecycle_module, "launch", fake_launch)
+    return deploy_module, captured
+
+
+@pytest.mark.parametrize(
+    (
+        "provider",
+        "access_key_name",
+        "secret_key_name",
+        "session_token_name",
+        "region_name",
+        "region",
+    ),
+    [
+        (
+            "volcengine",
+            "VOLCENGINE_ACCESS_KEY",
+            "VOLCENGINE_SECRET_KEY",
+            "VOLCENGINE_SESSION_TOKEN",
+            "VOLCENGINE_REGION",
+            "cn-beijing",
+        ),
+        (
+            "byteplus",
+            "BYTEPLUS_ACCESS_KEY",
+            "BYTEPLUS_SECRET_KEY",
+            "BYTEPLUS_SESSION_TOKEN",
+            "BYTEPLUS_REGION",
+            "ap-southeast-1",
+        ),
+    ],
+)
+def test_deploy_harness_resolves_provider_credentials_and_region(
+    tmp_path,
+    monkeypatch,
+    harness_deploy_spy,
+    provider,
+    access_key_name,
+    secret_key_name,
+    session_token_name,
+    region_name,
+    region,
+):
+    deploy_module, captured = harness_deploy_spy
+    (tmp_path / "demo.harness.json").write_text("{}")
+
+    for key in (
+        "VOLCENGINE_ACCESS_KEY",
+        "VOLCENGINE_SECRET_KEY",
+        "VOLCENGINE_SESSION_TOKEN",
+        "VOLCENGINE_REGION",
+        "VOLC_ACCESSKEY",
+        "VOLC_SECRETKEY",
+        "VOLC_SESSIONTOKEN",
+        "BYTEPLUS_ACCESS_KEY",
+        "BYTEPLUS_SECRET_KEY",
+        "BYTEPLUS_SESSION_TOKEN",
+        "BYTEPLUS_REGION",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    monkeypatch.setenv("CLOUD_PROVIDER", provider)
+    monkeypatch.setenv(access_key_name, "test-ak")
+    monkeypatch.setenv(secret_key_name, "test-sk")
+    monkeypatch.setenv(session_token_name, "test-token")
+    monkeypatch.setenv(region_name, region)
+
+    deploy_module.deploy_harness("demo", tmp_path)
+
+    assert captured["client_kwargs"] == {
+        "access_key": "test-ak",
+        "secret_key": "test-sk",
+        "region": region,
+        "session_token": "test-token",
+    }
+    assert captured["config_dict"]["common"]["cloud_provider"] == provider
+    assert captured["config_dict"]["launch_types"]["cloud"]["region"] == region
+    assert captured["excluded_env"] >= {
+        access_key_name,
+        secret_key_name,
+        session_token_name,
+    }
+    assert captured["deploy_env"] == {
+        "VOLC_ACCESSKEY": "test-ak",
+        "VOLC_SECRETKEY": "test-sk",
+        "VOLC_SESSIONTOKEN": "test-token",
+        access_key_name: "test-ak",
+        secret_key_name: "test-sk",
+        session_token_name: "test-token",
+    }
+    assert os.getenv("VOLC_ACCESSKEY") is None
+    assert os.getenv("VOLC_SECRETKEY") is None
+    assert os.getenv("VOLC_SESSIONTOKEN") is None
+
+
+def test_deploy_harness_maps_explicit_credentials_for_byteplus(
+    tmp_path, monkeypatch, harness_deploy_spy
+):
+    deploy_module, captured = harness_deploy_spy
+    (tmp_path / "demo.harness.json").write_text("{}")
+
+    monkeypatch.setenv("CLOUD_PROVIDER", "byteplus")
+    monkeypatch.setenv("BYTEPLUS_REGION", "ap-southeast-1")
+    for key in (
+        "VOLCENGINE_ACCESS_KEY",
+        "VOLCENGINE_SECRET_KEY",
+        "VOLCENGINE_SESSION_TOKEN",
+        "VOLC_ACCESSKEY",
+        "VOLC_SECRETKEY",
+        "VOLC_SESSIONTOKEN",
+        "BYTEPLUS_ACCESS_KEY",
+        "BYTEPLUS_SECRET_KEY",
+        "BYTEPLUS_SESSION_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    deploy_module.deploy_harness(
+        "demo", tmp_path, access_key="explicit-ak", secret_key="explicit-sk"
+    )
+
+    assert captured["client_kwargs"]["access_key"] == "explicit-ak"
+    assert captured["client_kwargs"]["secret_key"] == "explicit-sk"
+    assert captured["config_dict"]["common"]["cloud_provider"] == "byteplus"
+    assert captured["deploy_env"]["BYTEPLUS_ACCESS_KEY"] == "explicit-ak"
+    assert captured["deploy_env"]["BYTEPLUS_SECRET_KEY"] == "explicit-sk"


### PR DESCRIPTION
## Summary

- resolve harness deployment credentials, region, and session token using the active cloud provider
- pin the generated launch configuration to the resolved provider and avoid uploading deployment credentials
- document BytePlus harness setup and add Volcengine/BytePlus regression coverage

## Testing

- `pytest tests/toolkit tests/platform` (808 passed)
- targeted harness credential tests (18 passed)
- `ruff check` on changed Python files

Related issue: https://meego.larkoffice.com/v-vconsole/issue/detail/7363654775