### PR TITLE
feat(tools): support TOS IAM role mounts

### DIFF
--- a/agentkit/sdk/tools/types.py
+++ b/agentkit/sdk/tools/types.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Optional
 from pydantic import BaseModel, Field
 
@@ -28,6 +29,11 @@ class ToolsBaseModel(BaseModel):
 
 
 # Data Types
+class CredentialType(str, Enum):
+    TOS_CREDENTIAL_TYPE_ACCESS_KEY = "TOS_CREDENTIAL_TYPE_ACCESS_KEY"
+    TOS_CREDENTIAL_TYPE_IAM_ROLE = "TOS_CREDENTIAL_TYPE_IAM_ROLE"
+
+
 class AssociatedRuntimesForGetTool(ToolsBaseModel):
     id: Optional[str] = Field(default=None, alias="Id")
     name: Optional[str] = Field(default=None, alias="Name")
@@ -204,6 +210,9 @@ class TosMountConfigForGetTool(ToolsBaseModel):
     credentials: Optional[CredentialsForGetTool] = Field(
         default=None, alias="Credentials"
     )
+    credential_type: Optional[CredentialType] = Field(
+        default=None, alias="CredentialType"
+    )
     enable_tos: Optional[bool] = Field(default=None, alias="EnableTos")
     mount_points: Optional[list[MountPointsForGetTool]] = Field(
         default=None, alias="MountPoints"
@@ -347,6 +356,9 @@ class TlsForCreateTool(ToolsBaseModel):
 class TosMountForCreateTool(ToolsBaseModel):
     credentials: Optional[TosMountCredentialsForCreateTool] = Field(
         default=None, alias="Credentials"
+    )
+    credential_type: Optional[CredentialType] = Field(
+        default=None, alias="CredentialType"
     )
     mount_points: Optional[list[TosMountMountPointsItemForCreateTool]] = Field(
         default=None, alias="MountPoints"
@@ -677,6 +689,9 @@ class SetSessionTtlResponse(ToolsBaseModel):
 class TosMountForUpdateTool(ToolsBaseModel):
     credentials: Optional[TosMountCredentialsForUpdateTool] = Field(
         default=None, alias="Credentials"
+    )
+    credential_type: Optional[CredentialType] = Field(
+        default=None, alias="CredentialType"
     )
     mount_points: Optional[list[TosMountMountPointsItemForUpdateTool]] = Field(
         default=None, alias="MountPoints"

--- a/agentkit/toolkit/cli/cli_tools.py
+++ b/agentkit/toolkit/cli/cli_tools.py
@@ -329,6 +329,10 @@ def update_tool_command(
         client = AgentkitToolsClient(region=(region or "").strip())
         if json_body:
             payload = json.loads(json_body)
+            if not isinstance(payload, dict):
+                raise ValueError("--json must contain a JSON object")
+            payload.pop("tool_id", None)
+            payload["ToolId"] = tool_id.strip()
         else:
             payload = tools_types.UpdateToolRequest(
                 tool_id=tool_id, description=description

--- a/agentkit/toolkit/cli/sandbox/README.md
+++ b/agentkit/toolkit/cli/sandbox/README.md
@@ -136,6 +136,9 @@ Options:
   created without TOS mount configuration.
 - `--tos-mount`: optional. Local mount path for `--tos-bucket`; defaults to
   `/home/gem/workspace`.
+- `--tos-credential-type`: optional. TOS mount authentication mode. Accepts
+  `access-key` (the default) or `iam-role`. IAM Role mounting is supported only
+  for built-in `CodeEnv` and `SkillEnv` tools.
 - `--cpu`: optional. Sandbox vCPU count; allowed values are `2`, `4`, `8`, and
   `16`. Defaults to `4`. Memory is derived as 2 GiB per vCPU.
 - `--enable-snapshot`: optional. Enables snapshot support for the created
@@ -239,11 +242,20 @@ Provider defaults:
 | `byteplus_model_square` | `deepseek-v4-flash-260425` | `https://ark.ap-southeast.bytepluses.com/api/v3` |
 | `byteplus_coding_plan` | `dola-seed-2.0-pro` | `https://ark.ap-southeast.bytepluses.com/api/coding/v3` |
 
-Credential resolution is delegated to the underlying SDK/service clients:
-`AgentkitToolsClient` handles `CreateTool` credentials, and `TOSService` handles
-TOS credentials. The command supports the same credential sources as the shared
-Volcengine configuration, including environment variables and global
-`agentkit config --global` settings.
+Credential resolution is delegated to the underlying SDK/service clients.
+`AgentkitToolsClient` handles `CreateTool` credentials. With the default
+`--tos-credential-type access-key`, `TOSService` resolves TOS credentials and
+prepares the bucket path using the shared Volcengine configuration, including
+environment variables and global `agentkit config --global` settings. With
+`--tos-credential-type iam-role`, the bucket must already exist; the CLI does
+not initialize `TOSService` or send `Credentials` in `TosMountConfig`.
+
+```bash
+agentkit sandbox create \
+  --tool-type CodeEnv \
+  --tos-bucket existing-bucket \
+  --tos-credential-type iam-role
+```
 
 When `--tos-bucket` is set, the generated tool TOS mount uses
 `LocalMountPath: /home/gem/workspace` by default, or the path provided by

--- a/agentkit/toolkit/cli/sandbox/cli_create.py
+++ b/agentkit/toolkit/cli/sandbox/cli_create.py
@@ -56,8 +56,10 @@ from agentkit.toolkit.cli.sandbox.model_config import (
 )
 from agentkit.toolkit.cli.sandbox.tool_resolve import save_tool_result_if_resolvable
 from agentkit.toolkit.cli.sandbox.tos_config import (
+    DEFAULT_TOS_CREDENTIAL_TYPE,
     DEFAULT_TOS_LOCAL_PATH,
     build_create_tool_tos_mount_config,
+    normalize_tos_credential_type,
 )
 from agentkit.toolkit.cli.sandbox.sandbox_client import error
 from agentkit.toolkit.volcengine.services.tos_service import (
@@ -206,6 +208,7 @@ def _build_create_tool_request(
     tos_bucket: Optional[str],
     tos_region: str,
     tos_mount_path: str = DEFAULT_TOS_LOCAL_PATH,
+    tos_credential_type: str | tools_types.CredentialType | None = None,
     cpu: int = DEFAULT_CPU,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
@@ -228,6 +231,16 @@ def _build_create_tool_request(
     is_private_tool = resolved_tool_type == PRIVATE_TOOL_TYPE
     if is_private_tool and not (image_url or "").strip():
         error("--image-url is required when --tool-type Private")
+    resolved_tos_credential_type = normalize_tos_credential_type(
+        tos_credential_type
+    )
+    if (
+        is_private_tool
+        and (tos_bucket or "").strip()
+        and resolved_tos_credential_type
+        == tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE
+    ):
+        error("TOS IAM Role mounting is only supported for Built-in Tools")
     command = PRIVATE_TOOL_COMMAND if is_private_tool else None
     port = PRIVATE_TOOL_PORT if is_private_tool else None
     envs = (
@@ -256,6 +269,7 @@ def _build_create_tool_request(
         tos_bucket,
         tos_region,
         local_mount_path=tos_mount_path,
+        credential_type=resolved_tos_credential_type,
         tos_service_cls=TOSService,
         tos_service_config_cls=TOSServiceConfig,
     )
@@ -451,6 +465,7 @@ def create_tool(
     tool_name: Optional[str] = None,
     tos_bucket: Optional[str] = None,
     tos_mount_path: str = DEFAULT_TOS_LOCAL_PATH,
+    tos_credential_type: str | tools_types.CredentialType | None = None,
     cpu: int = DEFAULT_CPU,
     model_name: Optional[str] = None,
     model_api_key: Optional[str] = None,
@@ -508,6 +523,7 @@ def create_tool(
         tos_bucket=tos_bucket,
         tos_region=tos_region,
         tos_mount_path=tos_mount_path,
+        tos_credential_type=tos_credential_type,
         cpu=cpu,
         model_name=model_name,
         model_api_key=model_api_key,
@@ -569,6 +585,15 @@ def create_command(
         help=(
             "Local mount path for the TOS bucket. Requires --tos-bucket. "
             f"Defaults to {DEFAULT_TOS_LOCAL_PATH} when omitted."
+        ),
+    ),
+    tos_credential_type: Optional[str] = typer.Option(
+        None,
+        "--tos-credential-type",
+        help=(
+            "TOS mount authentication: access-key or iam-role. "
+            "IAM Role is only supported for Built-in Tools. "
+            "Defaults to access-key."
         ),
     ),
     cpu: int = typer.Option(
@@ -671,6 +696,13 @@ def create_command(
         )
         tos_mount = config_default_if_unprovided(
             ctx, "tos_mount", "tos-mount", tos_mount, data=config_defaults
+        )
+        tos_credential_type = config_default_if_unprovided(
+            ctx,
+            "tos_credential_type",
+            "tos-credential-type",
+            tos_credential_type,
+            data=config_defaults,
         )
         cpu = config_default_if_unprovided(
             ctx,
@@ -777,6 +809,11 @@ def create_command(
         )
         if tos_mount is not None and not (tos_bucket or "").strip():
             error("--tos-mount requires --tos-bucket")
+        if (
+            tos_credential_type is not None
+            and not (tos_bucket or "").strip()
+        ):
+            error("--tos-credential-type requires --tos-bucket")
         model_provider_was_provided = param_was_provided(ctx, "model_provider")
         model_base_url_was_provided = param_was_provided(ctx, "model_base_url")
         result = create_tool(
@@ -784,6 +821,9 @@ def create_command(
             tool_name=tool_name,
             tos_bucket=tos_bucket,
             tos_mount_path=tos_mount or DEFAULT_TOS_LOCAL_PATH,
+            tos_credential_type=(
+                tos_credential_type or DEFAULT_TOS_CREDENTIAL_TYPE
+            ),
             cpu=cpu,
             model_name=model_name,
             model_api_key=model_api_key,

--- a/agentkit/toolkit/cli/sandbox/config_store.py
+++ b/agentkit/toolkit/cli/sandbox/config_store.py
@@ -157,6 +157,11 @@ CONFIG_KEY_SPECS: dict[str, ConfigKeySpec] = {
     "cpu": ConfigKeySpec(("tool", "cpu"), _int_value, VALID_CPU_VALUES),
     "tos-bucket": ConfigKeySpec(("tool", "tos_bucket"), _str_value),
     "tos-mount": ConfigKeySpec(("tool", "tos_mount"), _str_value),
+    "tos-credential-type": ConfigKeySpec(
+        ("tool", "tos_credential_type"),
+        _str_value,
+        ("access-key", "iam-role"),
+    ),
     "role-name": ConfigKeySpec(("tool", "role_name"), _str_value),
     "enable-snapshot": ConfigKeySpec(("tool", "enable_snapshot"), _bool_value),
     "websearch-apikey": ConfigKeySpec(("tool", "websearch_apikey"), _str_value),

--- a/agentkit/toolkit/cli/sandbox/tos_config.py
+++ b/agentkit/toolkit/cli/sandbox/tos_config.py
@@ -29,6 +29,35 @@ from agentkit.toolkit.volcengine.services.tos_service import (
 DEFAULT_TOS_BUCKET_PATH = "/sandbox-session/default/default"
 DEFAULT_TOS_LOCAL_PATH = "/home/gem/workspace"
 DEFAULT_SANDBOX_WORKSPACE = "/home/gem"
+DEFAULT_TOS_CREDENTIAL_TYPE = (
+    tools_types.CredentialType.TOS_CREDENTIAL_TYPE_ACCESS_KEY
+)
+
+
+def normalize_tos_credential_type(
+    value: str | tools_types.CredentialType | None,
+) -> tools_types.CredentialType:
+    if isinstance(value, tools_types.CredentialType):
+        return value
+
+    normalized = (value or "").strip().upper().replace("-", "_")
+    aliases = {
+        "": DEFAULT_TOS_CREDENTIAL_TYPE,
+        "ACCESS_KEY": tools_types.CredentialType.TOS_CREDENTIAL_TYPE_ACCESS_KEY,
+        "TOS_CREDENTIAL_TYPE_ACCESS_KEY": (
+            tools_types.CredentialType.TOS_CREDENTIAL_TYPE_ACCESS_KEY
+        ),
+        "IAM_ROLE": tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE,
+        "TOS_CREDENTIAL_TYPE_IAM_ROLE": (
+            tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE
+        ),
+    }
+    credential_type = aliases.get(normalized)
+    if credential_type is None:
+        error(
+            "--tos-credential-type must be one of: access-key, iam-role"
+        )
+    return credential_type
 
 
 def resolve_tos_bucket(tos_bucket: Optional[str]) -> str:
@@ -50,6 +79,7 @@ def build_create_tool_tos_mount_config(
     region: str,
     *,
     local_mount_path: str = DEFAULT_TOS_LOCAL_PATH,
+    credential_type: str | tools_types.CredentialType | None = None,
     tos_service_cls=TOSService,
     tos_service_config_cls=TOSServiceConfig,
 ) -> tools_types.TosMountForCreateTool | None:
@@ -58,6 +88,25 @@ def build_create_tool_tos_mount_config(
 
     resolved_bucket = resolve_tos_bucket(tos_bucket)
     resolved_local_mount_path = resolve_tos_mount_path(local_mount_path)
+    resolved_credential_type = normalize_tos_credential_type(credential_type)
+    if (
+        resolved_credential_type
+        == tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE
+    ):
+        return tools_types.TosMountForCreateTool(
+            EnableTos=True,
+            CredentialType=resolved_credential_type,
+            MountPoints=[
+                tools_types.TosMountMountPointsItemForCreateTool(
+                    BucketName=resolved_bucket,
+                    BucketPath=DEFAULT_TOS_BUCKET_PATH,
+                    Endpoint=TOSService.build_mount_endpoint(region),
+                    LocalMountPath=resolved_local_mount_path,
+                    ReadOnly=False,
+                )
+            ],
+        )
+
     service = tos_service_cls(
         tos_service_config_cls(
             bucket=resolved_bucket,
@@ -76,6 +125,9 @@ def to_create_tool_tos_mount_config(
 ) -> tools_types.TosMountForCreateTool:
     return tools_types.TosMountForCreateTool(
         EnableTos=True,
+        CredentialType=(
+            tools_types.CredentialType.TOS_CREDENTIAL_TYPE_ACCESS_KEY
+        ),
         Credentials=tools_types.TosMountCredentialsForCreateTool(
             AccessKeyId=mount_config.credentials.access_key_id,
             SecretAccessKey=mount_config.credentials.secret_access_key,

--- a/tests/client/test_tools_tos_mount_types.py
+++ b/tests/client/test_tools_tos_mount_types.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from agentkit.sdk.tools import types as tools_types
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        tools_types.TosMountForCreateTool,
+        tools_types.TosMountConfigForGetTool,
+        tools_types.TosMountForUpdateTool,
+    ],
+)
+@pytest.mark.parametrize("credential_type", list(tools_types.CredentialType))
+def test_tos_mount_credential_type_accepts_supported_values(
+    model_type,
+    credential_type,
+) -> None:
+    config = model_type(CredentialType=credential_type.value)
+
+    assert config.credential_type is credential_type
+    assert config.model_dump(by_alias=True, mode="json", exclude_none=True) == {
+        "CredentialType": credential_type.value
+    }
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        tools_types.TosMountForCreateTool,
+        tools_types.TosMountConfigForGetTool,
+        tools_types.TosMountForUpdateTool,
+    ],
+)
+def test_tos_mount_credential_type_rejects_unknown_value(model_type) -> None:
+    with pytest.raises(ValidationError):
+        model_type(CredentialType="UNKNOWN")
+
+
+def test_update_tool_iam_role_tos_mount_keeps_credential_type_without_ak_sk(
+) -> None:
+    request = tools_types.UpdateToolRequest(
+        ToolId="tool-123",
+        TosMountConfig=tools_types.TosMountForUpdateTool(
+            EnableTos=True,
+            CredentialType=(
+                tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE
+            ),
+            MountPoints=[
+                tools_types.TosMountMountPointsItemForUpdateTool(
+                    BucketName="existing-bucket",
+                    BucketPath="/sandbox-session/default/default",
+                    Endpoint="http://tos-cn-beijing.ivolces.com",
+                    LocalMountPath="/home/gem/workspace",
+                    ReadOnly=False,
+                )
+            ],
+        ),
+    )
+
+    assert request.model_dump(
+        by_alias=True,
+        mode="json",
+        exclude_none=True,
+    ) == {
+        "ToolId": "tool-123",
+        "TosMountConfig": {
+            "EnableTos": True,
+            "CredentialType": "TOS_CREDENTIAL_TYPE_IAM_ROLE",
+            "MountPoints": [
+                {
+                    "BucketName": "existing-bucket",
+                    "BucketPath": "/sandbox-session/default/default",
+                    "Endpoint": "http://tos-cn-beijing.ivolces.com",
+                    "LocalMountPath": "/home/gem/workspace",
+                    "ReadOnly": False,
+                }
+            ],
+        },
+    }

--- a/tests/toolkit/cli/test_cli_create_tool.py
+++ b/tests/toolkit/cli/test_cli_create_tool.py
@@ -712,6 +712,10 @@ def test_build_create_tool_request_adds_tos_mount(monkeypatch):
     tos_config = request.tos_mount_config
     assert tos_config is not None
     assert tos_config.enable_tos is True
+    assert (
+        tos_config.credential_type.value
+        == "TOS_CREDENTIAL_TYPE_ACCESS_KEY"
+    )
     assert tos_config.credentials.access_key_id == _PLACEHOLDER_A
     assert tos_config.credentials.secret_access_key == _PLACEHOLDER_B
     assert len(tos_config.mount_points) == 1
@@ -735,6 +739,92 @@ def test_build_create_tool_request_adds_tos_mount(monkeypatch):
     assert request.network_configuration.enable_private_network is False
     assert request.cpu_milli == 4000
     assert request.memory_mb == 8192
+
+
+def test_build_create_tool_request_supports_tos_iam_role_mount(monkeypatch):
+    from agentkit.sdk.tools import types as tools_types
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    request = cli_create._build_create_tool_request(
+        tool_type="CodeEnv",
+        name="demo-tool",
+        tos_bucket="my-bucket",
+        tos_region="cn-beijing",
+        tos_credential_type="iam-role",
+    )
+
+    assert _FakeTOSService.instances == []
+    tos_config = request.tos_mount_config
+    assert tos_config is not None
+    assert (
+        tos_config.credential_type
+        == tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE
+    )
+    assert tos_config.credentials is None
+    assert len(tos_config.mount_points) == 1
+    mount_point = tos_config.mount_points[0]
+    assert mount_point.bucket_name == "my-bucket"
+    assert mount_point.bucket_path == "/sandbox-session/default/default"
+    assert mount_point.endpoint == "http://tos-cn-beijing.ivolces.com"
+    assert mount_point.local_mount_path == "/home/gem/workspace"
+    assert mount_point.read_only is False
+
+
+def test_build_create_tool_request_rejects_tos_iam_role_for_private_tool(
+    capsys,
+) -> None:
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    with pytest.raises(cli_create.typer.Exit):
+        cli_create._build_create_tool_request(
+            tool_type="Private",
+            name="demo-tool",
+            image_url="registry.example.com/custom-image:latest",
+            tos_bucket="my-bucket",
+            tos_region="cn-beijing",
+            tos_credential_type="iam-role",
+        )
+
+    assert (
+        "TOS IAM Role mounting is only supported for Built-in Tools"
+        in capsys.readouterr().err
+    )
+
+
+def test_create_command_accepts_tos_iam_role(monkeypatch):
+    from agentkit.sdk.tools import types as tools_types
+    from agentkit.toolkit.cli.cli import app
+    from agentkit.toolkit.cli.sandbox import cli_create
+
+    _reset_fake_tools_client()
+    monkeypatch.setattr(cli_create, "AgentkitToolsClient", _FakeToolsClient)
+    monkeypatch.setattr(cli_create, "TOSService", _FakeTOSService)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "--tool-name",
+            "demo-tool",
+            "--tos-bucket",
+            "my-bucket",
+            "--tos-credential-type",
+            "iam-role",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert _FakeTOSService.instances == []
+    tos_config = _FakeToolsClient.last_request.tos_mount_config
+    assert (
+        tos_config.credential_type
+        == tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE
+    )
+    assert tos_config.credentials is None
 
 
 def test_build_create_tool_request_uses_custom_tos_mount(monkeypatch):

--- a/tests/toolkit/cli/test_cli_sandbox_config.py
+++ b/tests/toolkit/cli/test_cli_sandbox_config.py
@@ -108,6 +108,31 @@ def test_sandbox_config_set_option_accepts_repeated_key_values(tmp_path, monkeyp
     assert payload["session"]["ttl"] == 200
 
 
+def test_sandbox_config_accepts_tos_credential_type(tmp_path, monkeypatch):
+    from agentkit.toolkit.cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "config",
+            "--set",
+            "tos-bucket=my-bucket",
+            "--set",
+            "tos-credential-type=iam-role",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = yaml.safe_load(
+        (tmp_path / ".agentkit" / "sandbox.yaml").read_text(encoding="utf-8")
+    )
+    assert payload["tool"]["tos_bucket"] == "my-bucket"
+    assert payload["tool"]["tos_credential_type"] == "iam-role"
+
+
 def test_sandbox_config_unset_option_accepts_repeated_keys(tmp_path, monkeypatch):
     from agentkit.toolkit.cli.cli import app
 

--- a/tests/toolkit/cli/test_cli_tools_update.py
+++ b/tests/toolkit/cli/test_cli_tools_update.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from agentkit.sdk.tools import types as tools_types
+
+
+runner = CliRunner()
+
+
+class _FakeToolsClient:
+    last_request = None
+
+    def __init__(self, **_kwargs):
+        pass
+
+    def update_tool(self, request):
+        _FakeToolsClient.last_request = request
+        return SimpleNamespace(tool_id=request.tool_id)
+
+
+def test_tools_update_sends_iam_role_tos_mount_without_credentials(
+    monkeypatch,
+) -> None:
+    from agentkit.toolkit.cli import cli_tools
+    from agentkit.toolkit.cli.cli import app
+
+    _FakeToolsClient.last_request = None
+    monkeypatch.setattr(cli_tools, "AgentkitToolsClient", _FakeToolsClient)
+
+    result = runner.invoke(
+        app,
+        [
+            "tools",
+            "update",
+            "--tool-id",
+            "tool-123",
+            "--json",
+            """{
+                "ToolId": "tool-123",
+                "TosMountConfig": {
+                    "EnableTos": true,
+                    "CredentialType": "TOS_CREDENTIAL_TYPE_IAM_ROLE",
+                    "MountPoints": [
+                        {
+                            "BucketName": "bucket-1",
+                            "BucketPath": "/",
+                            "Endpoint": "http://tos-cn-beijing.ivolces.com",
+                            "LocalMountPath": "/mnt/tos1",
+                            "ReadOnly": false
+                        },
+                        {
+                            "BucketName": "bucket-2",
+                            "BucketPath": "/",
+                            "Endpoint": "http://tos-cn-beijing.ivolces.com",
+                            "LocalMountPath": "/mnt/tos2",
+                            "ReadOnly": false
+                        }
+                    ]
+                }
+            }""",
+        ],
+    )
+
+    assert result.exit_code == 0
+    request = _FakeToolsClient.last_request
+    assert isinstance(request, tools_types.UpdateToolRequest)
+    assert request.tool_id == "tool-123"
+    tos_config = request.tos_mount_config
+    assert (
+        tos_config.credential_type
+        == tools_types.CredentialType.TOS_CREDENTIAL_TYPE_IAM_ROLE
+    )
+    assert tos_config.credentials is None
+    assert [item.local_mount_path for item in tos_config.mount_points] == [
+        "/mnt/tos1",
+        "/mnt/tos2",
+    ]
+
+
+def test_tools_update_uses_cli_tool_id_when_json_id_has_whitespace(
+    monkeypatch,
+) -> None:
+    from agentkit.toolkit.cli import cli_tools
+    from agentkit.toolkit.cli.cli import app
+
+    _FakeToolsClient.last_request = None
+    monkeypatch.setattr(cli_tools, "AgentkitToolsClient", _FakeToolsClient)
+
+    result = runner.invoke(
+        app,
+        [
+            "tools",
+            "update",
+            "--tool-id",
+            "tool-123",
+            "--json",
+            '{"ToolId": "tool-123 ", "Description": "updated"}',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert _FakeToolsClient.last_request.tool_id == "tool-123"


### PR DESCRIPTION
## Summary

  Add TOS credential type support across CreateTool, GetTool, and UpdateTool, enabling built-in tools to
  mount TOS buckets using IAM roles without embedding AK/SK credentials.

  This PR also improves the `agentkit tools update --json` flow by treating the CLI `--tool-id` as the
  authoritative tool ID.

  ## Motivation

  TOS mount configuration previously assumed Access Key authentication and always populated
  `Credentials`.

  This prevented IAM Role-based mounts because IAM Role configurations:

  - do not contain `AccessKeyId` or `SecretAccessKey`;
  - must explicitly set `CredentialType` to `TOS_CREDENTIAL_TYPE_IAM_ROLE`;
  - are currently supported only for built-in tools.

  UpdateTool also needs to preserve the credential type when modifying an existing IAM Role-based TOS
  mount, even when no AK/SK credentials are present.

  ## Changes

  ### SDK models

  Add the `CredentialType` string enum:

  - `TOS_CREDENTIAL_TYPE_ACCESS_KEY`
  - `TOS_CREDENTIAL_TYPE_IAM_ROLE`

  Expose the optional `CredentialType` field in:

  - `TosMountForCreateTool`
  - `TosMountConfigForGetTool`
  - `TosMountForUpdateTool`

  ### Sandbox CreateTool CLI

  Add the following option:

  ```text
  --tos-credential-type access-key|iam-role
  ```

  Access Key remains the default to preserve existing behavior.

  For Access Key mounts, the CLI:

  - initializes `TOSService`;
  - resolves AK/SK credentials;
  - prepares the bucket and directory markers;
  - sends `CredentialType=TOS_CREDENTIAL_TYPE_ACCESS_KEY`;
  - sends the `Credentials` object.

  For IAM Role mounts, the CLI:

  - sends `CredentialType=TOS_CREDENTIAL_TYPE_IAM_ROLE`;
  - does not initialize `TOSService`;
  - does not send the `Credentials` object;
  - expects the TOS bucket to already exist;
  - restricts IAM Role mounting to built-in `CodeEnv` and `SkillEnv` tools.

  Example:

  ```bash
  agentkit sandbox create \
    --tool-type CodeEnv \
    --tool-name iam-role-tos-tool \
    --tos-bucket existing-bucket \
    --tos-mount /home/gem/workspace \
    --tos-credential-type iam-role \
    --skill-role-name existing-role-name
  ```

  The option can also be persisted in sandbox configuration:

  ```bash
  agentkit sandbox config \
    --set tos-bucket=existing-bucket \
    --set tos-credential-type=iam-role
  ```

  ### UpdateTool support

  `UpdateToolRequest` can now explicitly send an IAM Role TOS configuration without AK/SK:

  ```json
  {
    "ToolId": "tool-123",
    "TosMountConfig": {
      "EnableTos": true,
      "CredentialType": "TOS_CREDENTIAL_TYPE_IAM_ROLE",
      "MountPoints": [
        {
          "BucketName": "existing-bucket",
          "BucketPath": "/",
          "Endpoint": "http://tos-cn-beijing.ivolces.com",
          "LocalMountPath": "/mnt/tos",
          "ReadOnly": false
        }
      ]
    }
  }
  ```

  The existing top-level `RoleName` remains associated with the tool. IAM Role TOS updates do not send
  `Credentials`.

  ### Tools update CLI safety

  When `agentkit tools update --json` is used:

  - `--json` must contain a JSON object;
  - the CLI `--tool-id` is treated as authoritative;
  - `ToolId` inside the JSON payload is replaced with the normalized CLI value.

  This prevents accidental `InvalidResource.NotFound` errors caused by mismatched IDs or trailing
  whitespace in the JSON body.

  ## Compatibility

  - Access Key authentication remains the default.
  - Existing Access Key-based TOS creation behavior is unchanged.
  - `Private` tools continue to use Access Key authentication and reject IAM Role TOS mounting.
  - Existing UpdateTool requests without `TosMountConfig` are unaffected.

  ## Testing

  Added coverage for:

  - supported and unsupported credential type validation;
  - CreateTool Access Key credential type serialization;
  - CreateTool IAM Role mounts without AK/SK;
  - rejection of IAM Role mounts for Private tools;
  - sandbox configuration persistence;
  - UpdateTool IAM Role serialization without credentials;
  - multiple UpdateTool TOS mount points;
  - authoritative handling of CLI `--tool-id`;
  - JSON tool IDs containing trailing whitespace.

  Test command:

  ```bash
  uv run --with pytest pytest -q \
    tests/client/test_tools_tos_mount_types.py \
    tests/toolkit/cli/test_cli_create_tool.py \
    tests/toolkit/cli/test_cli_sandbox_config.py \
    tests/toolkit/cli/test_cli_tools_update.py
  ```

  Result:

  ```text
  93 passed
  ```

  ## Checklist

  - [x] Added SDK model support for TOS credential types
  - [x] Added IAM Role support to sandbox CreateTool
  - [x] Added UpdateTool IAM Role coverage
  - [x] Preserved Access Key defaults
  - [x] Prevented AK/SK from being sent for IAM Role mounts
  - [x] Added configuration and CLI documentation
  - [x] Added unit tests
  - [x] Verified the diff with `git diff --check`
