### PR TITLE
fix: prevent UnboundLocalError in A2A telemetry and escape SSE error JSON

### DIFF
--- a/agentkit/apps/a2a_app/a2a_app.py
+++ b/agentkit/apps/a2a_app/a2a_app.py
@@ -46,6 +46,7 @@ def _wrap_agent_executor_execute_func(execute_func: Callable) -> Callable:
 
         with telemetry.tracer.start_as_current_span(name="a2a_invocation") as span:
             exception = None
+            result = None
             try:
                 result = await execute_func(
                     executor_instance, context=context, event_queue=event_queue

--- a/agentkit/apps/agent_server_app/agent_server_app.py
+++ b/agentkit/apps/agent_server_app/agent_server_app.py
@@ -618,7 +618,9 @@ class AgentkitAgentServerApp(BaseAgentkitApp):
                         telemetry.trace_agent_server_finish(
                             path="/invoke", func_result="", exception=e
                         )
-                        error_payload = f'data: {{"error": "{str(e)}"}}\n\n'
+                        error_payload = (
+                            "data: " + json.dumps({"error": str(e)}) + "\n\n"
+                        )
                 if error_payload is not None:
                     # The identity path never suspends while retaining the
                     # original exception or its credential-bearing traceback.


### PR DESCRIPTION
## Summary

- **a2a_app.py**: `_wrap_agent_executor_execute_func` references `result` in the
  `finally` block, but `result` is only assigned inside `try`. When `execute_func`
  raises, the `finally` clause hits `UnboundLocalError`, which suppresses the
  original exception and makes debugging impossible. Fix: initialize `result = None`
  before the `try` block.

- **agent_server_app.py**: The `_invoke_compat` SSE error path builds JSON via
  f-string (`f'data: {{"error": "{str(e)}"}}'`). If the exception message contains
  `"`, `\`, or newlines, the resulting JSON is malformed and breaks client-side
  parsing. The `/run_sse` endpoint at line 475 already uses `json.dumps()` correctly;
  this patch aligns `_invoke_compat` to the same pattern.

## Test plan

- [x] `pytest tests/apps/test_a2a_app.py` — 20 passed
- [x] `pytest tests/apps/test_agent_server_invoke.py` — 19 passed
- [x] `ruff check` — no new lint errors (count decreased from 13 → 12)
- [x] `ruff format --check` — both files formatted